### PR TITLE
seqno fix

### DIFF
--- a/test/plugins/TPSetSink.cpp
+++ b/test/plugins/TPSetSink.cpp
@@ -58,6 +58,8 @@ TPSetSink::do_work()
   uint64_t first_timestamp = 0;
   uint64_t last_timestamp = 0;
 
+  uint32_t last_seqno = 0;
+  
   while (true) {
     TPSet tpset;
     try {
@@ -74,6 +76,12 @@ TPSetSink::do_work()
     }
 
     // Do some checks on the received TPSet
+
+    if (last_seqno != 0 && tpset.seqno != last_seqno + 1) {
+      TLOG() << "Missed TPSets: last_seqno=" << last_seqno << ", current seqno=" << tpset.seqno;
+    }
+    last_seqno=tpset.seqno;
+    
     if (tpset.start_time <= last_timestamp) {
       TLOG() << "TPSets out of order: last start time " << last_timestamp << ", current start time "
              << tpset.start_time;


### PR DESCRIPTION
This PR fixes `TriggerPrimitiveMaker` to update the TPSet seqno correctly when the input file is looped over multiple times, and updates `TPSetSink` to check the sequence numbers.