### PR TITLE
Add `trigger::Set<T>`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ daq_add_plugin(FakeDataFlow duneDAQModule LINK_LIBRARIES trigger TEST)
 ##############################################################################
 # Integration tests
 
+daq_add_application( set_serialization_speed set_serialization_speed.cxx TEST LINK_LIBRARIES trigger)
 
 ##############################################################################
 # Unit Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ daq_add_plugin(FakeDataFlow duneDAQModule LINK_LIBRARIES trigger TEST)
 # Integration tests
 
 daq_add_application( set_serialization_speed set_serialization_speed.cxx TEST LINK_LIBRARIES trigger)
+daq_add_application( taset_serialization taset_serialization.cxx TEST LINK_LIBRARIES trigger)
 
 ##############################################################################
 # Unit Tests

--- a/include/trigger/Set.hpp
+++ b/include/trigger/Set.hpp
@@ -1,10 +1,18 @@
+/**
+ * @file Set.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
 #ifndef TRIGGER_INCLUDE_TRIGGER_SET_HPP_
 #define TRIGGER_INCLUDE_TRIGGER_SET_HPP_
 
 #include "dataformats/Types.hpp"
 #include "triggeralgs/TriggerActivity.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
-#include "triggeralgs/TriggerCandidate.hpp"
+#include "trigger/serialize.hpp"
 #include "serialization/Serialization.hpp"
 
 #include <cstdint>
@@ -12,6 +20,9 @@
 
 namespace dunedaq::trigger {
 
+/**
+ * @brief A set of TPs or TAs in a given time window, defined by its start and end times
+ */
 template<class T>
 class Set {
 public:
@@ -45,46 +56,10 @@ using TASet = Set<triggeralgs::TriggerActivity>;
 
 } // namespace dunedaq::trigger
 
-DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerPrimitive,
-                                 time_start,
-                                 time_peak,
-                                 time_over_threshold,
-                                 channel,
-                                 adc_integral,
-                                 adc_peak,
-                                 detid,
-                                 type,
-                                 algorithm,
-                                 version,
-                                 flag)
+MSGPACK_ADD_ENUM(dunedaq::trigger::TPSet::Type)
+MSGPACK_ADD_ENUM(dunedaq::trigger::TASet::Type)
 
-DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerActivity,
-                                 time_start,
-                                 time_end,
-                                 time_peak,
-                                 time_activity,
-                                 channel_start,
-                                 channel_end,
-                                 channel_peak,
-                                 adc_integral,
-                                 adc_peak,
-                                 detid,
-                                 type,
-                                 algorithm,
-                                 version,
-                                 tp_list)
-
-DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerCandidate,
-                                 time_start,
-                                 time_end,
-                                 time_candidate,
-                                 detid,
-                                 type,
-                                 algorithm,
-                                 version,
-                                 ta_list)
-
-DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(dunedaq::trigger, TPSet, seqno, from_detids, start_time, end_time, objects)
-DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(dunedaq::trigger, TASet, seqno, from_detids, start_time, end_time, objects)
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(dunedaq::trigger, TPSet, seqno, type, from_detids, start_time, end_time, objects)
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(dunedaq::trigger, TASet, seqno, type, from_detids, start_time, end_time, objects)
 
 #endif // TRIGGER_INCLUDE_TRIGGER_SET_HPP_

--- a/include/trigger/Set.hpp
+++ b/include/trigger/Set.hpp
@@ -10,10 +10,6 @@
 #define TRIGGER_INCLUDE_TRIGGER_SET_HPP_
 
 #include "dataformats/Types.hpp"
-#include "triggeralgs/TriggerActivity.hpp"
-#include "triggeralgs/TriggerPrimitive.hpp"
-#include "trigger/serialize.hpp"
-#include "serialization/Serialization.hpp"
 
 #include <cstdint>
 #include <vector>
@@ -51,15 +47,6 @@ public:
   std::vector<T> objects;
 };
 
-using TPSet = Set<triggeralgs::TriggerPrimitive>;
-using TASet = Set<triggeralgs::TriggerActivity>;
-
 } // namespace dunedaq::trigger
-
-MSGPACK_ADD_ENUM(dunedaq::trigger::TPSet::Type)
-MSGPACK_ADD_ENUM(dunedaq::trigger::TASet::Type)
-
-DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(dunedaq::trigger, TPSet, seqno, type, from_detids, start_time, end_time, objects)
-DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(dunedaq::trigger, TASet, seqno, type, from_detids, start_time, end_time, objects)
 
 #endif // TRIGGER_INCLUDE_TRIGGER_SET_HPP_

--- a/include/trigger/Set.hpp
+++ b/include/trigger/Set.hpp
@@ -15,16 +15,26 @@ namespace dunedaq::trigger {
 template<class T>
 class Set {
 public:
+
+  enum Type {
+    kUnknown = 0,
+    kPayload = 1,
+    kHeartbeat = 2
+  };
+
   // An incremental count of how many Sets have been produced by this source
-  uint32_t seqno;
+  uint32_t seqno{0};
+
+  // Whether this Set is a regular bag-of-objects or a heartbeat
+  Type type{kUnknown};
 
   // The detids that were inspected to form this Set
   std::vector<uint16_t> from_detids;
 
   // The earliest timestamp inspected to form this Set
-  dataformats::timestamp_t start_time;
+  dataformats::timestamp_t start_time{0};
   // The latest timestamp inspected to form this Set
-  dataformats::timestamp_t end_time;
+  dataformats::timestamp_t end_time{0};
 
   // The TPs/TAs themselves. Needs a better name!
   std::vector<T> objects;
@@ -33,7 +43,7 @@ public:
 using TPSet = Set<triggeralgs::TriggerPrimitive>;
 using TASet = Set<triggeralgs::TriggerActivity>;
 
-}
+} // namespace dunedaq::trigger
 
 DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerPrimitive,
                                  time_start,

--- a/include/trigger/Set.hpp
+++ b/include/trigger/Set.hpp
@@ -1,0 +1,80 @@
+#ifndef TRIGGER_INCLUDE_TRIGGER_SET_HPP_
+#define TRIGGER_INCLUDE_TRIGGER_SET_HPP_
+
+#include "dataformats/Types.hpp"
+#include "triggeralgs/TriggerActivity.hpp"
+#include "triggeralgs/TriggerPrimitive.hpp"
+#include "triggeralgs/TriggerCandidate.hpp"
+#include "serialization/Serialization.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace dunedaq::trigger {
+
+template<class T>
+class Set {
+public:
+  // An incremental count of how many Sets have been produced by this source
+  uint32_t seqno;
+
+  // The detids that were inspected to form this Set
+  std::vector<uint16_t> from_detids;
+
+  // The earliest timestamp inspected to form this Set
+  dataformats::timestamp_t start_time;
+  // The latest timestamp inspected to form this Set
+  dataformats::timestamp_t end_time;
+
+  // The TPs/TAs themselves. Needs a better name!
+  std::vector<T> objects;
+};
+
+using TPSet = Set<triggeralgs::TriggerPrimitive>;
+using TASet = Set<triggeralgs::TriggerActivity>;
+
+}
+
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerPrimitive,
+                                 time_start,
+                                 time_peak,
+                                 time_over_threshold,
+                                 channel,
+                                 adc_integral,
+                                 adc_peak,
+                                 detid,
+                                 type,
+                                 algorithm,
+                                 version,
+                                 flag)
+
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerActivity,
+                                 time_start,
+                                 time_end,
+                                 time_peak,
+                                 time_activity,
+                                 channel_start,
+                                 channel_end,
+                                 channel_peak,
+                                 adc_integral,
+                                 adc_peak,
+                                 detid,
+                                 type,
+                                 algorithm,
+                                 version,
+                                 tp_list)
+
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerCandidate,
+                                 time_start,
+                                 time_end,
+                                 time_candidate,
+                                 detid,
+                                 type,
+                                 algorithm,
+                                 version,
+                                 ta_list)
+
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(dunedaq::trigger, TPSet, seqno, from_detids, start_time, end_time, objects)
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(dunedaq::trigger, TASet, seqno, from_detids, start_time, end_time, objects)
+
+#endif // TRIGGER_INCLUDE_TRIGGER_SET_HPP_

--- a/include/trigger/TASet.hpp
+++ b/include/trigger/TASet.hpp
@@ -1,0 +1,26 @@
+/**
+ * @file TASet.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGER_INCLUDE_TRIGGER_TASET_HPP_
+#define TRIGGER_INCLUDE_TRIGGER_TASET_HPP_
+
+#include "trigger/Set.hpp"
+#include "trigger/TriggerActivity_serialization.hpp"
+#include "triggeralgs/TriggerActivity.hpp"
+#include "serialization/Serialization.hpp"
+
+namespace dunedaq::trigger {
+
+using TASet = Set<triggeralgs::TriggerActivity>;
+
+} // namespace dunedaq::trigger
+
+MSGPACK_ADD_ENUM(dunedaq::trigger::TASet::Type)
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(dunedaq::trigger, TASet, seqno, type, from_detids, start_time, end_time, objects)
+
+#endif // TRIGGER_INCLUDE_TRIGGER_TASET_HPP_

--- a/include/trigger/TPSet.hpp
+++ b/include/trigger/TPSet.hpp
@@ -1,0 +1,26 @@
+/**
+ * @file TPSet.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGER_INCLUDE_TRIGGER_TPSET_HPP_
+#define TRIGGER_INCLUDE_TRIGGER_TPSET_HPP_
+
+#include "trigger/Set.hpp"
+#include "trigger/TriggerPrimitive_serialization.hpp"
+#include "triggeralgs/TriggerPrimitive.hpp"
+#include "serialization/Serialization.hpp"
+
+namespace dunedaq::trigger {
+
+using TPSet = Set<triggeralgs::TriggerPrimitive>;
+
+} // namespace dunedaq::trigger
+
+MSGPACK_ADD_ENUM(dunedaq::trigger::TPSet::Type)
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(dunedaq::trigger, TPSet, seqno, type, from_detids, start_time, end_time, objects)
+
+#endif // TRIGGER_INCLUDE_TRIGGER_TPSET_HPP_

--- a/include/trigger/TriggerActivity_serialization.hpp
+++ b/include/trigger/TriggerActivity_serialization.hpp
@@ -1,0 +1,32 @@
+/**
+ * @file TriggerActivity_serialization.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGER_INCLUDE_TRIGGER_TRIGGERACTIVITY_SERIALIZATION_HPP_
+#define TRIGGER_INCLUDE_TRIGGER_TRIGGERACTIVITY_SERIALIZATION_HPP_
+
+#include "triggeralgs/TriggerActivity.hpp"
+#include "serialization/Serialization.hpp"
+#include "trigger/TriggerPrimitive_serialization.hpp"
+
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerActivity,
+                                 time_start,
+                                 time_end,
+                                 time_peak,
+                                 time_activity,
+                                 channel_start,
+                                 channel_end,
+                                 channel_peak,
+                                 adc_integral,
+                                 adc_peak,
+                                 detid,
+                                 type,
+                                 algorithm,
+                                 version,
+                                 tp_list)
+
+#endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERACTIVITY_SERIALIZATION_HPP_

--- a/include/trigger/TriggerCandidate_serialization.hpp
+++ b/include/trigger/TriggerCandidate_serialization.hpp
@@ -1,0 +1,32 @@
+/**
+ * @file TriggerCandidate_serialization.hpp
+ *
+ * This file contains the macro calls needed to allow
+ * TriggerCandidates from triggeralgs to be serialized using the
+ * dunedaq serialization package
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGER_INCLUDE_TRIGGER_TRIGGERCANDIDATE_SERIALIZATION_HPP_
+#define TRIGGER_INCLUDE_TRIGGER_TRIGGERCANDIDATE_SERIALIZATION_HPP_
+
+#include "serialization/Serialization.hpp"
+#include "triggeralgs/TriggerCandidate.hpp"
+#include "trigger/TriggerActivity_serialization.hpp"
+
+MSGPACK_ADD_ENUM(triggeralgs::TriggerCandidate::Type)
+
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerCandidate,
+                                 time_start,
+                                 time_end,
+                                 time_candidate,
+                                 detid,
+                                 type,
+                                 algorithm,
+                                 version,
+                                 ta_list)
+
+#endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERCANDIDATE_SERIALIZATION_HPP_

--- a/include/trigger/TriggerPrimitive_serialization.hpp
+++ b/include/trigger/TriggerPrimitive_serialization.hpp
@@ -1,0 +1,28 @@
+/**
+ * @file TriggerPrimitive_serialization.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGER_INCLUDE_TRIGGER_TRIGGERPRIMITIVE_SERIALIZATION_HPP_
+#define TRIGGER_INCLUDE_TRIGGER_TRIGGERPRIMITIVE_SERIALIZATION_HPP_
+
+#include "triggeralgs/TriggerPrimitive.hpp"
+#include "serialization/Serialization.hpp"
+
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerPrimitive,
+                                 time_start,
+                                 time_peak,
+                                 time_over_threshold,
+                                 channel,
+                                 adc_integral,
+                                 adc_peak,
+                                 detid,
+                                 type,
+                                 algorithm,
+                                 version,
+                                 flag)
+
+#endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERPRIMITIVE_SERIALIZATION_HPP_

--- a/include/trigger/serialize.hpp
+++ b/include/trigger/serialize.hpp
@@ -1,0 +1,63 @@
+/**
+ * @file serialize.hpp
+ *
+ * This file contains the macro calls needed to allow the data
+ * selection objects from triggeralgs to be serialized using the
+ * dunedaq serialization package
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGER_INCLUDE_TRIGGER_SERIALIZE_HPP_
+#define TRIGGER_INCLUDE_TRIGGER_SERIALIZE_HPP_
+
+#include "serialization/Serialization.hpp"
+
+#include "triggeralgs/TriggerActivity.hpp"
+#include "triggeralgs/TriggerPrimitive.hpp"
+#include "triggeralgs/TriggerCandidate.hpp"
+
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerPrimitive,
+                                 time_start,
+                                 time_peak,
+                                 time_over_threshold,
+                                 channel,
+                                 adc_integral,
+                                 adc_peak,
+                                 detid,
+                                 type,
+                                 algorithm,
+                                 version,
+                                 flag)
+
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerActivity,
+                                 time_start,
+                                 time_end,
+                                 time_peak,
+                                 time_activity,
+                                 channel_start,
+                                 channel_end,
+                                 channel_peak,
+                                 adc_integral,
+                                 adc_peak,
+                                 detid,
+                                 type,
+                                 algorithm,
+                                 version,
+                                 tp_list)
+
+MSGPACK_ADD_ENUM(triggeralgs::TriggerCandidateType)
+
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs, TriggerCandidate,
+                                 time_start,
+                                 time_end,
+                                 time_candidate,
+                                 detid,
+                                 type,
+                                 algorithm,
+                                 version,
+                                 ta_list)
+
+#endif // TRIGGER_INCLUDE_TRIGGER_SERIALIZE_HPP_

--- a/test/apps/set_serialization_speed.cxx
+++ b/test/apps/set_serialization_speed.cxx
@@ -1,4 +1,5 @@
-#include "trigger/Set.hpp"
+#include "trigger/TPSet.hpp"
+#include "trigger/TASet.hpp"
 #include "serialization/Serialization.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
 #include "logging/Logging.hpp"
@@ -74,4 +75,9 @@ int main()
     std::cout << n << " TPs per set: " << std::flush;
     time_serialization(n);
   }
+
+  dunedaq::trigger::TASet taset;
+  std::vector<uint8_t> bytes = dunedaq::serialization::serialize(taset, dunedaq::serialization::kMsgPack); // NOLINT(build/unsigned)
+  dunedaq::trigger::TASet set_recv = dunedaq::serialization::deserialize<dunedaq::trigger::TASet>(bytes);
+  
 }

--- a/test/apps/set_serialization_speed.cxx
+++ b/test/apps/set_serialization_speed.cxx
@@ -1,0 +1,77 @@
+#include "trigger/Set.hpp"
+#include "serialization/Serialization.hpp"
+#include "triggeralgs/TriggerPrimitive.hpp"
+#include "logging/Logging.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <random>
+
+// Return the current steady clock in microseconds
+inline uint64_t // NOLINT(build/unsigned)
+now_us()
+{
+  using namespace std::chrono;
+  // std::chrono is the worst
+  return duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
+void
+time_serialization(int tps_per_set)
+{
+  const int N = 100000;
+  int total = 0;
+
+  std::default_random_engine generator;
+  std::uniform_int_distribution<int> uniform(0, 1000);
+
+  std::vector<dunedaq::trigger::TPSet> sets;
+  for(int i=0; i<N; ++i){
+    dunedaq::trigger::TPSet set;
+    set.seqno=i+1;
+    set.start_time = (i+1)*5000;
+    set.end_time = (i+2)*5000-1;
+    set.from_detids={1,2,3};
+    for(int j=0; j<tps_per_set; ++j){
+      triggeralgs::TriggerPrimitive tp;
+      tp.time_start = 1234963454;
+      tp.time_peak = tp.time_start+10000;
+      tp.time_over_threshold = uniform(generator);
+      tp.channel = uniform(generator);
+      tp.adc_integral = uniform(generator);
+      tp.adc_peak = uniform(generator);
+      tp.detid = 1;
+      tp.type = 1;
+      tp.algorithm = 1;
+      tp.version = 1;
+      tp.flag = 1;
+
+      set.objects.push_back(tp);
+    }
+    sets.push_back(set);
+  }
+
+  uint64_t start_time = now_us(); // NOLINT(build/unsigned)
+
+  for (int i = 0; i < N; ++i) {
+    std::vector<uint8_t> bytes = dunedaq::serialization::serialize(sets[i], dunedaq::serialization::kMsgPack); // NOLINT(build/unsigned)
+    dunedaq::trigger::TPSet set_recv = dunedaq::serialization::deserialize<dunedaq::trigger::TPSet>(bytes);
+    total += set_recv.seqno;
+  }
+  uint64_t end_time = now_us(); // NOLINT(build/unsigned)
+  
+  double time_taken_s = 1e-6 * (end_time - start_time);
+  double msg_kHz = 1e-3 * N / time_taken_s;
+  double tp_kHz = 1e-3 * tps_per_set * N / time_taken_s;
+  std::cout << "Sent " << N << " messages in " << time_taken_s << " (" << msg_kHz << " kHz of msgs, " << tp_kHz << " kHz of TPs) " << total << std::endl; // NOLINT
+
+}
+
+int main()
+{
+  std::vector<int> n_tps{0, 1, 10, 100, 1000};
+  for(auto n: n_tps){
+    std::cout << n << " TPs per set: " << std::flush;
+    time_serialization(n);
+  }
+}

--- a/test/apps/taset_serialization.cxx
+++ b/test/apps/taset_serialization.cxx
@@ -1,0 +1,13 @@
+#include "trigger/TASet.hpp"
+#include "serialization/Serialization.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <random>
+
+int main()
+{
+  dunedaq::trigger::TASet taset;
+  std::vector<uint8_t> bytes = dunedaq::serialization::serialize(taset, dunedaq::serialization::kMsgPack); // NOLINT(build/unsigned)
+  dunedaq::trigger::TASet set_recv = dunedaq::serialization::deserialize<dunedaq::trigger::TASet>(bytes);
+}


### PR DESCRIPTION
This PR adds the `trigger::Set<T>` class (with aliases `TPSet = Set<TP>` and `TASet = Set<TA>` as a base for creating the data transport functionality for DS