### PR TITLE
Set component_type in GeoID instances

### DIFF
--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -78,7 +78,7 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
   m_links.clear();
   for (auto const& link : params.links) {
     // For the future: Set APA properly
-    m_links.push_back(dfmessages::GeoID{ 0, static_cast<uint32_t>(link) }); // NOLINT
+    m_links.push_back(dfmessages::GeoID{dataformats::GeoIDComponentType::kTPC, 0, static_cast<uint32_t>(link) }); // NOLINT
   }
 
   m_configured_flag.store(true);

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -78,7 +78,7 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
   m_links.clear();
   for (auto const& link : params.links) {
     // For the future: Set APA properly
-    m_links.push_back(dfmessages::GeoID{dataformats::GeoIDComponentType::kTPC, 0, static_cast<uint32_t>(link) }); // NOLINT
+    m_links.push_back(dfmessages::GeoID{dataformats::GeoID::SystemType::kTPC, 0, static_cast<uint32_t>(link) }); // NOLINT
   }
 
   m_configured_flag.store(true);

--- a/test/plugins/IntervalTriggerCreator.cpp
+++ b/test/plugins/IntervalTriggerCreator.cpp
@@ -83,7 +83,7 @@ IntervalTriggerCreator::do_configure(const nlohmann::json& confobj)
   m_links.clear();
   for (auto const& link : params.links) {
     // For the future: Set APA properly
-    m_links.push_back(dfmessages::GeoID{ dataformats::GeoIDComponentType::kTPC, 0, static_cast<uint32_t>(link) }); // NOLINT
+    m_links.push_back(dfmessages::GeoID{ dataformats::GeoID::SystemType::kTPC, 0, static_cast<uint32_t>(link) }); // NOLINT
   }
 
   // Sanity-check the values

--- a/test/plugins/IntervalTriggerCreator.cpp
+++ b/test/plugins/IntervalTriggerCreator.cpp
@@ -83,7 +83,7 @@ IntervalTriggerCreator::do_configure(const nlohmann::json& confobj)
   m_links.clear();
   for (auto const& link : params.links) {
     // For the future: Set APA properly
-    m_links.push_back(dfmessages::GeoID{ 0, static_cast<uint32_t>(link) }); // NOLINT
+    m_links.push_back(dfmessages::GeoID{ dataformats::GeoIDComponentType::kTPC, 0, static_cast<uint32_t>(link) }); // NOLINT
   }
 
   // Sanity-check the values


### PR DESCRIPTION
This PR is for compatibility with DUNE-DAQ/dataformats#62 (which should be merged first)