### PR TITLE
Add FakeDataFlow plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ daq_codegen(*.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 daq_add_plugin(ModuleLevelTrigger duneDAQModule LINK_LIBRARIES trigger)
 daq_add_plugin(IntervalTriggerCreator duneDAQModule LINK_LIBRARIES trigger TEST)
 daq_add_plugin(IntervalTCCreator duneDAQModule LINK_LIBRARIES trigger TEST)
+daq_add_plugin(FakeDataFlow duneDAQModule LINK_LIBRARIES dfmessages::dfmessages trigger)
 
 ##############################################################################
 # Integration tests

--- a/plugins/FakeDataFlow.cpp
+++ b/plugins/FakeDataFlow.cpp
@@ -1,0 +1,116 @@
+/**
+ * @file FakeDataFlow.cpp FakeDataFlow class implementation
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "FakeDataFlow.hpp"
+
+#include "dataformats/ComponentRequest.hpp"
+
+#include "dfmessages/TriggerDecision.hpp"
+#include "dfmessages/TriggerDecisionToken.hpp"
+#include "dfmessages/Types.hpp"
+#include "logging/Logging.hpp"
+
+#include "trigger/fakedataflow/Nljs.hpp"
+
+#include "appfwk/app/Nljs.hpp"
+
+
+namespace dunedaq {
+namespace trigger {
+
+FakeDataFlow::FakeDataFlow(const std::string& name)
+  : DAQModule(name)
+  , m_trigger_decision_source(nullptr)
+  , m_trigger_complete_sink(nullptr)
+{
+  register_command("conf", &FakeDataFlow::do_configure);
+  register_command("start", &FakeDataFlow::do_start);
+  register_command("stop", &FakeDataFlow::do_stop);
+  register_command("scrap", &FakeDataFlow::do_scrap);
+}
+  
+void
+FakeDataFlow::init(const nlohmann::json& obj)
+{
+  auto ini = obj.get<appfwk::app::ModInit>();
+  for (const auto& qi : ini.qinfos) {
+    if (qi.name == "trigger_decision_source") {
+      m_trigger_decision_source.reset(new appfwk::DAQSource<dfmessages::TriggerDecision>(qi.inst));
+    }
+    if (qi.name == "trigger_complete_sink") {
+      m_trigger_complete_sink.reset(new appfwk::DAQSink<dfmessages::TriggerDecisionToken>(qi.inst));
+    }
+  }
+}
+
+void
+FakeDataFlow::get_info(opmonlib::InfoCollector& /*ci*/, int /*level*/)
+{
+}
+
+void
+FakeDataFlow::do_configure(const nlohmann::json& /*obj*/)
+{
+  m_configured_flag.store(true);
+}
+
+void
+FakeDataFlow::do_start(const nlohmann::json& /*obj*/)
+{
+  m_running_flag.store(true);
+  m_fake_data_flow_thread = std::thread(&FakeDataFlow::respond_to_trigger_decisions, this);
+  pthread_setname_np(m_fake_data_flow_thread.native_handle(), "fake-data-flow");
+}
+
+void
+FakeDataFlow::do_stop(const nlohmann::json& /*obj*/)
+{
+  m_running_flag.store(false);
+  m_fake_data_flow_thread.join();
+}
+
+void
+FakeDataFlow::do_scrap(const nlohmann::json& /*obj*/)
+{
+  m_configured_flag.store(false);
+}
+
+void
+FakeDataFlow::respond_to_trigger_decisions()
+{
+  while (m_running_flag.load()) {
+    dfmessages::TriggerDecision td;
+    try {
+      m_trigger_decision_source->pop(td, std::chrono::milliseconds(1000));
+    }
+    catch (appfwk::QueueTimeoutExpired&) {
+      continue;
+    }
+    
+    TLOG_DEBUG(1) << "Responding to decision with"
+                  << " triggernumber " << td.trigger_number 
+                  << " timestamp " << td.trigger_timestamp 
+                  << " type " << td.trigger_type 
+                  << " number of links " << td.components.size();
+                  
+    dfmessages::TriggerDecisionToken td_token;
+    td_token.run_number = td.run_number;
+    td_token.trigger_number = td.trigger_number;
+    try {
+      m_trigger_complete_sink->push(td_token, std::chrono::milliseconds(10));
+    }
+    catch (appfwk::QueueTimeoutExpired& e) {
+      ers::error(e);
+    }
+  }
+}
+
+} // namespace trigger
+} // namespace dunedaq
+
+DEFINE_DUNE_DAQ_MODULE(dunedaq::trigger::FakeDataFlow)

--- a/plugins/FakeDataFlow.hpp
+++ b/plugins/FakeDataFlow.hpp
@@ -70,11 +70,6 @@ private:
   // Are we in a configured state, ie after conf and before scrap?
   std::atomic<bool> m_configured_flag{ false };
 
-  // Opmon variables
-  std::atomic<uint64_t> m_trigger_count{ 0 };
-  std::atomic<uint64_t> m_trigger_count_tot{ 0 };
-  std::atomic<uint64_t> m_inhibited_trigger_count{ 0 };
-  std::atomic<uint64_t> m_inhibited_trigger_count_tot{ 0 };
 };
 } // namespace trigger
 } // namespace dunedaq

--- a/plugins/FakeDataFlow.hpp
+++ b/plugins/FakeDataFlow.hpp
@@ -1,0 +1,84 @@
+/**
+ * @file FakeDataFlow.hpp
+ *
+ * FakeDataFlow is a DAQModule that emulates the data flow application for the
+ * sole purpose of testing trigger modules standalone.
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGER_PLUGINS_FAKEDATAFLOW_HPP_
+#define TRIGGER_PLUGINS_FAKEDATAFLOW_HPP_
+
+#include "dfmessages/TriggerDecision.hpp"
+#include "dfmessages/TriggerDecisionToken.hpp"
+#include "dfmessages/Types.hpp"
+
+#include "appfwk/DAQModule.hpp"
+#include "appfwk/DAQSink.hpp"
+#include "appfwk/DAQSource.hpp"
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace dunedaq {
+
+namespace trigger {
+
+/**
+ * @brief FakeDataFlow is a simple emulation of the data flow application
+ */
+class FakeDataFlow : public dunedaq::appfwk::DAQModule
+{
+public:
+  /**
+   * @brief FakeDataFlow Constructor
+   * @param name Instance name for this FakeDataFlow instance
+   */
+  explicit FakeDataFlow(const std::string& name);
+
+  FakeDataFlow(const FakeDataFlow&) = delete;            ///< FakeDataFlow is not copy-constructible
+  FakeDataFlow& operator=(const FakeDataFlow&) = delete; ///< FakeDataFlow is not copy-assignable
+  FakeDataFlow(FakeDataFlow&&) = delete;                 ///< FakeDataFlow is not move-constructible
+  FakeDataFlow& operator=(FakeDataFlow&&) = delete;      ///< FakeDataFlow is not move-assignable
+
+  void init(const nlohmann::json& obj) override;
+  void get_info(opmonlib::InfoCollector& ci, int level) override;
+
+private:
+  // Commands
+  void do_configure(const nlohmann::json& obj);
+  void do_start(const nlohmann::json& obj);
+  void do_stop(const nlohmann::json& obj);
+  void do_pause(const nlohmann::json& obj);
+  void do_resume(const nlohmann::json& obj);
+  void do_scrap(const nlohmann::json& obj);
+
+  void respond_to_trigger_decisions();
+  std::thread m_fake_data_flow_thread;
+
+  // Queue sources and sinks
+  std::unique_ptr<appfwk::DAQSource<dfmessages::TriggerDecision>> m_trigger_decision_source;
+  std::unique_ptr<appfwk::DAQSink<dfmessages::TriggerDecisionToken>> m_trigger_complete_sink;
+  
+  // Are we in the RUNNING state?
+  std::atomic<bool> m_running_flag{ false };
+  // Are we in a configured state, ie after conf and before scrap?
+  std::atomic<bool> m_configured_flag{ false };
+
+  // Opmon variables
+  std::atomic<uint64_t> m_trigger_count{ 0 };
+  std::atomic<uint64_t> m_trigger_count_tot{ 0 };
+  std::atomic<uint64_t> m_inhibited_trigger_count{ 0 };
+  std::atomic<uint64_t> m_inhibited_trigger_count_tot{ 0 };
+};
+} // namespace trigger
+} // namespace dunedaq
+
+
+#endif // TRIGGER_PLUGINS_FAKEDATAFLOW_HPP_
+

--- a/python/trigger/faketc/faketc_and_mlt_gen.py
+++ b/python/trigger/faketc/faketc_and_mlt_gen.py
@@ -81,7 +81,7 @@ def generate(
 
     mod_specs = [
         mspec("fdf", "FakeDataFlow", [
-            app.QueueInfo(name="trigger_decision_source", inst="trigger_candidate_q", dir="input"),
+            app.QueueInfo(name="trigger_decision_source", inst="trigger_decision_q", dir="input"),
             app.QueueInfo(name="trigger_complete_sink", inst="token_q", dir="output"),
         ]),
         

--- a/python/trigger/faketc/faketc_and_mlt_gen.py
+++ b/python/trigger/faketc/faketc_and_mlt_gen.py
@@ -13,6 +13,7 @@ moo.otypes.load_types('appfwk/app.jsonnet')
 
 moo.otypes.load_types('trigger/intervaltccreator.jsonnet')
 moo.otypes.load_types('trigger/moduleleveltrigger.jsonnet')
+moo.otypes.load_types('trigger/fakedataflow.jsonnet')
 
 # Import new types
 import dunedaq.cmdlib.cmd as basecmd # AddressedCmd, 
@@ -21,6 +22,7 @@ import dunedaq.appfwk.cmd as cmd # AddressedCmd,
 import dunedaq.appfwk.app as app # AddressedCmd,
 import dunedaq.trigger.intervaltccreator as itcc
 import dunedaq.trigger.moduleleveltrigger as mlt
+import dunedaq.trigger.fakedataflow as fdf
 
 
 from appfwk.utils import mcmd, mrccmd, mspec
@@ -78,6 +80,11 @@ def generate(
 
 
     mod_specs = [
+        mspec("fdf", "FakeDataFlow", [
+            app.QueueInfo(name="trigger_decision_source", inst="trigger_candidate_q", dir="input"),
+            app.QueueInfo(name="trigger_complete_sink", inst="token_q", dir="output"),
+        ]),
+        
         mspec("mlt", "ModuleLevelTrigger", [
             app.QueueInfo(name="token_source", inst="token_q", dir="input"),
             app.QueueInfo(name="trigger_decision_sink", inst="trigger_decision_q", dir="output"),
@@ -93,6 +100,8 @@ def generate(
     cmd_data['init'] = app.Init(queues=queue_specs, modules=mod_specs)
 
     cmd_data['conf'] = acmd([
+        ("fdf", fdf.ConfParams(
+        )),
         ("mlt", mlt.ConfParams(
             links=[idx for idx in range(3)],
             initial_token_count=TOKEN_COUNT                    
@@ -108,11 +117,13 @@ def generate(
 
     startpars = rccmd.StartParams(run=1, disable_data_storage=False)
     cmd_data['start'] = acmd([
+        ("fdf", startpars),
         ("mlt", startpars),
         ("itcc", startpars),
     ])
 
     cmd_data['stop'] = acmd([
+        ("fdf", None),
         ("mlt", None),
         ("itcc", None),
     ])

--- a/schema/trigger/fakedataflow.jsonnet
+++ b/schema/trigger/fakedataflow.jsonnet
@@ -1,0 +1,14 @@
+local moo = import "moo.jsonnet";
+local ns = "dunedaq.trigger.fakedataflow";
+local s = moo.oschema.schema(ns);
+
+local types = {
+  
+  conf : s.record("ConfParams", [
+  
+  ], doc="FakeDataFlow configuration parameters"),
+
+  
+};
+
+moo.oschema.sort_select(types, ns)


### PR DESCRIPTION
FakeDataFlow plugin to emulate the data flow app for testing. No frills yet, just returns `TriggerDecisionTokens` for all `TriggerDecision`. Example log below:
```
2021-Apr-14 14:07:13,006 DEBUG_1 [void dunedaq::trigger::IntervalTCCreator::send_trigger_candidates() at /scratch/ds_workspace_2.4.0/sourcecode/trigger/test/plugins/IntervalTCCreator.cpp:160] At timestamp 80920461650331850, pushing a candidate with timestamp 80920461650000000
2021-Apr-14 14:07:13,006 DEBUG_1 [void dunedaq::trigger::ModuleLevelTrigger::send_trigger_decisions() at /scratch/ds_workspace_2.4.0/sourcecode/trigger/plugins/ModuleLevelTrigger.cpp:182] Pushing a decision with triggernumber 1 timestamp 80920461650000000 number of links 3
2021-Apr-14 14:07:13,006 DEBUG_1 [void dunedaq::trigger::FakeDataFlow::respond_to_trigger_decisions() at /scratch/ds_workspace_2.4.0/sourcecode/trigger/plugins/FakeDataFlow.cpp:95] Responding to decision with triggernumber 1 timestamp 80920461650000000 type 1 number of links 3
2021-Apr-14 14:07:13,016 DEBUG_1 [void dunedaq::trigger::TokenManager::read_token_queue() at /scratch/ds_workspace_2.4.0/sourcecode/trigger/src/TokenManager.cpp:45] Received token with run number 4011200, current run number 4011200
2021-Apr-14 14:07:13,016 DEBUG_1 [void dunedaq::trigger::TokenManager::read_token_queue() at /scratch/ds_workspace_2.4.0/sourcecode/trigger/src/TokenManager.cpp:48] There are now 32719 tokens available
2021-Apr-14 14:07:13,016 DEBUG_1 [void dunedaq::trigger::TokenManager::read_token_queue() at /scratch/ds_workspace_2.4.0/sourcecode/trigger/src/TokenManager.cpp:54] Token indicates that trigger decision 1 has been completed. There are now 0 triggers in flight

```