### PR TITLE
Confgen for running FakeTPCreatorHeartbeatMaker

### DIFF
--- a/plugins/FakeTPCreatorHeartbeatMaker.cpp
+++ b/plugins/FakeTPCreatorHeartbeatMaker.cpp
@@ -30,8 +30,8 @@ void
 FakeTPCreatorHeartbeatMaker::init(const nlohmann::json& iniobj)
 {
   try {
-    m_input_queue.reset(new source_t(appfwk::queue_inst(iniobj, "input")));
-    m_output_queue.reset(new sink_t(appfwk::queue_inst(iniobj, "output")));
+    m_input_queue.reset(new source_t(appfwk::queue_inst(iniobj, "tpset_source")));
+    m_output_queue.reset(new sink_t(appfwk::queue_inst(iniobj, "tpset_sink")));
   } catch (const ers::Issue& excpt) {
     throw dunedaq::trigger::InvalidQueueFatalError(ERS_HERE, get_name(), "input/output", excpt);
   }

--- a/python/trigger/faketp_to_sink_faketpcreatorheartbeatmaker/faketp_to_sink_faketpcreatorheartbeatmaker.py
+++ b/python/trigger/faketp_to_sink_faketpcreatorheartbeatmaker/faketp_to_sink_faketpcreatorheartbeatmaker.py
@@ -1,0 +1,120 @@
+# Set moo schema search path
+from dunedaq.env import get_moo_model_path
+import moo.io
+moo.io.default_load_path = get_moo_model_path()
+
+from pprint import pprint
+pprint(moo.io.default_load_path)
+# Load configuration types
+import moo.otypes
+moo.otypes.load_types('rcif/cmd.jsonnet')
+moo.otypes.load_types('appfwk/cmd.jsonnet')
+moo.otypes.load_types('appfwk/app.jsonnet')
+
+moo.otypes.load_types('trigger/triggerprimitivemaker.jsonnet')
+moo.otypes.load_types('trigger/faketpcreatorheartbeatmaker.jsonnet')
+
+# Import new types
+import dunedaq.cmdlib.cmd as basecmd # AddressedCmd, 
+import dunedaq.rcif.cmd as rccmd # AddressedCmd, 
+import dunedaq.appfwk.cmd as cmd # AddressedCmd, 
+import dunedaq.appfwk.app as app # AddressedCmd,
+import dunedaq.trigger.triggerprimitivemaker as tpm
+import dunedaq.trigger.faketpcreatorheartbeatmaker as ftpchm
+
+from appfwk.utils import mcmd, mrccmd, mspec
+
+import json
+import math
+from pprint import pprint
+
+
+#===============================================================================
+def acmd(mods: list) -> cmd.CmdObj:
+    """ 
+    Helper function to create appfwk's Commands addressed to modules.
+        
+    :param      cmdid:  The coommand id
+    :type       cmdid:  str
+    :param      mods:   List of module name/data structures 
+    :type       mods:   list
+    
+    :returns:   A constructed Command object
+    :rtype:     dunedaq.appfwk.cmd.Command
+    """
+    return cmd.CmdObj(
+        modules=cmd.AddressedCmds(
+            cmd.AddressedCmd(match=m, data=o)
+            for m,o in mods
+        )
+    )
+
+#===============================================================================
+def generate(
+        OUTPUT_PATH: str,
+        INPUT_FILE: str,
+        SLOWDOWN_FACTOR: float
+):
+    cmd_data = {}
+
+    # Derived parameters
+    CLOCK_FREQUENCY_HZ = 50000000 / SLOWDOWN_FACTOR
+
+    # Define modules and queues
+    queue_specs = [
+        app.QueueSpec(inst="tpset_q", kind='FollySPSCQueue', capacity=1000),
+        app.QueueSpec(inst="tpset_incl_hb_q", kind='FollySPSCQueue', capacity=1000),
+    ]
+
+    mod_specs = [
+        mspec("tpm", "TriggerPrimitiveMaker", [
+            app.QueueInfo(name="tpset_sink", inst="tpset_q", dir="output"),
+        ]),
+        
+        mspec("ftpchm", "FakeTPCreatorHeartbeatMaker", [
+            app.QueueInfo(name="tpset_source", inst="tpset_q", dir="input"),
+            app.QueueInfo(name="tpset_sink", inst="tpset_incl_hb_q", dir="output"),
+        ]),
+        
+        mspec("tps_sink", "TPSetSink", [
+            app.QueueInfo(name="tpset_source", inst="tpset_incl_hb_q", dir="input"),
+        ]),
+    ]
+
+    cmd_data['init'] = app.Init(queues=queue_specs, modules=mod_specs)
+
+    cmd_data['conf'] = acmd([
+        ("tpm", tpm.ConfParams(
+            filename=INPUT_FILE,
+            number_of_loops=-1, # Infinite
+            tpset_time_offset=0,
+            tpset_time_width=10000,
+            clock_frequency_hz=CLOCK_FREQUENCY_HZ
+        )),
+        ("ftpchm", ftpchm.Conf(
+          heartbeat_interval = 50000
+        )),
+    ])
+
+    startpars = rccmd.StartParams(run=1, disable_data_storage=False)
+    cmd_data['start'] = acmd([
+        ("tpm", startpars),
+        ("ftpchm", startpars),
+        ("tps_sink", startpars),
+    ])
+
+    cmd_data['pause'] = acmd([])
+
+    cmd_data['resume'] = acmd([])
+    
+    cmd_data['stop'] = acmd([
+        ("tpm", None),
+        ("ftpchm", None),
+        ("tps_sink", None),
+    ])
+
+    cmd_data['scrap'] = acmd([
+        ("tpm", None),
+    ])
+
+    return cmd_data

--- a/python/trigger/faketp_to_sink_faketpcreatorheartbeatmaker/toplevel.py
+++ b/python/trigger/faketp_to_sink_faketpcreatorheartbeatmaker/toplevel.py
@@ -1,0 +1,159 @@
+import json
+import os
+import rich.traceback
+from rich.console import Console
+from os.path import exists, join
+
+
+# Add -h as default help option
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+console = Console()
+
+def generate_boot( faketp_spec: dict) -> dict:
+    """
+    Generates boot informations
+
+    :param      faketp_spec:  The faketp specifications
+    :type       faketp_spec:  dict
+
+    :returns:   { description_of_the_return_value }
+    :rtype:     dict
+    """
+
+    # TODO: think how to best handle this bit.
+    # Who is responsible for this bit? Not minidaqapp?
+    # Is this an appfwk configuration fragment?
+    daq_app_specs = {
+        "daq_application_ups" : {
+            "comment": "Application profile based on a full dbt runtime environment",
+            "env": {
+               "DBT_AREA_ROOT": "getenv" 
+            },
+            "cmd": [
+                "CMD_FAC=rest://localhost:${APP_PORT}",
+                "INFO_SVC=file://info_${APP_ID}_${APP_PORT}.json",
+                "cd ${DBT_AREA_ROOT}",
+                "source dbt-setup-env.sh",
+                "dbt-setup-runtime-environment",
+                "cd ${APP_WD}",
+                "daq_application --name ${APP_ID} -c ${CMD_FAC} -i ${INFO_SVC}"
+            ]
+        },
+        "daq_application" : {
+            "comment": "Application profile using  PATH variables (lower start time)",
+            "env":{
+                "CET_PLUGIN_PATH": "getenv",
+                "DUNEDAQ_SHARE_PATH": "getenv",
+                "LD_LIBRARY_PATH": "getenv",
+                "PATH": "getenv",
+                "DUNEDAQ_ERS_DEBUG_LEVEL": "1"
+            },
+            "cmd": [
+                "CMD_FAC=rest://localhost:${APP_PORT}",
+                "INFO_SVC=file://info_${APP_NAME}_${APP_PORT}.json",
+                "cd ${APP_WD}",
+                "daq_application --name ${APP_NAME} -c ${CMD_FAC} -i ${INFO_SVC}"
+            ]
+        }
+    }
+
+    boot = {
+        "env": {
+            "DUNEDAQ_ERS_VERBOSITY_LEVEL": 1
+        },
+        "apps": {
+            faketp_spec["name"]: {
+                "exec": "daq_application",
+                "host": "host_faketp",
+                "port": faketp_spec["port"]
+            }
+        },
+        "hosts": {
+            "host_faketp": faketp_spec["host"]
+        },
+        "response_listener": {
+            "port": 56789
+        },
+        "exec": daq_app_specs
+    }
+
+    console.log("Boot data")
+    console.log(boot)
+    return boot
+
+
+import click
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option('-s', '--slowdown-factor', default=1.0)
+@click.option('-f', '--input-file', type=click.Path())
+@click.argument('json_dir', type=click.Path())
+def cli(slowdown_factor, input_file, json_dir):
+    """
+      JSON_DIR: Json file output folder
+    """
+    console.log("Loading faketp config generator")
+    from . import faketp_to_sink_faketpcreatorheartbeatmaker
+    console.log(f"Generating configs")
+
+    cmd_data_faketp = faketp_to_sink_faketpcreatorheartbeatmaker.generate(
+        INPUT_FILE = input_file,
+        SLOWDOWN_FACTOR = slowdown_factor,
+        OUTPUT_PATH = json_dir,
+    )
+
+    console.log("faketp cmd data:", cmd_data_faketp)
+
+    if exists(json_dir):
+        raise RuntimeError(f"Directory {json_dir} already exists")
+
+    data_dir = join(json_dir, 'data')
+    os.makedirs(data_dir)
+
+    app_faketp="faketp"
+
+    jf_faketp = join(data_dir, app_faketp)
+
+    cmd_set = ["init", "conf", "start", "stop", "pause", "resume", "scrap"]
+    for app,data in ((app_faketp, cmd_data_faketp),):
+        console.log(f"Generating {app} command data json files")
+        for c in cmd_set:
+            with open(f'{join(data_dir, app)}_{c}.json', 'w') as f:
+                json.dump(data[c].pod(), f, indent=4, sort_keys=True)
+
+
+    console.log(f"Generating top-level command json files")
+    start_order = [app_faketp]
+    for c in cmd_set:
+        with open(join(json_dir,f'{c}.json'), 'w') as f:
+            cfg = {
+                "apps": { app: f'data/{app}_{c}' for app in (app_faketp, ) }
+            }
+            if c == 'start':
+                cfg['order'] = start_order
+            elif c == 'stop':
+                cfg['order'] = start_order[::-1]
+
+            json.dump(cfg, f, indent=4, sort_keys=True)
+
+
+    console.log(f"Generating boot json file")
+    with open(join(json_dir,'boot.json'), 'w') as f:
+        cfg = generate_boot(
+            faketp_spec = {
+                "name": app_faketp,
+                "host": "localhost",
+                "port": 3333
+            },
+        )
+        json.dump(cfg, f, indent=4, sort_keys=True)
+    console.log(f"MDAapp config generated in {json_dir}")
+
+
+if __name__ == '__main__':
+
+    try:
+            cli(show_default=True, standalone_mode=True)
+    except Exception as e:
+            console.print_exception()

--- a/test/plugins/TPSetSink.cpp
+++ b/test/plugins/TPSetSink.cpp
@@ -74,11 +74,14 @@ TPSetSink::do_work()
     }
 
     // Do some checks on the received TPSet
-    if (tpset.start_time <= last_timestamp) {
+    if (tpset.start_time < last_timestamp) {
       TLOG() << "TPSets out of order: last start time " << last_timestamp << ", current start time "
              << tpset.start_time;
     }
-    if (tpset.objects.empty()) {
+    if(tpset.type==TPSet::Type::kHeartbeat){
+      TLOG() << "Heartbeat TPSet with start time " << tpset.start_time;
+    }
+    else if (tpset.objects.empty()) {
       TLOG() << "Empty TPSet with start time " << tpset.start_time;
     }
     for (auto const& tp : tpset.objects) {


### PR DESCRIPTION
Minor change to FakeTPCreatorHeartbeatMaker following testing. Confgen script written which runs the module between TriggerPrimitiveMaker and TPSetSink. Module behaves as expected. Note that small changes have been made to the checks of the TPSets that come in to TPSetSink:

-- To avoid "TPSets out of order" message for fake heartbeats, changed the condition on from current.start_time <= last.start_time to current.start_time < last.start_time.
-- To avoid "Empty TPSet" message for fake heartbeat, added logic to recognise TPSets of Type kHeartbeat.