### PR TITLE
Drain queues at "stop"

### DIFF
--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -161,13 +161,19 @@ ModuleLevelTrigger::send_trigger_decisions()
   size_t n_tc_received = 0;
   size_t n_paused = 0;
 
-  while (m_running_flag.load()) {
+  while (true) {
     triggeralgs::TriggerCandidate tc;
     try {
       m_candidate_source->pop(tc, std::chrono::milliseconds(100));
       ++n_tc_received;
     } catch (appfwk::QueueTimeoutExpired&) {
-      continue;
+      // The condition to exit the loop is that we've been stopped and
+      // there's nothing left on the input queue
+      if (!m_running_flag.load()) {
+        break;
+      } else {
+        continue;
+      }
     }
 
     bool tokens_allow_triggers = m_token_manager->triggers_allowed();

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -79,14 +79,20 @@ TimingTriggerCandidateMaker::do_work(std::atomic<bool>& running_flag)
   size_t n_tsd_received = 0;
   size_t n_tc_sent = 0;
 
-  while (running_flag.load()) {
+  while (true) {
 
     triggeralgs::TimeStampedData data;
     try {
       m_input_queue->pop(data, m_queue_timeout);
       ++n_tsd_received;
     } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
-      continue;
+      // The condition to exit the loop is that we've been stopped and
+      // there's nothing left on the input queue
+      if (!running_flag.load()) {
+        break;
+      } else {
+        continue;
+      }
     }
 
     triggeralgs::TriggerCandidate candidate;

--- a/python/trigger/faketsd/faketsd_and_mlt_gen.py
+++ b/python/trigger/faketsd/faketsd_and_mlt_gen.py
@@ -142,11 +142,15 @@ def generate(
         ("ttcm", startpars),
     ])
 
+    # We issue stop commands in the order "upstream to downstream" so
+    # that each module can drain its input queue at stop, and be
+    # guaranteed to get all inputs (at least when everything lives in
+    # the same module)
     cmd_data['stop'] = acmd([
-        ("fdf", None),
-        ("mlt", None),
         ("ftsdg", None),
         ("ttcm", None),
+        ("mlt", None),
+        ("fdf", None),
     ])
 
     cmd_data['pause'] = acmd([


### PR DESCRIPTION
When each module gets a stop command, we pop items off the input queue until there are no more. This means that all data in flight gets processed (provided we're working entirely within a single application, no network; and there are no cycles in the queue/module graph).