### PR TITLE
 Retool TriggerGenericMaker to behave differently for Set<T> input/output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ daq_add_library(TokenManager.cpp LINK_LIBRARIES appfwk::appfwk logging::logging 
 ##############################################################################
 # Codegen
 
-daq_codegen( fakedataflow.jsonnet faketimestampeddatagenerator.jsonnet intervaltccreator.jsonnet intervaltriggercreator.jsonnet moduleleveltrigger.jsonnet randomtriggercandidatemaker.jsonnet timingtriggercandidatemaker.jsonnet triggeractivitymaker.jsonnet  TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+daq_codegen( fakedataflow.jsonnet faketimestampeddatagenerator.jsonnet intervaltccreator.jsonnet intervaltriggercreator.jsonnet moduleleveltrigger.jsonnet randomtriggercandidatemaker.jsonnet timingtriggercandidatemaker.jsonnet trigger*maker.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 daq_codegen( *info.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp.j2 opmonlib/InfoNljs.hpp.j2 )
 ##############################################################################
 # Plugins

--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -63,7 +63,14 @@ ERS_DECLARE_ISSUE_BASE(trigger,
 ERS_DECLARE_ISSUE_BASE(trigger,
                        UnknownSetError,
                        appfwk::GeneralDAQModuleIssue,
-                       "The " << algorithm << " encountered an unknown Set.",
+                       "The " << algorithm << " encountered an unknown Set type.",
+                       ((std::string)name),
+                       ((std::string)algorithm))
+                       
+ERS_DECLARE_ISSUE_BASE(trigger,
+                       InconsistentSetTimeError,
+                       appfwk::GeneralDAQModuleIssue,
+                       "The " << algorithm << " maker encountered Sets with inconsistent start/end times.",
                        ((std::string)name),
                        ((std::string)algorithm))
 

--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -52,6 +52,21 @@ ERS_DECLARE_ISSUE_BASE(trigger,
                        "The " << queueType << " queue was not successfully created.",
                        ((std::string)name),
                        ((std::string)queueType))
+                       
+ERS_DECLARE_ISSUE_BASE(trigger,
+                       AlgorithmFatalError,
+                       appfwk::GeneralDAQModuleIssue,
+                       "The " << algorithm << " failed to run.",
+                       ((std::string)name),
+                       ((std::string)algorithm))
+                       
+ERS_DECLARE_ISSUE_BASE(trigger,
+                       UnknownSetError,
+                       appfwk::GeneralDAQModuleIssue,
+                       "The " << algorithm << " encountered an unknown Set.",
+                       ((std::string)name),
+                       ((std::string)algorithm))
+
 
 } // namespace dunedaq
 

--- a/plugins/TriggerActivityMaker.cpp
+++ b/plugins/TriggerActivityMaker.cpp
@@ -19,6 +19,7 @@ namespace dunedaq::trigger {
   TriggerActivityMaker::make_maker(const nlohmann::json& obj)
   {
     auto params = obj.get<triggeractivitymaker::Conf>();
+    set_algorithm_name(params.activity_maker);
     return make_ta_maker(params.activity_maker);
   }
 

--- a/plugins/TriggerActivityMaker.cpp
+++ b/plugins/TriggerActivityMaker.cpp
@@ -1,7 +1,17 @@
+/**
+ * @file TriggerActivityMaker.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+ 
 #include "TriggerActivityMaker.hpp"
 
 #include "trigger/AlgorithmPlugins.hpp"
 #include "trigger/triggeractivitymaker/Nljs.hpp"
+
+#include <memory>
 
 namespace dunedaq::trigger {
 

--- a/plugins/TriggerActivityMaker.hpp
+++ b/plugins/TriggerActivityMaker.hpp
@@ -6,8 +6,8 @@
  * received with this code.
  */
  
-#ifndef TRIGGER_INCLUDE_TRIGGER_TRIGGERACTIVITYMAKER_HPP_
-#define TRIGGER_INCLUDE_TRIGGER_TRIGGERACTIVITYMAKER_HPP_
+#ifndef TRIGGER_PLUGINS_TRIGGERACTIVITYMAKER_HPP_
+#define TRIGGER_PLUGINS_TRIGGERACTIVITYMAKER_HPP_
 
 #include "trigger/TriggerGenericMaker.hpp"
 
@@ -16,6 +16,7 @@
 #include "triggeralgs/TriggerPrimitive.hpp"
 
 #include <string>
+#include <memory>
 
 namespace dunedaq::trigger {
 
@@ -41,4 +42,4 @@ private:
 
 } // namespace dunedaq::trigger
 
-#endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERACTIVITYMAKER_HPP_
+#endif // TRIGGER_PLUGINS_TRIGGERACTIVITYMAKER_HPP_

--- a/plugins/TriggerActivityMaker.hpp
+++ b/plugins/TriggerActivityMaker.hpp
@@ -1,3 +1,14 @@
+/**
+ * @file TriggerActivityMaker.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+ 
+#ifndef TRIGGER_INCLUDE_TRIGGER_TRIGGERACTIVITYMAKER_HPP_
+#define TRIGGER_INCLUDE_TRIGGER_TRIGGERACTIVITYMAKER_HPP_
+
 #include "trigger/TriggerGenericMaker.hpp"
 
 #include "triggeralgs/TriggerActivity.hpp"
@@ -10,8 +21,8 @@ namespace dunedaq::trigger {
 
 class TriggerActivityMaker 
   : public TriggerGenericMaker < 
-    triggeralgs::TriggerPrimitive, 
-    triggeralgs::TriggerActivity, 
+    Set<triggeralgs::TriggerPrimitive>, 
+    Set<triggeralgs::TriggerActivity>, 
     triggeralgs::TriggerActivityMaker 
   >
 {
@@ -29,3 +40,5 @@ private:
 };
 
 } // namespace dunedaq::trigger
+
+#endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERACTIVITYMAKER_HPP_

--- a/plugins/TriggerActivityMakerSupernovaPlugin.cpp
+++ b/plugins/TriggerActivityMakerSupernovaPlugin.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file TriggerActivityMakerSupernova.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+ 
 #include "trigger/AlgorithmPlugins.hpp"
 #include "triggeralgs/Supernova/TriggerActivityMakerSupernova.hpp"
 

--- a/plugins/TriggerCandidateMaker.cpp
+++ b/plugins/TriggerCandidateMaker.cpp
@@ -1,7 +1,17 @@
+/**
+ * @file TriggerCandidateMaker.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+ 
 #include "TriggerCandidateMaker.hpp"
 
 #include "trigger/AlgorithmPlugins.hpp"
 #include "trigger/triggercandidatemaker/Nljs.hpp"
+
+#include <memory>
 
 namespace dunedaq::trigger {
 

--- a/plugins/TriggerCandidateMaker.cpp
+++ b/plugins/TriggerCandidateMaker.cpp
@@ -19,6 +19,7 @@ namespace dunedaq::trigger {
   TriggerCandidateMaker::make_maker(const nlohmann::json& obj)
   {
     auto params = obj.get<triggercandidatemaker::Conf>();
+    set_algorithm_name(params.candidate_maker);
     return make_tc_maker(params.candidate_maker);
   }
 

--- a/plugins/TriggerCandidateMaker.hpp
+++ b/plugins/TriggerCandidateMaker.hpp
@@ -6,8 +6,8 @@
  * received with this code.
  */
  
-#ifndef TRIGGER_INCLUDE_TRIGGER_TRIGGERCANDIDATEMAKER_HPP_
-#define TRIGGER_INCLUDE_TRIGGER_TRIGGERCANDIDATEMAKER_HPP_
+#ifndef TRIGGER_PLUGINS_TRIGGERCANDIDATEMAKER_HPP_
+#define TRIGGER_PLUGINS_TRIGGERCANDIDATEMAKER_HPP_
 
 #include "trigger/TriggerGenericMaker.hpp"
 
@@ -16,6 +16,7 @@
 #include "triggeralgs/TriggerActivity.hpp"
 
 #include <string>
+#include <memory>
 
 namespace dunedaq::trigger {
 
@@ -41,4 +42,4 @@ private:
 
 } // namespace dunedaq::trigger
 
-#endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERCANDIDATEMAKER_HPP_
+#endif // TRIGGER_PLUGINS_TRIGGERCANDIDATEMAKER_HPP_

--- a/plugins/TriggerCandidateMaker.hpp
+++ b/plugins/TriggerCandidateMaker.hpp
@@ -1,3 +1,14 @@
+/**
+ * @file TriggerCandidateMaker.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+ 
+#ifndef TRIGGER_INCLUDE_TRIGGER_TRIGGERCANDIDATEMAKER_HPP_
+#define TRIGGER_INCLUDE_TRIGGER_TRIGGERCANDIDATEMAKER_HPP_
+
 #include "trigger/TriggerGenericMaker.hpp"
 
 #include "triggeralgs/TriggerCandidate.hpp"
@@ -10,7 +21,7 @@ namespace dunedaq::trigger {
 
 class TriggerCandidateMaker 
   : public TriggerGenericMaker < 
-    triggeralgs::TriggerActivity, 
+    Set<triggeralgs::TriggerActivity>, 
     triggeralgs::TriggerCandidate, 
     triggeralgs::TriggerCandidateMaker 
   >
@@ -29,3 +40,5 @@ private:
 };
 
 } // namespace dunedaq::trigger
+
+#endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERCANDIDATEMAKER_HPP_

--- a/plugins/TriggerCandidateMakerSupernovaPlugin.cpp
+++ b/plugins/TriggerCandidateMakerSupernovaPlugin.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file TriggerCandidateMakerSupernova.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
 #include "trigger/AlgorithmPlugins.hpp"
 #include "triggeralgs/Supernova/TriggerCandidateMakerSupernova.hpp"
 

--- a/plugins/TriggerDecisionMaker.cpp
+++ b/plugins/TriggerDecisionMaker.cpp
@@ -1,7 +1,17 @@
+/**
+ * @file TriggerDecisionMaker.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+ 
 #include "TriggerDecisionMaker.hpp"
 
 #include "trigger/AlgorithmPlugins.hpp"
 #include "trigger/triggerdecisionmaker/Nljs.hpp"
+
+#include <memory>
 
 namespace dunedaq::trigger {
 

--- a/plugins/TriggerDecisionMaker.cpp
+++ b/plugins/TriggerDecisionMaker.cpp
@@ -19,6 +19,7 @@ namespace dunedaq::trigger {
   TriggerDecisionMaker::make_maker(const nlohmann::json& obj)
   {
     auto params = obj.get<triggerdecisionmaker::Conf>();
+    set_algorithm_name(params.decision_maker);
     return make_td_maker(params.decision_maker);
   }
 

--- a/plugins/TriggerDecisionMaker.hpp
+++ b/plugins/TriggerDecisionMaker.hpp
@@ -6,8 +6,8 @@
  * received with this code.
  */
  
-#ifndef TRIGGER_INCLUDE_TRIGGER_TRIGGERDECISIONMAKER_HPP_
-#define TRIGGER_INCLUDE_TRIGGER_TRIGGERDECISIONMAKER_HPP_
+#ifndef TRIGGER_PLUGINS_TRIGGERDECISIONMAKER_HPP_
+#define TRIGGER_PLUGINS_TRIGGERDECISIONMAKER_HPP_
 
 #include "trigger/TriggerGenericMaker.hpp"
 
@@ -16,6 +16,7 @@
 #include "triggeralgs/TriggerCandidate.hpp"
 
 #include <string>
+#include <memory>
 
 namespace dunedaq::trigger {
 
@@ -41,4 +42,4 @@ private:
 
 } // namespace dunedaq::trigger
 
-#endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERDECISIONMAKER_HPP_
+#endif // TRIGGER_PLUGINS_TRIGGERDECISIONMAKER_HPP_

--- a/plugins/TriggerDecisionMaker.hpp
+++ b/plugins/TriggerDecisionMaker.hpp
@@ -1,3 +1,14 @@
+/**
+ * @file TriggerDecisionMaker.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+ 
+#ifndef TRIGGER_INCLUDE_TRIGGER_TRIGGERDECISIONMAKER_HPP_
+#define TRIGGER_INCLUDE_TRIGGER_TRIGGERDECISIONMAKER_HPP_
+
 #include "trigger/TriggerGenericMaker.hpp"
 
 #include "triggeralgs/TriggerDecision.hpp"
@@ -29,3 +40,5 @@ private:
 };
 
 } // namespace dunedaq::trigger
+
+#endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERDECISIONMAKER_HPP_

--- a/plugins/TriggerDecisionMakerSupernovaPlugin.cpp
+++ b/plugins/TriggerDecisionMakerSupernovaPlugin.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file TriggerDecisionMakerSupernova.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+ 
 #include "trigger/AlgorithmPlugins.hpp"
 #include "triggeralgs/Supernova/TriggerDecisionMakerSupernova.hpp"
 

--- a/src/trigger/TriggerGenericMaker.hpp
+++ b/src/trigger/TriggerGenericMaker.hpp
@@ -28,12 +28,12 @@ namespace dunedaq::trigger {
 
 // Forward declare the class encapsulating partial specifications of do_work
 template<class IN, class OUT, class MAKER>
-class Worker;
+class TriggerGenericWorker;
 
 template<class IN, class OUT, class MAKER>
 class TriggerGenericMaker : public dunedaq::appfwk::DAQModule
 {
-friend class Worker<IN,OUT,MAKER>;
+friend class TriggerGenericWorker<IN,OUT,MAKER>;
   
 public:
 
@@ -44,6 +44,7 @@ public:
     , m_input_queue(nullptr)
     , m_output_queue(nullptr)
     , m_queue_timeout(100)
+    , m_algorithm_name("[uninitialized]")
   {
     register_command("start", &TriggerGenericMaker::do_start);
     register_command("stop", &TriggerGenericMaker::do_stop);
@@ -63,11 +64,21 @@ public:
     m_output_queue.reset(new sink_t(appfwk::queue_inst(obj, "output")));
   }
 
+protected:
+
+  void set_algorithm_name(const std::string &name) 
+  { 
+    m_algorithm_name = name;
+  }
+
 private:
 
-  Worker<IN,OUT,MAKER> worker;
+  TriggerGenericWorker<IN,OUT,MAKER> worker;
 
   dunedaq::appfwk::ThreadHelper m_thread;
+  
+  size_t m_received_count;
+  size_t m_sent_count;
   
   using source_t = dunedaq::appfwk::DAQSource<IN>;
   std::unique_ptr<source_t> m_input_queue;
@@ -76,13 +87,19 @@ private:
   std::unique_ptr<sink_t> m_output_queue;
 
   std::chrono::milliseconds m_queue_timeout;
+  
+  std::string m_algorithm_name;
 
   std::shared_ptr<MAKER> m_maker;
   
+  // This should return a shared_ptr to the MAKER created from conf command
+  // arguments, and also call set_algorithm_name.
   virtual std::shared_ptr<MAKER> make_maker(const nlohmann::json& obj) = 0;
   
   void do_start(const nlohmann::json& /*obj*/)
   {
+    m_received_count = 0;
+    m_sent_count = 0;
     m_thread.start_working_thread();
   }
   
@@ -100,7 +117,30 @@ private:
   {
     worker.do_work(running_flag);
   }
-
+  
+  bool receive(IN &in) {
+    try {
+      m_input_queue->pop(in, m_queue_timeout);
+    } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
+      // it is perfectly reasonable that there might be no data in the queue
+      // some fraction of the times that we check, so we just continue on and try again
+      return false;
+    }
+    ++m_received_count;
+    return true;
+  }
+  
+  bool send(const OUT &out) {
+    try {
+      m_output_queue->push(out, m_queue_timeout);
+    } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
+      ers::warning(excpt);
+      return false;
+    }
+    ++m_sent_count;
+    return true;
+  }
+  
 };
 
 // To handle the different unpacking schemes implied by different templates,
@@ -108,89 +148,73 @@ private:
 // TriggerGenericMaker. C++ still does not support partial specification of a 
 // single method in a template class, so this approach is the least redundant
 // way to achieve that functionality
+
+// The base template assumes the MAKER has an operator() with the signature
+// operator()(IN, std::vector<OUT>)
 template<class IN, class OUT, class MAKER>
-class Worker
+class TriggerGenericWorker
 {
 public:
-  explicit Worker(TriggerGenericMaker<IN, OUT, MAKER> &_parent) : parent(_parent) { }
+  explicit TriggerGenericWorker(TriggerGenericMaker<IN, OUT, MAKER> &parent) : m_parent(parent) { }
   
-  TriggerGenericMaker<IN, OUT, MAKER> &parent;
+  TriggerGenericMaker<IN, OUT, MAKER> &m_parent;
   
   void do_work(std::atomic<bool> &running_flag)
   {
-    int received_count = 0;
-    int sent_count = 0;
-
     while (running_flag.load()) {
       IN in;
-      try {
-        parent.m_input_queue->pop(in, parent.m_queue_timeout);
-      } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
-        // it is perfectly reasonable that there might be no data in the queue
-        // some fraction of the times that we check, so we just continue on and try again
-        continue;
+      if (!m_parent.receive(in)) {
+        continue; //nothing to do
       }
-      ++received_count;
   
-      std::vector<OUT> outs;
+      std::vector<OUT> out_vec; // 1 input -> many outputs
       try {
-        parent.m_maker->operator()(in, outs);
-      } catch (...) {
-        ers::error(AlgorithmFatalError(ERS_HERE, parent.get_name(), "algorithm_name_placeholder"));
+        m_parent.m_maker->operator()(in, out_vec);
+      } catch (...) { // TODO BJL May 28-2021 can we restrict the possible exceptions triggeralgs might raise?
+        ers::error(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
         continue;
       }
 
-      while (outs.size() && running_flag.load()) {
-        try {
-          parent.m_output_queue->push(outs.back(), parent.m_queue_timeout);
-          outs.pop_back();
-          ++sent_count;
-        } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
-          ers::warning(excpt);
+      while (out_vec.size() && running_flag.load()) {
+        if (m_parent.send(out_vec.back())) {
+          out_vec.pop_back();
         }
       }
     } // end while (running_flag.load())
 
-    TLOG() << ": Exiting do_work() method, received " << received_count 
-           << " inputs and successfully sent " << sent_count << " outputs. ";
+    TLOG() << ": Exiting do_work() method, received " << m_parent.m_received_count 
+           << " inputs and successfully sent " << m_parent.m_sent_count << " outputs. ";
   }
-  
 };
 
-// Partial specilization for Set<A> -> Set<B>
+// Partial specilization for IN = Set<A>, OUT = Set<B> and assumes the MAKER has:
+// operator()(A, std::vector<B>)
 template<class A, class B, class MAKER> 
-class Worker<Set<A>, Set<B>, MAKER> 
+class TriggerGenericWorker<Set<A>, Set<B>, MAKER> 
 {
 public:
-  explicit Worker(TriggerGenericMaker<Set<A>, Set<B>, MAKER> &_parent) : parent(_parent) { }
+  explicit TriggerGenericWorker(TriggerGenericMaker<Set<A>, Set<B>, MAKER> &parent) : m_parent(parent) { }
   
-  TriggerGenericMaker<Set<A>, Set<B>, MAKER> &parent;
+  TriggerGenericMaker<Set<A>, Set<B>, MAKER> &m_parent;
   
   void do_work(std::atomic<bool> &running_flag)
   {
-    int received_count = 0;
-    int sent_count = 0;
-
     while (running_flag.load()) {
       Set<A> in;
-      try {
-        parent.m_input_queue->pop(in, parent.m_queue_timeout);
-      } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
-        // it is perfectly reasonable that there might be no data in the queue
-        // some fraction of the times that we check, so we just continue on and try again
-        continue;
+      if (!m_parent.receive(in)) {
+        continue; //nothing to do
       }
-      ++received_count;
 
-      Set<B> out;
+      Set<B> out; // 1 input set -> 1 output set
       switch (in.type) {
         case Set<A>::Type::kPayload:
+          // call operator for each of the objects in the set
           for (size_t i = 0; i < in.objects.size(); i++) {
             std::vector<B> out_vec;
             try {
-              parent.m_maker->operator()(in.objects[i], out_vec);
-            } catch (...) {
-              ers::error(AlgorithmFatalError(ERS_HERE, parent.get_name(), "algorithm_name_placeholder"));
+              m_parent.m_maker->operator()(in.objects[i], out_vec);
+            } catch (...) { // TODO BJL May 28-2021 can we restrict the possible exceptions triggeralgs might raise?
+              ers::error(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
               continue;
             }
             out.objects.insert(out.objects.end(), out_vec.begin(), out_vec.end());
@@ -198,18 +222,38 @@ public:
           out.type = Set<B>::Type::kPayload;
           break;
         case Set<A>::Type::kHeartbeat:
-          // TODO BJL May-27-2021 do we flush the m_maker here?
-          out.type = Set<B>::Type::kHeartbeat;
+          // forward the heartbeat
+          { 
+            Set<B> heartbeat;
+            heartbeat.seqno = m_parent.m_sent_count;
+            heartbeat.type = Set<B>::Type::kHeartbeat;
+            heartbeat.start_time = in.start_time;
+            heartbeat.end_time = in.end_time;
+            while (running_flag.load()) {
+              if (m_parent.send(heartbeat)) {
+                break;
+              }
+            }
+          }
+          // flush the maker
+          try {
+            m_parent.m_maker->flush(in.end_time, out.objects);
+          } catch (...) { // TODO BJL May 28-2021 can we restrict the possible exceptions triggeralgs might raise?
+            ers::error(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
+            continue;
+          }
+          out.type = Set<B>::Type::kPayload;
           break;
         case Set<A>::Type::kUnknown:
-          ers::error(UnknownSetError(ERS_HERE, parent.get_name(), "algorithm_name_placeholder"));
+          ers::error(UnknownSetError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
           break;
       }
           
-      out.seqno = sent_count;
       if (out.objects.size() > 0) {
+        out.seqno = m_parent.m_sent_count;
+        
         // TODO BJL May-27-2021 Set<T> should implement some helper methods to 
-        // populate these fields in lieu of that, this is an approximation
+        // populate these fields. in lieu of that, this is an approximation
         out.from_detids.resize(out.objects.size());
         for (size_t i = 0; i < out.objects.size(); i++) {
           out.from_detids[i] = out.objects[i].detid;
@@ -217,83 +261,76 @@ public:
         out.start_time = out.objects[0].time_start;
         // TODO BJL May-27-2021 TP and TA both have time_start, but only TA has time_end
         // really, Set<T> should decide what is desired here, not the maker
+        // for now, let end_time be the largest time_start (start_time the smallest)
         out.end_time = out.objects[out.objects.size()-1].time_start;
-      }
         
-      try {
-        parent.m_output_queue->push(out, parent.m_queue_timeout);
-        ++sent_count;
-      } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
-        ers::warning(excpt);
+        while (running_flag.load()) {
+          if (m_parent.send(out)) {
+            break;
+          }
+        }
       }
+      
     } // end while (running_flag.load())
 
-    TLOG() << ": Exiting do_work() method, received " << received_count 
-           << " inputs and successfully sent " << sent_count << " outputs. ";
+    TLOG() << ": Exiting do_work() method, received " << m_parent.m_received_count 
+           << " inputs and successfully sent " << m_parent.m_sent_count << " outputs. ";
   }
-  
 };
 
-// Partial specilization for Set<A> -> OUT
+// Partial specilization for IN = Set<A> and assumes the the MAKER has:
+// operator()(A, std::vector<OUT>)
 template<class A, class OUT, class MAKER> 
-class Worker<Set<A>, OUT, MAKER> 
+class TriggerGenericWorker<Set<A>, OUT, MAKER> 
 {
 public:
-  explicit Worker(TriggerGenericMaker<Set<A>, OUT, MAKER> &_parent) : parent(_parent) { }
+  explicit TriggerGenericWorker(TriggerGenericMaker<Set<A>, OUT, MAKER> &parent) : m_parent(parent) { }
   
-  TriggerGenericMaker<Set<A>, OUT, MAKER> &parent;
+  TriggerGenericMaker<Set<A>, OUT, MAKER> &m_parent;
   
   void do_work(std::atomic<bool> &running_flag)
   {
-    int received_count = 0;
-    int sent_count = 0;
-
     while (running_flag.load()) {
       Set<A> in;
-      try {
-        parent.m_input_queue->pop(in, parent.m_queue_timeout);
-      } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
-        // it is perfectly reasonable that there might be no data in the queue
-        // some fraction of the times that we check, so we just continue on and try again
-        continue;
+      if (!m_parent.receive(in)) {
+        continue; //nothing to do
       }
-      ++received_count;
 
-      Set<OUT> out;
+      std::vector<OUT> out_vec; // 1 input set -> many outputs
       switch (in.type) {
         case Set<A>::Type::kPayload:
           for (size_t i = 0; i < in.objects.size(); i++) {
-            std::vector<OUT> out_vec;
             try {
-              parent.m_maker->operator()(in.objects[i], out_vec);
-            } catch (...) {
-              ers::error(AlgorithmFatalError(ERS_HERE, parent.get_name(), "algorithm_name_placeholder"));
-            }
-            while (out_vec.size() && running_flag.load()) {
-              try {
-                parent.m_output_queue->push(out_vec.back(), parent.m_queue_timeout);
-                out_vec.pop_back();
-                ++sent_count;
-              } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
-                ers::warning(excpt);
-              }
+              m_parent.m_maker->operator()(in.objects[i], out_vec);
+            } catch (...) { // TODO BJL May 28-2021 can we restrict the possible exceptions triggeralgs might raise?
+              ers::error(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
             }
           }
           break;
         case Set<A>::Type::kHeartbeat:
-          // TODO BJL May-27-2021 do we flush the m_maker here? Forward payload?
+          // TODO BJL May-28-2021 should anything happen with the heartbeat when OUT is not a Set<T>?
+          try {
+            m_parent.m_maker->flush(in.end_time, out_vec);
+          } catch (...) { // TODO BJL May 28-2021 can we restrict the possible exceptions triggeralgs might raise?
+            ers::error(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
+            continue;
+          }
           break;
         case Set<A>::Type::kUnknown:
-          ers::error(UnknownSetError(ERS_HERE, parent.get_name(), "algorithm_name_placeholder"));
+          ers::error(UnknownSetError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
           break;
       }
-          
+      
+      while (out_vec.size() && running_flag.load()) {
+        if (m_parent.send(out_vec.back())) {
+          out_vec.pop_back();
+        }
+      }
     } // end while (running_flag.load())
 
-    TLOG() << ": Exiting do_work() method, received " << received_count 
-           << " inputs and successfully sent " << sent_count << " outputs. ";
+    TLOG() << ": Exiting do_work() method, received " << m_parent.m_received_count 
+           << " inputs and successfully sent " << m_parent.m_sent_count << " outputs. ";
   }
-  
 };
 
 } // namespace dunedaq::trigger

--- a/src/trigger/TriggerGenericMaker.hpp
+++ b/src/trigger/TriggerGenericMaker.hpp
@@ -171,8 +171,8 @@ public:
       try {
         m_parent.m_maker->operator()(in, out_vec);
       } catch (...) { // TODO BJL May 28-2021 can we restrict the possible exceptions triggeralgs might raise?
-        ers::error(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
-        continue;
+        ers::fatal(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
+        return;
       }
 
       while (out_vec.size() && running_flag.load()) {
@@ -214,8 +214,8 @@ public:
             try {
               m_parent.m_maker->operator()(in.objects[i], out_vec);
             } catch (...) { // TODO BJL May 28-2021 can we restrict the possible exceptions triggeralgs might raise?
-              ers::error(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
-              continue;
+              ers::fatal(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
+              return;
             }
             out.objects.insert(out.objects.end(), out_vec.begin(), out_vec.end());
           }
@@ -239,8 +239,8 @@ public:
           try {
             m_parent.m_maker->flush(in.end_time, out.objects);
           } catch (...) { // TODO BJL May 28-2021 can we restrict the possible exceptions triggeralgs might raise?
-            ers::error(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
-            continue;
+            ers::fatal(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
+            return;
           }
           out.type = Set<B>::Type::kPayload;
           break;
@@ -303,7 +303,8 @@ public:
             try {
               m_parent.m_maker->operator()(in.objects[i], out_vec);
             } catch (...) { // TODO BJL May 28-2021 can we restrict the possible exceptions triggeralgs might raise?
-              ers::error(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
+              ers::fatal(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
+              return;
             }
           }
           break;
@@ -312,8 +313,8 @@ public:
           try {
             m_parent.m_maker->flush(in.end_time, out_vec);
           } catch (...) { // TODO BJL May 28-2021 can we restrict the possible exceptions triggeralgs might raise?
-            ers::error(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
-            continue;
+            ers::fatal(AlgorithmFatalError(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
+            return;
           }
           break;
         case Set<A>::Type::kUnknown:

--- a/src/trigger/TriggerGenericMaker.hpp
+++ b/src/trigger/TriggerGenericMaker.hpp
@@ -6,8 +6,8 @@
  * received with this code.
  */
  
-#ifndef TRIGGER_INCLUDE_TRIGGER_TRIGGERGENERICMAKER_HPP_
-#define TRIGGER_INCLUDE_TRIGGER_TRIGGERGENERICMAKER_HPP_
+#ifndef TRIGGER_SRC_TRIGGER_TRIGGERGENERICMAKER_HPP_
+#define TRIGGER_SRC_TRIGGER_TRIGGERGENERICMAKER_HPP_
 
 #include "trigger/Set.hpp"
 #include "trigger/Issues.hpp"
@@ -22,6 +22,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace dunedaq::trigger {
 
@@ -111,7 +112,7 @@ template<class IN, class OUT, class MAKER>
 class Worker
 {
 public:
-  Worker(TriggerGenericMaker<IN, OUT, MAKER> &_parent) : parent(_parent) { }
+  explicit Worker(TriggerGenericMaker<IN, OUT, MAKER> &_parent) : parent(_parent) { }
   
   TriggerGenericMaker<IN, OUT, MAKER> &parent;
   
@@ -161,7 +162,7 @@ template<class A, class B, class MAKER>
 class Worker<Set<A>, Set<B>, MAKER> 
 {
 public:
-  Worker(TriggerGenericMaker<Set<A>, Set<B>, MAKER> &_parent) : parent(_parent) { }
+  explicit Worker(TriggerGenericMaker<Set<A>, Set<B>, MAKER> &_parent) : parent(_parent) { }
   
   TriggerGenericMaker<Set<A>, Set<B>, MAKER> &parent;
   
@@ -197,7 +198,7 @@ public:
           out.type = Set<B>::Type::kPayload;
           break;
         case Set<A>::Type::kHeartbeat:
-          // FIXME BJL 5-27-21 do we flush the m_maker here?
+          // TODO BJL May-27-2021 do we flush the m_maker here?
           out.type = Set<B>::Type::kHeartbeat;
           break;
         case Set<A>::Type::kUnknown:
@@ -207,14 +208,14 @@ public:
           
       out.seqno = sent_count;
       if (out.objects.size() > 0) {
-        // FIXME BJL 5-27-21 Set<T> should implement some helper methods to 
+        // TODO BJL May-27-2021 Set<T> should implement some helper methods to 
         // populate these fields in lieu of that, this is an approximation
         out.from_detids.resize(out.objects.size());
         for (size_t i = 0; i < out.objects.size(); i++) {
           out.from_detids[i] = out.objects[i].detid;
         }
         out.start_time = out.objects[0].time_start;
-        // TODO BJL 5-27-21 TP and TA both have time_start, but only TA has time_end
+        // TODO BJL May-27-2021 TP and TA both have time_start, but only TA has time_end
         // really, Set<T> should decide what is desired here, not the maker
         out.end_time = out.objects[out.objects.size()-1].time_start;
       }
@@ -238,7 +239,7 @@ template<class A, class OUT, class MAKER>
 class Worker<Set<A>, OUT, MAKER> 
 {
 public:
-  Worker(TriggerGenericMaker<Set<A>, OUT, MAKER> &_parent) : parent(_parent) { }
+  explicit Worker(TriggerGenericMaker<Set<A>, OUT, MAKER> &_parent) : parent(_parent) { }
   
   TriggerGenericMaker<Set<A>, OUT, MAKER> &parent;
   
@@ -280,7 +281,7 @@ public:
           }
           break;
         case Set<A>::Type::kHeartbeat:
-          // FIXME BJL 5-27-21 do we flush the m_maker here? Forward payload?
+          // TODO BJL May-27-2021 do we flush the m_maker here? Forward payload?
           break;
         case Set<A>::Type::kUnknown:
           ers::error(UnknownSetError(ERS_HERE, parent.get_name(), "algorithm_name_placeholder"));
@@ -297,4 +298,4 @@ public:
 
 } // namespace dunedaq::trigger
 
-#endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERGENERICMAKER_HPP_
+#endif // TRIGGER_SRC_TRIGGER_TRIGGERGENERICMAKER_HPP_

--- a/src/trigger/TriggerGenericMaker.hpp
+++ b/src/trigger/TriggerGenericMaker.hpp
@@ -1,3 +1,17 @@
+/**
+ * @file TriggerGenericMaker.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+ 
+#ifndef TRIGGER_INCLUDE_TRIGGER_TRIGGERGENERICMAKER_HPP_
+#define TRIGGER_INCLUDE_TRIGGER_TRIGGERGENERICMAKER_HPP_
+
+#include "trigger/Set.hpp"
+#include "trigger/Issues.hpp"
+ 
 #include "appfwk/DAQModule.hpp"
 #include "appfwk/DAQSink.hpp"
 #include "appfwk/DAQSource.hpp"
@@ -11,12 +25,20 @@
 
 namespace dunedaq::trigger {
 
+// Forward declare the class encapsulating partial specifications of do_work
+template<class IN, class OUT, class MAKER>
+class Worker;
+
 template<class IN, class OUT, class MAKER>
 class TriggerGenericMaker : public dunedaq::appfwk::DAQModule
 {
+friend class Worker<IN,OUT,MAKER>;
+  
 public:
+
   explicit TriggerGenericMaker(const std::string& name)
     : DAQModule(name)
+    , worker(*this)
     , m_thread(std::bind(&TriggerGenericMaker::do_work, this, std::placeholders::_1))
     , m_input_queue(nullptr)
     , m_output_queue(nullptr)
@@ -41,6 +63,9 @@ public:
   }
 
 private:
+
+  Worker<IN,OUT,MAKER> worker;
+
   dunedaq::appfwk::ThreadHelper m_thread;
   
   using source_t = dunedaq::appfwk::DAQSource<IN>;
@@ -72,13 +97,83 @@ private:
   
   void do_work(std::atomic<bool> &running_flag)
   {
+    worker.do_work(running_flag);
+  }
+
+};
+
+// To handle the different unpacking schemes implied by different templates,
+// do_work is broken out into its own template class that is a friend of 
+// TriggerGenericMaker. C++ still does not support partial specification of a 
+// single method in a template class, so this approach is the least redundant
+// way to achieve that functionality
+template<class IN, class OUT, class MAKER>
+class Worker
+{
+public:
+  Worker(TriggerGenericMaker<IN, OUT, MAKER> &_parent) : parent(_parent) { }
+  
+  TriggerGenericMaker<IN, OUT, MAKER> &parent;
+  
+  void do_work(std::atomic<bool> &running_flag)
+  {
     int received_count = 0;
     int sent_count = 0;
 
     while (running_flag.load()) {
       IN in;
       try {
-        m_input_queue->pop(in, m_queue_timeout);
+        parent.m_input_queue->pop(in, parent.m_queue_timeout);
+      } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
+        // it is perfectly reasonable that there might be no data in the queue
+        // some fraction of the times that we check, so we just continue on and try again
+        continue;
+      }
+      ++received_count;
+  
+      std::vector<OUT> outs;
+      try {
+        parent.m_maker->operator()(in, outs);
+      } catch (...) {
+        ers::error(AlgorithmFatalError(ERS_HERE, parent.get_name(), "algorithm_name_placeholder"));
+        continue;
+      }
+
+      while (outs.size() && running_flag.load()) {
+        try {
+          parent.m_output_queue->push(outs.back(), parent.m_queue_timeout);
+          outs.pop_back();
+          ++sent_count;
+        } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
+          ers::warning(excpt);
+        }
+      }
+    } // end while (running_flag.load())
+
+    TLOG() << ": Exiting do_work() method, received " << received_count 
+           << " inputs and successfully sent " << sent_count << " outputs. ";
+  }
+  
+};
+
+// Partial specilization for Set<A> -> Set<B>
+template<class A, class B, class MAKER> 
+class Worker<Set<A>, Set<B>, MAKER> 
+{
+public:
+  Worker(TriggerGenericMaker<Set<A>, Set<B>, MAKER> &_parent) : parent(_parent) { }
+  
+  TriggerGenericMaker<Set<A>, Set<B>, MAKER> &parent;
+  
+  void do_work(std::atomic<bool> &running_flag)
+  {
+    int received_count = 0;
+    int sent_count = 0;
+
+    while (running_flag.load()) {
+      Set<A> in;
+      try {
+        parent.m_input_queue->pop(in, parent.m_queue_timeout);
       } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
         // it is perfectly reasonable that there might be no data in the queue
         // some fraction of the times that we check, so we just continue on and try again
@@ -86,28 +181,120 @@ private:
       }
       ++received_count;
 
-      std::vector<OUT> outs;
-      m_maker->operator()(in, outs);
-
-      while (outs.size()) {
-        bool successfullyWasSent = false;
-        while (!successfullyWasSent && running_flag.load()) {
-          try {
-            m_output_queue->push(outs.back(), m_queue_timeout);
-            outs.pop_back();
-            successfullyWasSent = true;
-            ++sent_count;
-          } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
-            ers::warning(excpt);
+      Set<B> out;
+      switch (in.type) {
+        case Set<A>::Type::kPayload:
+          for (size_t i = 0; i < in.objects.size(); i++) {
+            std::vector<B> out_vec;
+            try {
+              parent.m_maker->operator()(in.objects[i], out_vec);
+            } catch (...) {
+              ers::error(AlgorithmFatalError(ERS_HERE, parent.get_name(), "algorithm_name_placeholder"));
+              continue;
+            }
+            out.objects.insert(out.objects.end(), out_vec.begin(), out_vec.end());
           }
+          out.type = Set<B>::Type::kPayload;
+          break;
+        case Set<A>::Type::kHeartbeat:
+          // FIXME BJL 5-27-21 do we flush the m_maker here?
+          out.type = Set<B>::Type::kHeartbeat;
+          break;
+        case Set<A>::Type::kUnknown:
+          ers::error(UnknownSetError(ERS_HERE, parent.get_name(), "algorithm_name_placeholder"));
+          break;
+      }
+          
+      out.seqno = sent_count;
+      if (out.objects.size() > 0) {
+        // FIXME BJL 5-27-21 Set<T> should implement some helper methods to 
+        // populate these fields in lieu of that, this is an approximation
+        out.from_detids.resize(out.objects.size());
+        for (size_t i = 0; i < out.objects.size(); i++) {
+          out.from_detids[i] = out.objects[i].detid;
         }
+        out.start_time = out.objects[0].time_start;
+        // TODO BJL 5-27-21 TP and TA both have time_start, but only TA has time_end
+        // really, Set<T> should decide what is desired here, not the maker
+        out.end_time = out.objects[out.objects.size()-1].time_start;
+      }
+        
+      try {
+        parent.m_output_queue->push(out, parent.m_queue_timeout);
+        ++sent_count;
+      } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
+        ers::warning(excpt);
       }
     } // end while (running_flag.load())
 
-    TLOG() << ": Exiting do_work() method, received " << received_count << " inputs and successfully sent " << sent_count
-           << " outputs. ";
+    TLOG() << ": Exiting do_work() method, received " << received_count 
+           << " inputs and successfully sent " << sent_count << " outputs. ";
   }
+  
+};
 
+// Partial specilization for Set<A> -> OUT
+template<class A, class OUT, class MAKER> 
+class Worker<Set<A>, OUT, MAKER> 
+{
+public:
+  Worker(TriggerGenericMaker<Set<A>, OUT, MAKER> &_parent) : parent(_parent) { }
+  
+  TriggerGenericMaker<Set<A>, OUT, MAKER> &parent;
+  
+  void do_work(std::atomic<bool> &running_flag)
+  {
+    int received_count = 0;
+    int sent_count = 0;
+
+    while (running_flag.load()) {
+      Set<A> in;
+      try {
+        parent.m_input_queue->pop(in, parent.m_queue_timeout);
+      } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
+        // it is perfectly reasonable that there might be no data in the queue
+        // some fraction of the times that we check, so we just continue on and try again
+        continue;
+      }
+      ++received_count;
+
+      Set<OUT> out;
+      switch (in.type) {
+        case Set<A>::Type::kPayload:
+          for (size_t i = 0; i < in.objects.size(); i++) {
+            std::vector<OUT> out_vec;
+            try {
+              parent.m_maker->operator()(in.objects[i], out_vec);
+            } catch (...) {
+              ers::error(AlgorithmFatalError(ERS_HERE, parent.get_name(), "algorithm_name_placeholder"));
+            }
+            while (out_vec.size() && running_flag.load()) {
+              try {
+                parent.m_output_queue->push(out_vec.back(), parent.m_queue_timeout);
+                out_vec.pop_back();
+                ++sent_count;
+              } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
+                ers::warning(excpt);
+              }
+            }
+          }
+          break;
+        case Set<A>::Type::kHeartbeat:
+          // FIXME BJL 5-27-21 do we flush the m_maker here? Forward payload?
+          break;
+        case Set<A>::Type::kUnknown:
+          ers::error(UnknownSetError(ERS_HERE, parent.get_name(), "algorithm_name_placeholder"));
+          break;
+      }
+          
+    } // end while (running_flag.load())
+
+    TLOG() << ": Exiting do_work() method, received " << received_count 
+           << " inputs and successfully sent " << sent_count << " outputs. ";
+  }
+  
 };
 
 } // namespace dunedaq::trigger
+
+#endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERGENERICMAKER_HPP_


### PR DESCRIPTION
Introduces a helper class `TriggerGenericWorker` to deal with the partial specialization of the `do_work` method. This allows queues of type `Set<A>` -> `OUT` and `Set<A>` -> `Set<B>` to be handled correctly. Unfortunately C++ does not yet allow partial specialization of methods in a template class, and the helper class is the cleanest workaround for this.