### PR TITLE
Use the TC start and end times in the trigger decision

### DIFF
--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -156,9 +156,8 @@ ModuleLevelTrigger::create_decision(const triggeralgs::TriggerCandidate& tc)
   for (auto link : m_links) {
     dfmessages::ComponentRequest request;
     request.component = link;
-    // TODO: set these from some config map
-    request.window_begin = tc.time_candidate;
-    request.window_end = tc.time_candidate + 1000;
+    request.window_begin = tc.time_start;
+    request.window_end = tc.time_end;
 
     decision.components.push_back(request);
   }


### PR DESCRIPTION
This fixes #55 by using the trigger candidate start and end times in the trigger decision sent out by `ModuleLevelTrigger`