### PR TITLE
Added suggestions for how to download sample TPSet files from cernbox

### DIFF
--- a/python/trigger/faketp_chain/README.md
+++ b/python/trigger/faketp_chain/README.md
@@ -67,3 +67,12 @@ the `ModuleLevelTrigger`, waits 10 seconds, and stops.
 
 This will produce a log file `log_faketp_chain_3333.txt` with output from the 
 run, and a similarly named info file.
+
+## Data files
+
+As of 23-Jun, there are a couple of TP files available from [cernbox](https://cernbox.cern.ch/index.php/s/75PDf54a9DWXWOJ).
+
+To download them, you can use the following commands:
+
+* `curl -o tps_link_05.txt -O https://cernbox.cern.ch/index.php/s/75PDf54a9DWXWOJ/download?files=tps_link_05.txt`
+* `curl -o tps_link_11.txt -O https://cernbox.cern.ch/index.php/s/75PDf54a9DWXWOJ/download?files=tps_link_11.txt`


### PR DESCRIPTION
To help make it a little easier to remember where to find the sample TPSet files, I added some comments to the faketp_chain/README file.  

If these look reasonable, then hopefully we can approve this PR and merge the branch to _develop_, so that everyone can see these suggestions.