### PR TITLE
Add GeoID origin to Set<T> output of TriggerGenericMaker

### DIFF
--- a/plugins/TriggerActivityMaker.cpp
+++ b/plugins/TriggerActivityMaker.cpp
@@ -20,6 +20,7 @@ namespace dunedaq::trigger {
   {
     auto params = obj.get<triggeractivitymaker::Conf>();
     set_algorithm_name(params.activity_maker);
+    set_geoid(params.geoid_region, params.geoid_element);
     std::shared_ptr<triggeralgs::TriggerActivityMaker> maker = make_ta_maker(params.activity_maker);
     maker->configure(params.activity_maker_config);
     return maker;

--- a/python/trigger/faketp_chain/README.md
+++ b/python/trigger/faketp_chain/README.md
@@ -1,12 +1,12 @@
 # faketp_chain
 
 This is an example application that runs a full dataselection chain using 
-`TriggerPrimativeMaker` to read TPs from a file, and `FakeDataFlow` to emulate
+`TriggerPrimitiveMaker` to read TPs from a file, and `FakeDataFlow` to emulate
 the response of dataflow. In the middle, the following trigger modules are used:
 
 * `TriggerActivityMaker` which loads a `triggeralgs` plugin to convert `TPSet` 
   from `TriggerPrimativeMaker` into `TASet` consisting of the `TriggerActivity`
-  produced by the algorithm being called on `TriggerPrimative` in the `TPSet`.
+  produced by the algorithm being called on `TriggerPrimitive` in the `TPSet`.
   
 * `TriggerCandidateMaker` which loads a `triggeralgs` plugin to convert `TASet` 
   from `TriggerActivityMaker` into `TriggerCandidates` produced by the algorithm

--- a/python/trigger/faketp_chain/faketp_chain.py
+++ b/python/trigger/faketp_chain/faketp_chain.py
@@ -151,6 +151,8 @@ def generate(
         )),
         ('tam', tam.Conf(
             activity_maker=ACTIVITY_PLUGIN,
+            geoid_region=0, # Fake placeholder
+            geoid_element=0, # Fake placeholder
             activity_maker_config=temptypes.ActivityConf(**ACTIVITY_CONFIG)
         )),
         ('tcm', tcm.Conf(

--- a/schema/trigger/triggeractivitymaker.jsonnet
+++ b/schema/trigger/triggeractivitymaker.jsonnet
@@ -3,14 +3,18 @@ local ns = "dunedaq.trigger.triggeractivitymaker";
 local s = moo.oschema.schema(ns);
 
 local types = {
-  name: s.string("Name", ".*",
-    doc="Name of a plugin etc"),
-
+  name: s.string("Name", ".*", doc="Name of a plugin etc"),
+  region: s.number("Region", "u2", doc="16bit region identifier for a GeoID"),
+  element: s.number("Element", "u4", doc="32bit element identifier for a GeoID"),
   any: s.any("Data", doc="Any"),
 
   conf: s.record("Conf", [
     s.field("activity_maker", self.name,
       doc="Name of the activity maker implementation to be used via plugin"),
+    s.field("geoid_region", self.region,
+      doc="The region used in the GeoID for TASets produced by this maker"),
+    s.field("geoid_element", self.element,
+      doc="The element used in the GeoID for TASets produced by this maker"),
     s.field("activity_maker_config", self.any,
       doc="Configuration for the activity maker implementation"),
     ], doc="TriggerActivityMaker configuration"),

--- a/src/trigger/TriggerGenericMaker.hpp
+++ b/src/trigger/TriggerGenericMaker.hpp
@@ -18,6 +18,8 @@
 #include "appfwk/ThreadHelper.hpp"
 #include "appfwk/DAQModuleHelper.hpp"
 
+#include "dataformats/GeoID.hpp"
+
 #include "logging/Logging.hpp"
 
 #include <memory>
@@ -46,6 +48,8 @@ public:
     , m_output_queue(nullptr)
     , m_queue_timeout(100)
     , m_algorithm_name("[uninitialized]")
+    , m_geoid_region_id(dunedaq::dataformats::GeoID::s_invalid_region_id)
+    , m_geoid_element_id(dunedaq::dataformats::GeoID::s_invalid_element_id)
   {
     register_command("start", &TriggerGenericMaker::do_start);
     register_command("stop", &TriggerGenericMaker::do_stop);
@@ -72,6 +76,12 @@ protected:
     m_algorithm_name = name;
   }
 
+  void set_geoid(uint16_t region_id, uint32_t element_id)
+  {
+    m_geoid_region_id = region_id;
+    m_geoid_element_id = element_id;
+  }
+
 private:
 
   TriggerGenericWorker<IN,OUT,MAKER> worker;
@@ -90,11 +100,14 @@ private:
   std::chrono::milliseconds m_queue_timeout;
   
   std::string m_algorithm_name;
+  
+  uint16_t m_geoid_region_id;
+  uint32_t m_geoid_element_id;
 
   std::shared_ptr<MAKER> m_maker;
   
   // This should return a shared_ptr to the MAKER created from conf command
-  // arguments, and also call set_algorithm_name.
+  // arguments. Should also call set_algorithm_name and set_geoid (if desired)
   virtual std::shared_ptr<MAKER> make_maker(const nlohmann::json& obj) = 0;
   
   void do_start(const nlohmann::json& /*obj*/)
@@ -222,7 +235,7 @@ public:
   void flush(std::vector<T> &time_slice, 
              dataformats::timestamp_t &start_time, 
              dataformats::timestamp_t &end_time) {
-    // build a vector of the A objects from all the sets in the slice
+    // build a vector of the T objects from all the sets in the slice
     start_time = m_buffer[0].start_time;
     end_time = m_buffer[0].end_time;
     for (Set<T> &x : m_buffer) {
@@ -244,7 +257,7 @@ private:
   const std::string &m_name, &m_algorithm;
 };
 
-// Partial specilization for IN = Set<A>, OUT = Set<B> and assumes the MAKER has:
+// Partial specialization for IN = Set<A>, OUT = Set<B> and assumes the MAKER has:
 // operator()(A, std::vector<B>)
 template<class A, class B, class MAKER> 
 class TriggerGenericWorker<Set<A>, Set<B>, MAKER> 
@@ -301,6 +314,9 @@ public:
             heartbeat.type = Set<B>::Type::kHeartbeat;
             heartbeat.start_time = in.start_time;
             heartbeat.end_time = in.end_time;
+            heartbeat.origin = dataformats::GeoID(dataformats::GeoID::SystemType::kDataSelection, 
+                                                  m_parent.m_geoid_region_id,
+                                                  m_parent.m_geoid_element_id);
             while (running_flag.load()) {
               if (m_parent.send(heartbeat)) {
                 break;
@@ -327,7 +343,9 @@ public:
       if (out.objects.size() > 0) {
         out.seqno = m_parent.m_sent_count;
         
-        // fixme: set out.origin from config
+        out.origin = dataformats::GeoID(dataformats::GeoID::SystemType::kDataSelection, 
+                                        m_parent.m_geoid_region_id,
+                                        m_parent.m_geoid_element_id);
         
         while (running_flag.load()) {
           if (m_parent.send(out)) {


### PR DESCRIPTION
Relies on the derrived class to call set_geoid and read parameters from its configuration file. Only TriggerActivityMaker emits Set<T>, and is augmented to read region and element info from its config.

Also fixes a few misc typos.