### PR TITLE
Use `appfwk::queue_inst` function to get queues

### DIFF
--- a/plugins/FakeDataFlow.cpp
+++ b/plugins/FakeDataFlow.cpp
@@ -18,7 +18,7 @@
 #include "trigger/fakedataflow/Nljs.hpp"
 
 #include "appfwk/app/Nljs.hpp"
-
+#include "appfwk/DAQModuleHelper.hpp"
 
 namespace dunedaq {
 namespace trigger {
@@ -37,15 +37,8 @@ FakeDataFlow::FakeDataFlow(const std::string& name)
 void
 FakeDataFlow::init(const nlohmann::json& obj)
 {
-  auto ini = obj.get<appfwk::app::ModInit>();
-  for (const auto& qi : ini.qinfos) {
-    if (qi.name == "trigger_decision_source") {
-      m_trigger_decision_source.reset(new appfwk::DAQSource<dfmessages::TriggerDecision>(qi.inst));
-    }
-    if (qi.name == "trigger_complete_sink") {
-      m_trigger_complete_sink.reset(new appfwk::DAQSink<dfmessages::TriggerDecisionToken>(qi.inst));
-    }
-  }
+  m_trigger_decision_source.reset(new appfwk::DAQSource<dfmessages::TriggerDecision>(appfwk::queue_inst(obj, "trigger_decision_source")));
+  m_trigger_complete_sink.reset(new appfwk::DAQSink<dfmessages::TriggerDecisionToken>(appfwk::queue_inst(obj,"trigger_complete_sink")));
 }
 
 void

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -23,6 +23,7 @@
 // #include "trigger/moduleleveltriggerinfo/Nljs.hpp"
 
 #include "appfwk/app/Nljs.hpp"
+#include "appfwk/DAQModuleHelper.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -54,18 +55,9 @@ ModuleLevelTrigger::ModuleLevelTrigger(const std::string& name)
 void
 ModuleLevelTrigger::init(const nlohmann::json& iniobj)
 {
-  auto ini = iniobj.get<appfwk::app::ModInit>();
-  for (const auto& qi : ini.qinfos) {
-    if (qi.name == "trigger_decision_sink") {
-      m_trigger_decision_sink.reset(new appfwk::DAQSink<dfmessages::TriggerDecision>(qi.inst));
-    }
-    if (qi.name == "token_source") {
-      m_token_source.reset(new appfwk::DAQSource<dfmessages::TriggerDecisionToken>(qi.inst));
-    }
-    if (qi.name == "trigger_candidate_source") {
-      m_candidate_source.reset(new appfwk::DAQSource<triggeralgs::TriggerCandidate>(qi.inst));
-    }
-  }
+  m_trigger_decision_sink.reset(new appfwk::DAQSink<dfmessages::TriggerDecision>(appfwk::queue_inst(iniobj, "trigger_decision_sink")));
+  m_token_source.reset(new appfwk::DAQSource<dfmessages::TriggerDecisionToken>(appfwk::queue_inst(iniobj,"token_source")));
+  m_candidate_source.reset(new appfwk::DAQSource<triggeralgs::TriggerCandidate>(appfwk::queue_inst(iniobj,"trigger_candidate_source")));
 }
 
 void

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -52,9 +52,8 @@ void
 TimingTriggerCandidateMaker::init(const nlohmann::json& iniobj)
 {
   try {
-    auto qi = appfwk::queue_index(iniobj, { "input", "output" });
-    m_input_queue.reset(new source_t(qi["input"].inst));
-    m_output_queue.reset(new sink_t(qi["output"].inst));
+    m_input_queue.reset(new source_t(appfwk::queue_inst(iniobj, "input")));
+    m_output_queue.reset(new sink_t(appfwk::queue_inst(iniobj, "output")));
   } catch (const ers::Issue& excpt) {
     throw dunedaq::trigger::InvalidQueueFatalError(ERS_HERE, get_name(), "input/output", excpt);
   }

--- a/test/plugins/IntervalTCCreator.cpp
+++ b/test/plugins/IntervalTCCreator.cpp
@@ -23,6 +23,7 @@
 #include "trigger/TimestampEstimatorSystem.hpp"
 
 #include "appfwk/app/Nljs.hpp"
+#include "appfwk/DAQModuleHelper.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -50,15 +51,8 @@ IntervalTCCreator::IntervalTCCreator(const std::string& name)
 void
 IntervalTCCreator::init(const nlohmann::json& iniobj)
 {
-  auto ini = iniobj.get<appfwk::app::ModInit>();
-  for (const auto& qi : ini.qinfos) {
-    if (qi.name == "time_sync_source") {
-      m_time_sync_source.reset(new appfwk::DAQSource<dfmessages::TimeSync>(qi.inst));
-    }
-    if (qi.name == "trigger_candidate_sink") {
-      m_trigger_candidate_sink.reset(new appfwk::DAQSink<triggeralgs::TriggerCandidate>(qi.inst));
-    }
-  }
+  m_time_sync_source.reset(new appfwk::DAQSource<dfmessages::TimeSync>(appfwk::queue_inst(iniobj,"time_sync_source")));
+  m_trigger_candidate_sink.reset(new appfwk::DAQSink<triggeralgs::TriggerCandidate>(appfwk::queue_inst(iniobj, "trigger_candidate_sink")));
 }
 
 void

--- a/test/plugins/IntervalTriggerCreator.cpp
+++ b/test/plugins/IntervalTriggerCreator.cpp
@@ -22,6 +22,7 @@
 #include "trigger/intervaltriggercreator/Nljs.hpp"
 
 #include "appfwk/app/Nljs.hpp"
+#include "appfwk/DAQModuleHelper.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -49,15 +50,8 @@ IntervalTriggerCreator::IntervalTriggerCreator(const std::string& name)
 void
 IntervalTriggerCreator::init(const nlohmann::json& iniobj)
 {
-  auto ini = iniobj.get<appfwk::app::ModInit>();
-  for (const auto& qi : ini.qinfos) {
-    if (qi.name == "time_sync_source") {
-      m_time_sync_source.reset(new appfwk::DAQSource<dfmessages::TimeSync>(qi.inst));
-    }
-    if (qi.name == "trigger_candidate_sink") {
-      m_trigger_decision_sink.reset(new appfwk::DAQSink<dfmessages::TriggerDecision>(qi.inst));
-    }
-  }
+  m_time_sync_source.reset(new appfwk::DAQSource<dfmessages::TimeSync>(appfwk::queue_inst(iniobj,"time_sync_source")));
+  m_trigger_decision_sink.reset(new appfwk::DAQSink<dfmessages::TriggerDecision>(appfwk::queue_inst(iniobj,"trigger_candidate_sink")));
 }
 
 void


### PR DESCRIPTION
The `appfwk::queue_inst` function does the internal name -> queue instance mapping for a module, in a way that's a bit nicer than looping over all of the available queues. This PR uses that function wherever available.