### PR TITLE
Make GeoID configurable

### DIFF
--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -87,9 +87,8 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
 
   m_links.clear();
   for (auto const& link : params.links) {
-    // For the future: Set APA properly
     m_links.push_back(
-      dfmessages::GeoID{ dataformats::GeoID::SystemType::kTPC, 0, static_cast<uint32_t>(link) }); // NOLINT
+        dfmessages::GeoID{ dataformats::GeoID::string_to_system_type(link.system), link.region, link.element });
   }
 
   m_configured_flag.store(true);

--- a/schema/trigger/moduleleveltrigger.jsonnet
+++ b/schema/trigger/moduleleveltrigger.jsonnet
@@ -3,8 +3,16 @@ local ns = "dunedaq.trigger.moduleleveltrigger";
 local s = moo.oschema.schema(ns);
 
 local types = {
-  linkid: s.number("link_id", dtype="i4"),
-  linkvec : s.sequence("link_vec", self.linkid),
+  region_id : s.number("region_id", "u2"),
+  element_id : s.number("element_id", "u4"),
+  system_type : s.string("system_type"),
+
+  geoid : s.record("GeoID", [s.field("region", self.region_id, doc="" ),
+      s.field("element", self.element_id, doc="" ),
+      s.field("system", self.system_type, doc="" )],
+      doc="GeoID"),
+
+  linkvec : s.sequence("link_vec", self.geoid),
   token_count: s.number("token_count", dtype="i4"),
   
   conf : s.record("ConfParams", [


### PR DESCRIPTION
Make the GeoID configurable. This is needed to set the system type and exercise the whole PDS chain.