### PR TITLE
add trigger candidate maker to daq-codegen call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ daq_add_library(TokenManager.cpp LINK_LIBRARIES appfwk::appfwk logging::logging 
 ##############################################################################
 # Codegen
 
-daq_codegen( fakedataflow.jsonnet faketimestampeddatagenerator.jsonnet intervaltccreator.jsonnet intervaltriggercreator.jsonnet moduleleveltrigger.jsonnet randomtriggercandidatemaker.jsonnet timingtriggercandidatemaker.jsonnet triggeractivitymaker.jsonnet triggercandidatemaker.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+daq_codegen( fakedataflow.jsonnet faketimestampeddatagenerator.jsonnet intervaltccreator.jsonnet intervaltriggercreator.jsonnet moduleleveltrigger.jsonnet randomtriggercandidatemaker.jsonnet timingtriggercandidatemaker.jsonnet triggeractivitymaker.jsonnet triggercandidatemaker.jsonnet triggerdecisionmaker.jsonnet  TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 daq_codegen( *info.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp.j2 opmonlib/InfoNljs.hpp.j2 )
 ##############################################################################
 # Plugins

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ daq_add_library(TokenManager.cpp LINK_LIBRARIES appfwk::appfwk logging::logging 
 ##############################################################################
 # Codegen
 
-daq_codegen( fakedataflow.jsonnet faketimestampeddatagenerator.jsonnet intervaltccreator.jsonnet intervaltriggercreator.jsonnet moduleleveltrigger.jsonnet randomtriggercandidatemaker.jsonnet timingtriggercandidatemaker.jsonnet triggeractivitymaker.jsonnet  TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+daq_codegen( fakedataflow.jsonnet faketimestampeddatagenerator.jsonnet intervaltccreator.jsonnet intervaltriggercreator.jsonnet moduleleveltrigger.jsonnet randomtriggercandidatemaker.jsonnet timingtriggercandidatemaker.jsonnet triggeractivitymaker.jsonnet triggercandidatemaker.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 daq_codegen( *info.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp.j2 opmonlib/InfoNljs.hpp.j2 )
 ##############################################################################
 # Plugins


### PR DESCRIPTION
To fix the following error:

CI build on Develop HEAD failed with:
```/__w/trigger/trigger/dev/sourcecode/trigger/plugins/TriggerCandidateMaker.cpp:4:10: fatal error: trigger/triggercandidatemaker/Nljs.hpp: No such file or directory```

https://github.com/DUNE-DAQ/trigger/runs/2687161822?check_suite_focus=true#step:7:140
