### PR TITLE
Add unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ daq_add_plugin(IntervalTCCreator duneDAQModule LINK_LIBRARIES trigger TEST)
 
 daq_add_unit_test(TimestampEstimatorSystem_test  LINK_LIBRARIES trigger)
 daq_add_unit_test(TimestampEstimator_test        LINK_LIBRARIES trigger)
+daq_add_unit_test(TokenManager_test              LINK_LIBRARIES trigger)
 
 ##############################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,8 @@ daq_add_plugin(IntervalTCCreator duneDAQModule LINK_LIBRARIES trigger TEST)
 ##############################################################################
 # Unit Tests
 
-# daq_add_unit_test(ComponentRequest_test        LINK_LIBRARIES trigger)
+daq_add_unit_test(TimestampEstimatorSystem_test  LINK_LIBRARIES trigger)
+daq_add_unit_test(TimestampEstimator_test        LINK_LIBRARIES trigger)
 
 ##############################################################################
 

--- a/src/TokenManager.cpp
+++ b/src/TokenManager.cpp
@@ -5,7 +5,7 @@ namespace dunedaq::trigger {
 TokenManager::TokenManager(std::unique_ptr<appfwk::DAQSource<dfmessages::TriggerDecisionToken>>& token_source,
                            int initial_tokens,
                            dataformats::run_number_t run_number)
-  : m_n_initial_tokens(initial_tokens)
+  : m_n_tokens(initial_tokens)
   , m_token_source(token_source)
   , m_run_number(run_number)
 

--- a/unittest/TimestampEstimatorSystem_test.cxx
+++ b/unittest/TimestampEstimatorSystem_test.cxx
@@ -1,0 +1,47 @@
+/**
+ * @file TimestampEstimatorSystem_test.cxx  TimestampEstimatorSystem class Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "trigger/TimestampEstimatorSystem.hpp"
+
+#include <boost/test/tools/old/interface.hpp>
+#include <chrono>
+
+/**
+ * @brief Name of this test module
+ */
+#define BOOST_TEST_MODULE TimestampEstimatorSystem_test // NOLINT
+
+#include "boost/test/unit_test.hpp"
+
+BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+
+BOOST_AUTO_TEST_CASE(Basics)
+{
+  const uint64_t clock_frequency_hz=62'500'000;
+  std::atomic<bool> continue_flag{true};
+  dunedaq::trigger::TimestampEstimatorSystem tes(clock_frequency_hz);
+
+  BOOST_CHECK_EQUAL(tes.wait_for_valid_timestamp(continue_flag), dunedaq::trigger::TimestampEstimatorBase::kFinished);
+
+  std::atomic<bool> do_not_continue_flag{false};
+  BOOST_CHECK_EQUAL(tes.wait_for_valid_timestamp(do_not_continue_flag), dunedaq::trigger::TimestampEstimatorBase::kInterrupted);
+
+  dunedaq::dfmessages::timestamp_t ts_now=tes.get_timestamp_estimate();
+  BOOST_CHECK_EQUAL(tes.wait_for_timestamp(ts_now+clock_frequency_hz, continue_flag), dunedaq::trigger::TimestampEstimatorBase::kFinished);
+
+  ts_now=tes.get_timestamp_estimate();
+  BOOST_CHECK_EQUAL(tes.wait_for_timestamp(ts_now+clock_frequency_hz, do_not_continue_flag), dunedaq::trigger::TimestampEstimatorBase::kInterrupted);
+
+  // Check that the timestamp doesn't go backwards
+  dunedaq::dfmessages::timestamp_t ts1=tes.get_timestamp_estimate();
+  dunedaq::dfmessages::timestamp_t ts2=tes.get_timestamp_estimate();
+  BOOST_CHECK_GE(ts2, ts1);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/TimestampEstimator_test.cxx
+++ b/unittest/TimestampEstimator_test.cxx
@@ -1,0 +1,90 @@
+/**
+ * @file TimestampEstimatorSystem_test.cxx  TimestampEstimatorSystem class Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "appfwk/DAQSink.hpp"
+#include "appfwk/DAQSource.hpp"
+#include "trigger/TimestampEstimator.hpp"
+
+#include <chrono>
+
+/**
+ * @brief Name of this test module
+ */
+#define BOOST_TEST_MODULE TimestampEstimator_test // NOLINT
+
+#include "boost/test/unit_test.hpp"
+
+using namespace dunedaq;
+
+BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+
+/**
+ * @brief Initializes the QueueRegistry
+ */
+struct DAQSinkDAQSourceTestFixture
+{
+  DAQSinkDAQSourceTestFixture() {}
+
+  void setup()
+  {
+    std::map<std::string, appfwk::QueueConfig> queue_map = { { "dummy", { appfwk::QueueConfig::queue_kind::kFollyMPMCQueue, 100 } } };
+
+    appfwk::QueueRegistry::get().configure(queue_map);
+  }
+};
+
+BOOST_TEST_GLOBAL_FIXTURE(DAQSinkDAQSourceTestFixture);
+
+BOOST_AUTO_TEST_CASE(Basics)
+{
+  using namespace std::chrono_literals;
+  
+  using sink_t=appfwk::DAQSink<dfmessages::TimeSync>;
+  using source_t=appfwk::DAQSource<dfmessages::TimeSync>;
+  auto sink=std::make_unique<sink_t>("dummy");
+  auto source=std::make_unique<source_t>("dummy");
+
+  const uint64_t clock_frequency_hz=62'500'000;
+  
+  trigger::TimestampEstimator te(source, clock_frequency_hz);
+
+  // There's no valid timestamp yet, because no TimeSync messages have
+  // been received. We should immediately return with kInterrupted
+  std::atomic<bool> do_not_continue_flag{false};
+  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag), trigger::TimestampEstimatorBase::kInterrupted);
+
+  std::atomic<bool> continue_flag{true};
+  dfmessages::timestamp_t initial_ts=1;
+  sink->push(dfmessages::TimeSync(initial_ts), 10ms);
+  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(continue_flag), trigger::TimestampEstimatorBase::kFinished);
+  
+  dfmessages::timestamp_t ts_now=te.get_timestamp_estimate();
+
+  // Check that the timestamp has advanced a bit from the initial TimeSync, but not by "too much".
+  auto too_much=clock_frequency_hz/10; // 100 ms
+  BOOST_CHECK_GE(ts_now, initial_ts);
+  BOOST_CHECK_LT(ts_now, initial_ts+too_much);
+  
+  BOOST_CHECK_EQUAL(te.wait_for_timestamp(ts_now+clock_frequency_hz, continue_flag), trigger::TimestampEstimatorBase::kFinished);
+
+  ts_now=te.get_timestamp_estimate();
+  BOOST_CHECK_EQUAL(te.wait_for_timestamp(ts_now+clock_frequency_hz, do_not_continue_flag), trigger::TimestampEstimatorBase::kInterrupted);
+
+  // Check that the timestamp doesn't go backwards
+  dfmessages::timestamp_t ts1=te.get_timestamp_estimate();
+  BOOST_CHECK_GE(ts1, initial_ts);
+  dfmessages::timestamp_t ts2=te.get_timestamp_estimate();
+  BOOST_CHECK_GE(ts2, ts1);
+  // Check that the timestamp advances
+  std::this_thread::sleep_for(10ms);
+  dfmessages::timestamp_t ts3=te.get_timestamp_estimate();
+  BOOST_CHECK_GT(ts3, ts2);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/TokenManager_test.cxx
+++ b/unittest/TokenManager_test.cxx
@@ -1,0 +1,83 @@
+/**
+ * @file TokenManager_test.cxx  TokenManager class Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "appfwk/DAQSink.hpp"
+#include "appfwk/DAQSource.hpp"
+#include "trigger/TokenManager.hpp"
+
+#include <chrono>
+
+/**
+ * @brief Name of this test module
+ */
+#define BOOST_TEST_MODULE TokenManager_test // NOLINT
+
+#include "boost/test/unit_test.hpp"
+
+using namespace dunedaq;
+
+BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+
+/**
+ * @brief Initializes the QueueRegistry
+ */
+struct DAQSinkDAQSourceTestFixture
+{
+  DAQSinkDAQSourceTestFixture() {}
+
+  void setup()
+  {
+    std::map<std::string, appfwk::QueueConfig> queue_map = { { "dummy", { appfwk::QueueConfig::queue_kind::kFollyMPMCQueue, 100 } } };
+
+    appfwk::QueueRegistry::get().configure(queue_map);
+  }
+};
+
+BOOST_TEST_GLOBAL_FIXTURE(DAQSinkDAQSourceTestFixture);
+
+BOOST_AUTO_TEST_CASE(Basics)
+{
+  using namespace std::chrono_literals;
+  
+  using sink_t=appfwk::DAQSink<dfmessages::TriggerDecisionToken>;
+  using source_t=appfwk::DAQSource<dfmessages::TriggerDecisionToken>;
+  auto sink=std::make_unique<sink_t>("dummy");
+  auto source=std::make_unique<source_t>("dummy");
+
+  int initial_tokens = 10;
+  dataformats::run_number_t run_number=1;
+  trigger::TokenManager tm(source, initial_tokens, run_number);
+
+  BOOST_CHECK_EQUAL(tm.get_n_tokens(), initial_tokens);
+  BOOST_CHECK_EQUAL(tm.triggers_allowed(), true);
+
+  for(int i=0; i<initial_tokens-1; ++i){
+    tm.trigger_sent(i);
+    BOOST_CHECK_EQUAL(tm.get_n_tokens(), initial_tokens-i-1);
+    BOOST_CHECK_EQUAL(tm.triggers_allowed(), true);
+  }
+  
+  tm.trigger_sent(initial_tokens);
+  BOOST_CHECK_EQUAL(tm.get_n_tokens(), 0);
+  BOOST_CHECK_EQUAL(tm.triggers_allowed(), false);
+
+  // Send a token and check that triggers become allowed again
+  dfmessages::TriggerDecisionToken token;
+  token.run_number=run_number;
+  token.trigger_number=1;
+  sink->push(token);
+
+  // Give TokenManager a little time to pop the token off the queue
+  std::this_thread::sleep_for(100ms);
+  BOOST_CHECK_EQUAL(tm.get_n_tokens(), 1);
+  BOOST_CHECK_EQUAL(tm.triggers_allowed(), true);
+  
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds unit tests for `TimestampEstimator`, `TimestampEstimatorSystem` and `TokenManager` (and a fix for a bug in `TokenManager` found by the unit test). Fixes #6 