### PR TITLE
Improve behaviour at high trigger rates

### DIFF
--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -161,13 +161,19 @@ ModuleLevelTrigger::send_trigger_decisions()
   size_t n_tc_received = 0;
   size_t n_paused = 0;
 
-  while (m_running_flag.load()) {
+  while (true) {
     triggeralgs::TriggerCandidate tc;
     try {
       m_candidate_source->pop(tc, std::chrono::milliseconds(100));
       ++n_tc_received;
     } catch (appfwk::QueueTimeoutExpired&) {
-      continue;
+      // The condition to exit the loop is that we've been stopped and
+      // there's nothing left on the input queue
+      if (!m_running_flag.load()) {
+        break;
+      } else {
+        continue;
+      }
     }
 
     bool tokens_allow_triggers = m_token_manager->triggers_allowed();

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -79,14 +79,20 @@ TimingTriggerCandidateMaker::do_work(std::atomic<bool>& running_flag)
   size_t n_tsd_received = 0;
   size_t n_tc_sent = 0;
 
-  while (running_flag.load()) {
+  while (true) {
 
     triggeralgs::TimeStampedData data;
     try {
       m_input_queue->pop(data, m_queue_timeout);
       ++n_tsd_received;
     } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
-      continue;
+      // The condition to exit the loop is that we've been stopped and
+      // there's nothing left on the input queue
+      if (!running_flag.load()) {
+        break;
+      } else {
+        continue;
+      }
     }
 
     triggeralgs::TriggerCandidate candidate;

--- a/python/trigger/faketsd/faketsd_and_mlt_gen.py
+++ b/python/trigger/faketsd/faketsd_and_mlt_gen.py
@@ -142,11 +142,15 @@ def generate(
         ("ttcm", startpars),
     ])
 
+    # We issue stop commands in the order "upstream to downstream" so
+    # that each module can drain its input queue at stop, and be
+    # guaranteed to get all inputs (at least when everything lives in
+    # the same module)
     cmd_data['stop'] = acmd([
-        ("fdf", None),
-        ("mlt", None),
         ("ftsdg", None),
         ("ttcm", None),
+        ("mlt", None),
+        ("fdf", None),
     ])
 
     cmd_data['pause'] = acmd([

--- a/python/trigger/faketsd/toplevel.py
+++ b/python/trigger/faketsd/toplevel.py
@@ -51,7 +51,8 @@ def generate_boot( tremu_spec: dict) -> dict:
                 "DUNEDAQ_SHARE_PATH": "getenv",
                 "LD_LIBRARY_PATH": "getenv",
                 "PATH": "getenv",
-                "DUNEDAQ_ERS_DEBUG_LEVEL": "1"
+                "DUNEDAQ_ERS_DEBUG_LEVEL": "getenv",
+                "DUNEDAQ_ERS_VERBOSITY_LEVEL": "getenv",
             },
             "cmd": [
                 "CMD_FAC=rest://localhost:${APP_PORT}",
@@ -64,7 +65,7 @@ def generate_boot( tremu_spec: dict) -> dict:
 
     boot = {
         "env": {
-            "DUNEDAQ_ERS_VERBOSITY_LEVEL": 1
+            "DUNEDAQ_ERS_VERBOSITY_LEVEL": "getenv"
         },
         "apps": {
             tremu_spec["name"]: {

--- a/src/TokenManager.cpp
+++ b/src/TokenManager.cpp
@@ -12,6 +12,7 @@ TokenManager::TokenManager(std::unique_ptr<appfwk::DAQSource<dfmessages::Trigger
 {
   m_running_flag.store(true);
   m_read_queue_thread = std::thread(&TokenManager::read_token_queue, this);
+  pthread_setname_np(m_read_queue_thread.native_handle(), "token-mgr");
 }
 
 TokenManager::~TokenManager()

--- a/src/TokenManager.cpp
+++ b/src/TokenManager.cpp
@@ -39,51 +39,60 @@ void
 TokenManager::read_token_queue()
 {
   auto open_trigger_report_time = std::chrono::steady_clock::now();
-  while (m_running_flag.load()) {
-    while (m_token_source->can_pop()) {
-      dfmessages::TriggerDecisionToken tdt;
-      m_token_source->pop(tdt);
-      TLOG_DEBUG(1) << "Received token with run number " << tdt.run_number << ", current run number " << m_run_number;
-      if (tdt.run_number == m_run_number) {
-        m_n_tokens++;
-        TLOG_DEBUG(1) << "There are now " << m_n_tokens.load() << " tokens available";
+  while (true) {
 
-        if (tdt.trigger_number != dfmessages::TypeDefaults::s_invalid_trigger_number) {
-          if (m_open_trigger_decisions.count(tdt.trigger_number)) {
-            std::lock_guard<std::mutex> lk(m_open_trigger_decisions_mutex);
-            m_open_trigger_decisions.erase(tdt.trigger_number);
-            TLOG_DEBUG(1) << "Token indicates that trigger decision " << tdt.trigger_number
-                          << " has been completed. There are now " << m_open_trigger_decisions.size()
-                          << " triggers in flight";
-          } else {
-            // ERS warning: received token for trigger number I don't recognize
-          }
-        }
+    dfmessages::TriggerDecisionToken tdt;
+    try {
+      m_token_source->pop(tdt, std::chrono::milliseconds(100));
+    } catch (appfwk::QueueTimeoutExpired&) {
+      // The condition to exit the loop is that we've been stopped and
+      // there's nothing left on the input queue
+      if (!m_running_flag.load()) {
+        break;
+      } else {
+        continue;
       }
     }
-    if (!m_open_trigger_decisions.empty()) {
 
-      auto now = std::chrono::steady_clock::now();
-      if (std::chrono::duration_cast<std::chrono::milliseconds>(now - open_trigger_report_time) >
-          std::chrono::milliseconds(3000)) {
-        std::ostringstream o;
-        o << "Open Trigger Decisions: [";
-        { // Scope for lock_guard
-          bool first = true;
+    TLOG_DEBUG(1) << "Received token with run number " << tdt.run_number << ", current run number " << m_run_number;
+    if (tdt.run_number == m_run_number) {
+      m_n_tokens++;
+      TLOG_DEBUG(1) << "There are now " << m_n_tokens.load() << " tokens available";
+
+      if (tdt.trigger_number != dfmessages::TypeDefaults::s_invalid_trigger_number) {
+        if (m_open_trigger_decisions.count(tdt.trigger_number)) {
           std::lock_guard<std::mutex> lk(m_open_trigger_decisions_mutex);
-          for (auto& td : m_open_trigger_decisions) {
-            if (!first)
-              o << ", ";
-            o << td;
-            first = false;
-          }
-          o << "]";
+          m_open_trigger_decisions.erase(tdt.trigger_number);
+          TLOG_DEBUG(1) << "Token indicates that trigger decision " << tdt.trigger_number
+                        << " has been completed. There are now " << m_open_trigger_decisions.size()
+                        << " triggers in flight";
+        } else {
+          // ERS warning: received token for trigger number I don't recognize
         }
-        TLOG_DEBUG(0) << o.str();
-        open_trigger_report_time = now;
       }
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  if (!m_open_trigger_decisions.empty()) {
+
+    auto now = std::chrono::steady_clock::now();
+    if (std::chrono::duration_cast<std::chrono::milliseconds>(now - open_trigger_report_time) >
+        std::chrono::milliseconds(3000)) {
+      std::ostringstream o;
+      o << "Open Trigger Decisions: [";
+      { // Scope for lock_guard
+        bool first = true;
+        std::lock_guard<std::mutex> lk(m_open_trigger_decisions_mutex);
+        for (auto& td : m_open_trigger_decisions) {
+          if (!first)
+            o << ", ";
+          o << td;
+          first = false;
+        }
+        o << "]";
+      }
+      TLOG_DEBUG(0) << o.str();
+      open_trigger_report_time = now;
+    }
   }
 }
 

--- a/src/trigger/TokenManager.hpp
+++ b/src/trigger/TokenManager.hpp
@@ -23,6 +23,17 @@
 namespace dunedaq {
 namespace trigger {
 
+/**
+ * @brief TokenManager keeps track of the number of in-flight trigger decisions.
+ *
+ * TokenManager implements a credit-based system for trigger
+ * inhibits. It is constructed with an initial number of tokens and a
+ * queue of @a dfmessages::TriggerDecisionToken. When a trigger
+ * decision is sent, the number of tokens is decremented, and when a
+ * TriggerDecisionToken is received on the queue, the number of tokens
+ * is incremented. When the count of available tokens reaches zero, no
+ * further TriggerDecisions may be issued.
+ */
 class TokenManager
 {
 public:
@@ -32,22 +43,40 @@ public:
 
   ~TokenManager();
 
+  /**
+   *  Get the number of available tokens
+   */
   int get_n_tokens() const;
 
+  /**
+   * Are tokens currently available, to allow sending of new trigger decisions?
+   */
   bool triggers_allowed() const { return get_n_tokens() > 0; }
 
+  /**
+   * Notify TokenManager that a trigger decision has been sent. This
+   * decreases the number of available tokens by one.
+   *
+   * Note: you should call this function *before* pushing the corresponding TriggerDecision
+   * to its output queue. If you do these steps in the other order, the TriggerComplete message
+   * may be returned before TokenManager is aware of the corresponding trigger decision
+   */
   void trigger_sent(dfmessages::trigger_number_t);
 
 private:
+  // The main thread
   void read_token_queue();
-
   std::thread m_read_queue_thread;
 
+  // Are we running?
   std::atomic<bool> m_running_flag;
+  // How many tokens are currently available?
   std::atomic<int> m_n_tokens;
-  int m_n_initial_tokens;
-  std::mutex m_open_trigger_decisions_mutex;
+
+  // The currently-in-flight trigger decisions, and a mutex to guard it
   std::set<dfmessages::trigger_number_t> m_open_trigger_decisions;
+  std::mutex m_open_trigger_decisions_mutex;
+
   std::unique_ptr<appfwk::DAQSource<dfmessages::TriggerDecisionToken>>& m_token_source;
   dataformats::run_number_t m_run_number;
 };


### PR DESCRIPTION
Make the trigger app work a bit better at high rates. With these changes I can run the "faketsd" app at 100 kHz with no inhibits (using 1000 initial tokens).

Changes:

* Removed a sleep() from the TokenManager loop (and replaced it with a timeout in pop()), which helped reduce the number of inhibits
* TimingTriggerCandidateMaker and ModuleLevelTrigger now drain their input queues after they receive the stop command. This ensures that all the data in-flight end-of-run is processed. PR'ed separately in #16 because it's more general than just high rates.
* Fixed a race condition in ModuleLevelTrigger's use of TokenManager. It was doing:
```cpp
    trigger_decision_q->push(td);
    token_manager->trigger_sent(td.trigger_number);
```
But at high rates (and with the FakeDF), the TokenManager's background thread may receive the "trigger complete" message for td *before* trigger_sent is called. It sees a "trigger complete" for a trigger number it doesn't know and ignores it. Then the td never gets removed from TokenManager's list of outstanding triggers. Putting the two lines in the other order fixes this.