### PR TITLE
Add several fuzzing options to FakeDataFlow

### DIFF
--- a/plugins/FakeDataFlow.cpp
+++ b/plugins/FakeDataFlow.cpp
@@ -20,6 +20,10 @@
 #include "appfwk/app/Nljs.hpp"
 #include "appfwk/DAQModuleHelper.hpp"
 
+#include <vector>
+#include <random>
+#include <chrono>
+
 namespace dunedaq {
 namespace trigger {
 
@@ -47,9 +51,16 @@ FakeDataFlow::get_info(opmonlib::InfoCollector& /*ci*/, int /*level*/)
 }
 
 void
-FakeDataFlow::do_configure(const nlohmann::json& /*obj*/)
+FakeDataFlow::do_configure(const nlohmann::json& obj)
 {
+  auto params = obj.get<fakedataflow::ConfParams>();
   m_configured_flag.store(true);
+  m_hold_max_size = params.hold_max_size;
+  m_hold_min_size = params.hold_min_size;
+  m_hold_min_ms = params.hold_min_ms;
+  m_release_randomly_prob = params.release_randomly_prob;
+  m_forget_decision_prob = params.forget_decision_prob;
+  m_hold_decision_prob = params.hold_decision_prob;
 }
 
 void
@@ -74,32 +85,103 @@ FakeDataFlow::do_scrap(const nlohmann::json& /*obj*/)
 }
 
 void
+FakeDataFlow::respond_with_token(const dfmessages::TriggerDecision &td)
+{
+  TLOG_DEBUG(1) << "Responding to decision with"
+                << " triggernumber " << td.trigger_number 
+                << " timestamp " << td.trigger_timestamp 
+                << " type " << td.trigger_type 
+                << " number of links " << td.components.size();
+                
+  dfmessages::TriggerDecisionToken td_token;
+  td_token.run_number = td.run_number;
+  td_token.trigger_number = td.trigger_number;
+  try {
+    m_trigger_complete_sink->push(td_token, std::chrono::milliseconds(10));
+  }
+  catch (appfwk::QueueTimeoutExpired& e) {
+    ers::error(e);
+  }
+}
+
+/*
+
+Logic goes like this: 
+1) TriggerDecision is received
+2) A flat probability to forget the decision and go to 1
+3) A flat probability to hold the decision in a queue and go to 1
+4) A TriggerDecisionToken is sent
+
+The held decision queue is filled until it reaches a predetermined size and
+then empties itself with the following logic until it reaches a predetermined
+minimum size.
+1) A flat probability to reply to a random held decision
+2) Otherwise reply to the oldest held decision
+
+*/
+void
 FakeDataFlow::respond_to_trigger_decisions()
 {
+  std::default_random_engine generator;
+  std::uniform_real_distribution<double> uniform(0.0,1.0);
+  std::vector<dfmessages::TriggerDecision> held_decisions;
+  bool hold_full = false;
+  std::chrono::steady_clock::time_point hold_full_time;
   while (m_running_flag.load()) {
+    if (held_decisions.size() >= m_hold_max_size) {
+      if (hold_full) {
+        std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+        int delta = std::chrono::duration_cast<std::chrono::milliseconds>(now - hold_full_time).count();
+        if (delta > m_hold_min_ms) {
+          TLOG_DEBUG(1) << "Now releasing held TDs";
+          while (held_decisions.size() > m_hold_min_size) {
+            int i;
+            if (uniform(generator) < m_release_randomly_prob) {
+              i = (int)(uniform(generator)*held_decisions.size());
+            } else {
+              i = 0;
+            }
+            respond_with_token(held_decisions[i]);
+            held_decisions.erase(held_decisions.begin()+i);
+          }
+          hold_full = false;
+        }
+      } else {
+        TLOG_DEBUG(1) << "Held TD queue full, waiting " << m_hold_min_ms << " ms to release";
+        hold_full_time = std::chrono::steady_clock::now();
+        hold_full = true;
+      }
+    }
+  
     dfmessages::TriggerDecision td;
     try {
-      m_trigger_decision_source->pop(td, std::chrono::milliseconds(1000));
+      m_trigger_decision_source->pop(td, std::chrono::milliseconds(100));
     }
     catch (appfwk::QueueTimeoutExpired&) {
       continue;
     }
     
-    TLOG_DEBUG(1) << "Responding to decision with"
-                  << " triggernumber " << td.trigger_number 
-                  << " timestamp " << td.trigger_timestamp 
-                  << " type " << td.trigger_type 
-                  << " number of links " << td.components.size();
-                  
-    dfmessages::TriggerDecisionToken td_token;
-    td_token.run_number = td.run_number;
-    td_token.trigger_number = td.trigger_number;
-    try {
-      m_trigger_complete_sink->push(td_token, std::chrono::milliseconds(10));
+    if (uniform(generator) < m_forget_decision_prob) {
+      TLOG_DEBUG(1) << "Forgetting decision with"
+                    << " triggernumber " << td.trigger_number 
+                    << " timestamp " << td.trigger_timestamp 
+                    << " type " << td.trigger_type 
+                    << " number of links " << td.components.size();  
+      continue;
     }
-    catch (appfwk::QueueTimeoutExpired& e) {
-      ers::error(e);
+    
+    if (uniform(generator) < m_hold_decision_prob) {
+      TLOG_DEBUG(1) << "Holding decision with"
+                    << " triggernumber " << td.trigger_number 
+                    << " timestamp " << td.trigger_timestamp 
+                    << " type " << td.trigger_type 
+                    << " number of links " << td.components.size();  
+      held_decisions.push_back(td);
+      continue;
     }
+    
+    respond_with_token(td);
+    
   }
 }
 

--- a/plugins/FakeDataFlow.hpp
+++ b/plugins/FakeDataFlow.hpp
@@ -58,6 +58,14 @@ private:
   void do_resume(const nlohmann::json& obj);
   void do_scrap(const nlohmann::json& obj);
 
+  size_t m_hold_max_size;
+  size_t m_hold_min_size;
+  int m_hold_min_ms;
+  double m_release_randomly_prob;
+  double m_forget_decision_prob;
+  double m_hold_decision_prob;
+  
+  void respond_with_token(const dfmessages::TriggerDecision &td);
   void respond_to_trigger_decisions();
   std::thread m_fake_data_flow_thread;
 

--- a/python/trigger/faketc/faketc_and_mlt_gen.py
+++ b/python/trigger/faketc/faketc_and_mlt_gen.py
@@ -58,6 +58,12 @@ def generate(
         OUTPUT_PATH: str = ".",
         TOKEN_COUNT: int = 10,
         CLOCK_SPEED_HZ: int = 50000000,
+        FORGET_DECISION_PROB: float = 0.0,
+        HOLD_DECISION_PROB: float = 0.0,
+        HOLD_MAX_SIZE: int = 0,
+        HOLD_MIN_SIZE: int = 0,
+        HOLD_MIN_MS: int = 0,
+        RELEASE_RANDOMLY_PROB: float = 0.0
 ):
     """
     { item_description }
@@ -101,6 +107,12 @@ def generate(
 
     cmd_data['conf'] = acmd([
         ("fdf", fdf.ConfParams(
+          hold_max_size = HOLD_MAX_SIZE,
+          hold_min_size = HOLD_MIN_SIZE,
+          hold_min_ms = HOLD_MIN_MS,
+          release_randomly_prob = RELEASE_RANDOMLY_PROB,
+          forget_decision_prob = FORGET_DECISION_PROB,
+          hold_decision_prob = HOLD_DECISION_PROB
         )),
         ("mlt", mlt.ConfParams(
             links=[idx for idx in range(3)],

--- a/python/trigger/faketc/toplevel.py
+++ b/python/trigger/faketc/toplevel.py
@@ -92,8 +92,15 @@ import click
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-t', '--trigger-rate-hz', default=1.0)
 @click.option('-c', '--token-count', default=10)
+@click.option('-F', '--forget-decision-prob', default=0.0)
+@click.option('-H', '--hold-decision-prob', default=0.0)
+@click.option('-M', '--hold-max-size', default=0)
+@click.option('-m', '--hold-min-size', default=0)
+@click.option('-T', '--hold-min-ms', default=0)
+@click.option('-R', '--release-randomly-prob', default=0.0)
 @click.argument('json_dir', type=click.Path())
-def cli(trigger_rate_hz, token_count, json_dir):
+def cli(trigger_rate_hz, token_count, forget_decision_prob, hold_decision_prob, 
+        hold_max_size, hold_min_size, hold_min_ms, release_randomly_prob, json_dir):
     """
       JSON_DIR: Json file output folder
     """
@@ -112,7 +119,13 @@ def cli(trigger_rate_hz, token_count, json_dir):
         TRIGGER_RATE_HZ = trigger_rate_hz,
         OUTPUT_PATH = json_dir,
         TOKEN_COUNT = trigemu_token_count,
-        CLOCK_SPEED_HZ = CLOCK_SPEED_HZ
+        CLOCK_SPEED_HZ = CLOCK_SPEED_HZ,
+        FORGET_DECISION_PROB = forget_decision_prob,
+        HOLD_DECISION_PROB = hold_decision_prob,
+        HOLD_MAX_SIZE = hold_max_size,
+        HOLD_MIN_SIZE = hold_min_size,
+        HOLD_MIN_MS = hold_min_ms,
+        RELEASE_RANDOMLY_PROB = release_randomly_prob
     )
 
     console.log("trg cmd data:", cmd_data_trg)

--- a/python/trigger/faketsd/faketsd_and_mlt_gen.py
+++ b/python/trigger/faketsd/faketsd_and_mlt_gen.py
@@ -61,6 +61,12 @@ def generate(
         OUTPUT_PATH: str = ".",
         TOKEN_COUNT: int = 10,
         CLOCK_SPEED_HZ: int = 50000000,
+        FORGET_DECISION_PROB: float = 0.0,
+        HOLD_DECISION_PROB: float = 0.0,
+        HOLD_MAX_SIZE: int = 0,
+        HOLD_MIN_SIZE: int = 0,
+        HOLD_MIN_MS: int = 0,
+        RELEASE_RANDOMLY_PROB: float = 0.0
 ):
     """
     { item_description }
@@ -109,6 +115,12 @@ def generate(
 
     cmd_data['conf'] = acmd([
         ("fdf", fdf.ConfParams(
+          hold_max_size = HOLD_MAX_SIZE,
+          hold_min_size = HOLD_MIN_SIZE,
+          hold_min_ms = HOLD_MIN_MS,
+          release_randomly_prob = RELEASE_RANDOMLY_PROB,
+          forget_decision_prob = FORGET_DECISION_PROB,
+          hold_decision_prob = HOLD_DECISION_PROB
         )),
         ("mlt", mlt.ConfParams(
             links=[idx for idx in range(3)],

--- a/python/trigger/faketsd/toplevel.py
+++ b/python/trigger/faketsd/toplevel.py
@@ -92,8 +92,15 @@ import click
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-t', '--trigger-rate-hz', default=1.0)
 @click.option('-c', '--token-count', default=10)
+@click.option('-F', '--forget-decision-prob', default=0.0)
+@click.option('-H', '--hold-decision-prob', default=0.0)
+@click.option('-M', '--hold-max-size', default=0)
+@click.option('-m', '--hold-min-size', default=0)
+@click.option('-T', '--hold-min-ms', default=0)
+@click.option('-R', '--release-randomly-prob', default=0.0)
 @click.argument('json_dir', type=click.Path())
-def cli(trigger_rate_hz, token_count, json_dir):
+def cli(trigger_rate_hz, token_count, forget_decision_prob, hold_decision_prob, 
+        hold_max_size, hold_min_size, hold_min_ms, release_randomly_prob, json_dir):
     """
       JSON_DIR: Json file output folder
     """
@@ -112,7 +119,13 @@ def cli(trigger_rate_hz, token_count, json_dir):
         TRIGGER_RATE_HZ = trigger_rate_hz,
         OUTPUT_PATH = json_dir,
         TOKEN_COUNT = trigemu_token_count,
-        CLOCK_SPEED_HZ = CLOCK_SPEED_HZ
+        CLOCK_SPEED_HZ = CLOCK_SPEED_HZ,
+        FORGET_DECISION_PROB = forget_decision_prob,
+        HOLD_DECISION_PROB = hold_decision_prob,
+        HOLD_MAX_SIZE = hold_max_size,
+        HOLD_MIN_SIZE = hold_min_size,
+        HOLD_MIN_MS = hold_min_ms,
+        RELEASE_RANDOMLY_PROB = release_randomly_prob
     )
 
     console.log("trg cmd data:", cmd_data_trg)

--- a/schema/trigger/fakedataflow.jsonnet
+++ b/schema/trigger/fakedataflow.jsonnet
@@ -3,11 +3,24 @@ local ns = "dunedaq.trigger.fakedataflow";
 local s = moo.oschema.schema(ns);
 
 local types = {
+  count: s.number("count", dtype="i4"),
+  ms: s.number("milliseconds", dtype="i4"),
+  probability: s.number("probability", dtype="f8"),
   
   conf : s.record("ConfParams", [
-  
-  ], doc="FakeDataFlow configuration parameters"),
-
+    s.field("forget_decision_prob", self.probability,
+      doc="Probability to completely forget about a received TD"),
+    s.field("hold_decision_prob", self.probability,
+      doc="Probability to hold a TD and send TDT later"),
+    s.field("hold_max_size", self.count,
+      doc="Maximum number of held TDs before sending TDTs for held TDs"),
+    s.field("hold_min_size", self.count,
+      doc="Minimum number of held TDs to keep when sending TDTs for held TDs"),
+    s.field("hold_min_ms", self.ms,
+      doc="Minimum number ms to hold TDs once hold_max_size is met"),
+    s.field("release_randomly_prob", self.probability,
+      doc="Probability to release a random held TD out of order")
+  ], doc="FakeDataFlow configuration parameters")
   
 };
 


### PR DESCRIPTION
Logic goes like this:
1) TriggerDecision is received
2) A flat probability to forget the decision and go to 1
3) A flat probability to hold the decision in a queue and go to 1
4) A TriggerDecisionToken is sent

The held decision queue is filled until it reaches a predetermined size and
then after a configurable delay, empties itself with the following logic
until it reaches a predetermined minimum size.
1) A flat probability to reply to a random held decision
2) Otherwise reply to the oldest held decision

Configuration arguments:
--forget-decision-prob probability to forget trigger decision
--hold-decision-prob probability to hold a trigger decision
--hold-max-size maximum size of held queue (releases at this number)
--hold-min-size minimum size of held queue (this many remain held after release)
--hold-min-ms milliseconds to wait after hold queue is full before release
--release-randomly-prob probability to release a trigger decision out of order

To hold 10 TDs, wait 5 seconds, then release all:
--hold-decision-prob 1.0 --hold-max-size 10 --hold-min-ms 5000

To randomly forget 5% of TDs:
--forget-decision-prob 0.05

To hold 5 TDs and release them out of order as new TDs arrive:
--hold-decision-prob 1.0 --hold-max-size 5 --hold-min-size 4 --release-randomly-prob 1.0

To hold 1% of TDs and release them in batches 10s after the first is held
--hold-decision-prob 0.01 --hold-max-size 1 --hold-min-ms 10000