### PR TITLE
Add functions to read/write TP fragments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,14 @@ find_package(logging REQUIRED)
 find_package(appfwk REQUIRED)
 find_package(triggeralgs REQUIRED)
 find_package(dfmessages REQUIRED)
+find_package(dataformats REQUIRED)
 find_package(timinglibs REQUIRED)
 find_package(nwqueueadapters REQUIRED)
 
 ##############################################################################
 # Main library
 
-daq_add_library(TokenManager.cpp LivetimeCounter.cpp LINK_LIBRARIES appfwk::appfwk logging::logging dfmessages::dfmessages triggeralgs::triggeralgs)
+daq_add_library(TokenManager.cpp LivetimeCounter.cpp FragmentMakers.cpp LINK_LIBRARIES appfwk::appfwk logging::logging dfmessages::dfmessages dataformats::dataformats triggeralgs::triggeralgs)
 
 ##############################################################################
 # Codegen
@@ -70,6 +71,7 @@ daq_add_application( taset_serialization taset_serialization.cxx TEST LINK_LIBRA
 daq_add_unit_test(TokenManager_test              LINK_LIBRARIES trigger)
 daq_add_unit_test(LivetimeCounter_test           LINK_LIBRARIES trigger)
 daq_add_unit_test(TxSet_test                     LINK_LIBRARIES trigger)
+daq_add_unit_test(TPFragment_test                LINK_LIBRARIES trigger)
 
 ##############################################################################
 

--- a/include/trigger/FragmentMakers.hpp
+++ b/include/trigger/FragmentMakers.hpp
@@ -11,9 +11,6 @@
 
 namespace dunedaq::trigger {
 
-dataformats::FragmentHeader
-create_fragment_header(const dfmessages::DataRequest& dr);
-
 std::unique_ptr<dataformats::Fragment>
 make_fragment(std::vector<TPSet>& tpsets);
 

--- a/include/trigger/FragmentMakers.hpp
+++ b/include/trigger/FragmentMakers.hpp
@@ -1,0 +1,28 @@
+#ifndef TRIGGER_INCLUDE_TRIGGER_FRAGMENTMAKERS_HPP_
+#define TRIGGER_INCLUDE_TRIGGER_FRAGMENTMAKERS_HPP_
+
+#include "dataformats/Fragment.hpp"
+#include "dfmessages/DataRequest.hpp"
+#include "trigger/TPSet.hpp"
+#include "triggeralgs/TriggerPrimitive.hpp"
+
+#include <memory> // For unique_ptr
+#include <vector>
+
+namespace dunedaq::trigger {
+
+dataformats::FragmentHeader
+create_fragment_header(const dfmessages::DataRequest& dr);
+
+std::unique_ptr<dataformats::Fragment>
+make_fragment(std::vector<TPSet>& tpsets);
+
+std::unique_ptr<dataformats::Fragment>
+make_fragment(std::vector<triggeralgs::TriggerPrimitive>& tps);
+
+std::vector<triggeralgs::TriggerPrimitive>
+read_fragment_to_trigger_primitives(dataformats::Fragment* frag);
+
+}
+
+#endif // TRIGGER_INCLUDE_TRIGGER_FRAGMENTMAKERS_HPP_

--- a/src/FragmentMakers.cpp
+++ b/src/FragmentMakers.cpp
@@ -30,18 +30,18 @@ make_fragment(std::vector<triggeralgs::TriggerPrimitive>& tps)
   tpf->n_trigger_primitives = tps.size();
   size_t counter = 0;
   for (auto const& tp : tps) {
-    dataformats::TriggerPrimitivesFragment::TriggerPrimitive& tp_fragment = tpf->primitives[counter++];
-    tp_fragment.time_start = tp.time_start;
-    tp_fragment.time_peak = tp.time_peak;
-    tp_fragment.time_over_threshold = tp.time_over_threshold;
-    tp_fragment.channel = tp.channel;
-    tp_fragment.adc_integral = tp.adc_integral;
-    tp_fragment.adc_peak = tp.adc_peak;
-    tp_fragment.detid = tp.detid;
-    tp_fragment.type = static_cast<uint32_t>(tp.type);
-    tp_fragment.algorithm = static_cast<uint32_t>(tp.algorithm);
-    tp_fragment.version = tp.version;
-    tp_fragment.flag = tp.flag;
+    dataformats::TriggerPrimitivesFragment::TriggerPrimitive& fragment_tp = tpf->primitives[counter++];
+    fragment_tp.time_start = tp.time_start;
+    fragment_tp.time_peak = tp.time_peak;
+    fragment_tp.time_over_threshold = tp.time_over_threshold;
+    fragment_tp.channel = tp.channel;
+    fragment_tp.adc_integral = tp.adc_integral;
+    fragment_tp.adc_peak = tp.adc_peak;
+    fragment_tp.detid = tp.detid;
+    fragment_tp.type = static_cast<uint32_t>(tp.type);
+    fragment_tp.algorithm = static_cast<uint32_t>(tp.algorithm);
+    fragment_tp.version = tp.version;
+    fragment_tp.flag = tp.flag;
   }
 
   std::unique_ptr<dataformats::Fragment> frag = std::make_unique<dataformats::Fragment>(buffer.get(), n_bytes);
@@ -56,20 +56,20 @@ read_fragment_to_trigger_primitives(dataformats::Fragment* frag)
   const dataformats::TriggerPrimitivesFragment* tpf =
     reinterpret_cast<const dataformats::TriggerPrimitivesFragment*>(frag->get_data());
   for (uint64_t i = 0; i < tpf->n_trigger_primitives; ++i) {
-    const dataformats::TriggerPrimitivesFragment::TriggerPrimitive& tp_fragment = tpf->primitives[i];
+    const dataformats::TriggerPrimitivesFragment::TriggerPrimitive& fragment_tp = tpf->primitives[i];
 
     triggeralgs::TriggerPrimitive tp;
-    tp.time_start = tp_fragment.time_start;
-    tp.time_peak = tp_fragment.time_peak;
-    tp.time_over_threshold = tp_fragment.time_over_threshold;
-    tp.channel = tp_fragment.channel;
-    tp.adc_integral = tp_fragment.adc_integral;
-    tp.adc_peak = tp_fragment.adc_peak;
-    tp.detid = tp_fragment.detid;
-    tp.type = static_cast<triggeralgs::TriggerPrimitive::Type>(tp_fragment.type);
-    tp.algorithm = static_cast<triggeralgs::TriggerPrimitive::Algorithm>(tp_fragment.algorithm);
-    tp.version = tp_fragment.version;
-    tp.flag = tp_fragment.flag;
+    tp.time_start = fragment_tp.time_start;
+    tp.time_peak = fragment_tp.time_peak;
+    tp.time_over_threshold = fragment_tp.time_over_threshold;
+    tp.channel = fragment_tp.channel;
+    tp.adc_integral = fragment_tp.adc_integral;
+    tp.adc_peak = fragment_tp.adc_peak;
+    tp.detid = fragment_tp.detid;
+    tp.type = static_cast<triggeralgs::TriggerPrimitive::Type>(fragment_tp.type);
+    tp.algorithm = static_cast<triggeralgs::TriggerPrimitive::Algorithm>(fragment_tp.algorithm);
+    tp.version = fragment_tp.version;
+    tp.flag = fragment_tp.flag;
 
     tps.push_back(tp);
   }

--- a/src/FragmentMakers.cpp
+++ b/src/FragmentMakers.cpp
@@ -5,23 +5,6 @@
 namespace dunedaq::trigger {
 
 //======================================================================
-
-dataformats::FragmentHeader
-create_fragment_header(const dfmessages::DataRequest& dr)
-{
-  dataformats::FragmentHeader fh;
-  fh.size = sizeof(fh);
-  fh.trigger_number = dr.trigger_number;
-  fh.trigger_timestamp = dr.trigger_timestamp;
-  fh.window_begin = dr.window_begin;
-  fh.window_end = dr.window_end;
-  fh.run_number = dr.run_number;
-  // fh.element_id = { m_geoid.system_type, m_geoid.region_id, m_geoid.element_id };
-  // fh.fragment_type = static_cast<dataformats::fragment_type_t>(ReadoutType::fragment_type);
-  return fh;
-}
-
-//======================================================================
 std::unique_ptr<dataformats::Fragment>
 make_fragment(std::vector<TPSet>& tpsets)
 {

--- a/src/FragmentMakers.cpp
+++ b/src/FragmentMakers.cpp
@@ -30,7 +30,7 @@ make_fragment(std::vector<triggeralgs::TriggerPrimitive>& tps)
   tpf->n_trigger_primitives = tps.size();
   size_t counter = 0;
   for (auto const& tp : tps) {
-    dataformats::TriggerPrimitivesFragment::TriggerPrimitive& fragment_tp = tpf->primitives[counter++];
+    dataformats::TriggerPrimitivesFragment::TriggerPrimitive& fragment_tp = tpf->at(counter++);
     fragment_tp.time_start = tp.time_start;
     fragment_tp.time_peak = tp.time_peak;
     fragment_tp.time_over_threshold = tp.time_over_threshold;
@@ -56,7 +56,7 @@ read_fragment_to_trigger_primitives(dataformats::Fragment* frag)
   const dataformats::TriggerPrimitivesFragment* tpf =
     reinterpret_cast<const dataformats::TriggerPrimitivesFragment*>(frag->get_data());
   for (uint64_t i = 0; i < tpf->n_trigger_primitives; ++i) {
-    const dataformats::TriggerPrimitivesFragment::TriggerPrimitive& fragment_tp = tpf->primitives[i];
+    const dataformats::TriggerPrimitivesFragment::TriggerPrimitive& fragment_tp = tpf->at(i);
 
     triggeralgs::TriggerPrimitive tp;
     tp.time_start = fragment_tp.time_start;

--- a/src/FragmentMakers.cpp
+++ b/src/FragmentMakers.cpp
@@ -22,12 +22,12 @@ make_fragment(std::vector<TPSet>& tpsets)
 std::unique_ptr<dataformats::Fragment>
 make_fragment(std::vector<triggeralgs::TriggerPrimitive>& tps)
 {
-  size_t n_bytes = sizeof(dataformats::TriggerPrimitivesFragment) +
+  size_t num_bytes = sizeof(dataformats::TriggerPrimitivesFragment) +
                    tps.size() * sizeof(dataformats::TriggerPrimitivesFragment::TriggerPrimitive);
-  std::unique_ptr<uint8_t[]> buffer(new uint8_t[n_bytes]);
+  std::unique_ptr<uint8_t[]> buffer(new uint8_t[num_bytes]);
   dataformats::TriggerPrimitivesFragment* tpf = reinterpret_cast<dataformats::TriggerPrimitivesFragment*>(buffer.get());
   tpf->version = dataformats::TriggerPrimitivesFragment::s_tpf_version;
-  tpf->n_trigger_primitives = tps.size();
+  tpf->num_trigger_primitives = tps.size();
   size_t counter = 0;
   for (auto const& tp : tps) {
     dataformats::TriggerPrimitivesFragment::TriggerPrimitive& fragment_tp = tpf->at(counter++);
@@ -44,7 +44,7 @@ make_fragment(std::vector<triggeralgs::TriggerPrimitive>& tps)
     fragment_tp.flag = tp.flag;
   }
 
-  std::unique_ptr<dataformats::Fragment> frag = std::make_unique<dataformats::Fragment>(buffer.get(), n_bytes);
+  std::unique_ptr<dataformats::Fragment> frag = std::make_unique<dataformats::Fragment>(buffer.get(), num_bytes);
   return frag;
 }
 
@@ -55,7 +55,7 @@ read_fragment_to_trigger_primitives(dataformats::Fragment* frag)
   std::vector<triggeralgs::TriggerPrimitive> tps;
   const dataformats::TriggerPrimitivesFragment* tpf =
     reinterpret_cast<const dataformats::TriggerPrimitivesFragment*>(frag->get_data());
-  for (uint64_t i = 0; i < tpf->n_trigger_primitives; ++i) {
+  for (uint64_t i = 0; i < tpf->num_trigger_primitives; ++i) {
     const dataformats::TriggerPrimitivesFragment::TriggerPrimitive& fragment_tp = tpf->at(i);
 
     triggeralgs::TriggerPrimitive tp;

--- a/src/FragmentMakers.cpp
+++ b/src/FragmentMakers.cpp
@@ -1,0 +1,97 @@
+#include "trigger/FragmentMakers.hpp"
+#include "dataformats/trigger/TriggerPrimitivesFragment.hpp"
+#include "triggeralgs/TriggerPrimitive.hpp"
+
+namespace dunedaq::trigger {
+
+//======================================================================
+
+dataformats::FragmentHeader
+create_fragment_header(const dfmessages::DataRequest& dr)
+{
+  dataformats::FragmentHeader fh;
+  fh.size = sizeof(fh);
+  fh.trigger_number = dr.trigger_number;
+  fh.trigger_timestamp = dr.trigger_timestamp;
+  fh.window_begin = dr.window_begin;
+  fh.window_end = dr.window_end;
+  fh.run_number = dr.run_number;
+  // fh.element_id = { m_geoid.system_type, m_geoid.region_id, m_geoid.element_id };
+  // fh.fragment_type = static_cast<dataformats::fragment_type_t>(ReadoutType::fragment_type);
+  return fh;
+}
+
+//======================================================================
+std::unique_ptr<dataformats::Fragment>
+make_fragment(std::vector<TPSet>& tpsets)
+{
+  std::vector<triggeralgs::TriggerPrimitive> tps;
+  for (auto const& tpset : tpsets) {
+    for (auto const& tp : tpset.objects) {
+      tps.push_back(tp);
+    }
+  }
+
+  return make_fragment(tps);
+}
+
+//======================================================================
+std::unique_ptr<dataformats::Fragment>
+make_fragment(std::vector<triggeralgs::TriggerPrimitive>& tps)
+{
+  size_t n_bytes = sizeof(dataformats::TriggerPrimitivesFragment) +
+                   tps.size() * sizeof(dataformats::TriggerPrimitivesFragment::TriggerPrimitive);
+  std::unique_ptr<uint8_t[]> buffer(new uint8_t[n_bytes]);
+  dataformats::TriggerPrimitivesFragment* tpf = reinterpret_cast<dataformats::TriggerPrimitivesFragment*>(buffer.get());
+  tpf->version = dataformats::TriggerPrimitivesFragment::s_tpf_version;
+  tpf->n_trigger_primitives = tps.size();
+  size_t counter = 0;
+  for (auto const& tp : tps) {
+    dataformats::TriggerPrimitivesFragment::TriggerPrimitive& tp_fragment = tpf->primitives[counter++];
+    tp_fragment.time_start = tp.time_start;
+    tp_fragment.time_peak = tp.time_peak;
+    tp_fragment.time_over_threshold = tp.time_over_threshold;
+    tp_fragment.channel = tp.channel;
+    tp_fragment.adc_integral = tp.adc_integral;
+    tp_fragment.adc_peak = tp.adc_peak;
+    tp_fragment.detid = tp.detid;
+    tp_fragment.type = static_cast<uint32_t>(tp.type);
+    tp_fragment.algorithm = static_cast<uint32_t>(tp.algorithm);
+    tp_fragment.version = tp.version;
+    tp_fragment.flag = tp.flag;
+  }
+
+  std::unique_ptr<dataformats::Fragment> frag = std::make_unique<dataformats::Fragment>(buffer.get(), n_bytes);
+  return frag;
+}
+
+//======================================================================
+std::vector<triggeralgs::TriggerPrimitive>
+read_fragment_to_trigger_primitives(dataformats::Fragment* frag)
+{
+  std::vector<triggeralgs::TriggerPrimitive> tps;
+  const dataformats::TriggerPrimitivesFragment* tpf =
+    reinterpret_cast<const dataformats::TriggerPrimitivesFragment*>(frag->get_data());
+  for (uint64_t i = 0; i < tpf->n_trigger_primitives; ++i) {
+    const dataformats::TriggerPrimitivesFragment::TriggerPrimitive& tp_fragment = tpf->primitives[i];
+
+    triggeralgs::TriggerPrimitive tp;
+    tp.time_start = tp_fragment.time_start;
+    tp.time_peak = tp_fragment.time_peak;
+    tp.time_over_threshold = tp_fragment.time_over_threshold;
+    tp.channel = tp_fragment.channel;
+    tp.adc_integral = tp_fragment.adc_integral;
+    tp.adc_peak = tp_fragment.adc_peak;
+    tp.detid = tp_fragment.detid;
+    tp.type = static_cast<triggeralgs::TriggerPrimitive::Type>(tp_fragment.type);
+    tp.algorithm = static_cast<triggeralgs::TriggerPrimitive::Algorithm>(tp_fragment.algorithm);
+    tp.version = tp_fragment.version;
+    tp.flag = tp_fragment.flag;
+
+    tps.push_back(tp);
+  }
+
+  return tps;
+}
+
+} // namespace dunedaq

--- a/unittest/TPFragment_test.cxx
+++ b/unittest/TPFragment_test.cxx
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(Basics)
   dataformats::TriggerPrimitivesFragment* tpf =
     reinterpret_cast<dataformats::TriggerPrimitivesFragment*>(frag->get_data());
 
-  BOOST_REQUIRE_EQUAL(tpf->n_trigger_primitives, n_trigger_primitives);
+  BOOST_REQUIRE_EQUAL(tpf->num_trigger_primitives, n_trigger_primitives);
   BOOST_REQUIRE_EQUAL(tpf->version, 1);
 
   std::vector<triggeralgs::TriggerPrimitive> tps_out = trigger::read_fragment_to_trigger_primitives(frag.get());

--- a/unittest/TPFragment_test.cxx
+++ b/unittest/TPFragment_test.cxx
@@ -1,0 +1,84 @@
+/**
+ * @file TPFragment_test.cxx  Unit Tests for reading and writing code for TriggerPrimitivesFragment
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "dataformats/trigger/TriggerPrimitivesFragment.hpp"
+#include "trigger/FragmentMakers.hpp"
+#include "triggeralgs/TriggerPrimitive.hpp"
+
+#include <random>
+
+/**
+ * @brief Name of this test module
+ */
+#define BOOST_TEST_MODULE TPFragment_test // NOLINT
+
+#include "boost/test/unit_test.hpp"
+
+using namespace dunedaq;
+
+namespace triggeralgs {
+std::ostream&
+boost_test_print_type(std::ostream& os, TriggerPrimitive::Algorithm const& alg)
+{
+  using underlying_t = std::underlying_type<TriggerPrimitive::Algorithm>::type;
+  return os << static_cast<underlying_t>(alg);
+}
+}
+
+BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+
+BOOST_AUTO_TEST_CASE(Basics)
+{
+
+  std::default_random_engine generator;
+  std::uniform_int_distribution<int> uniform(0, 1000);
+
+  int n_trigger_primitives = 10;
+  std::vector<triggeralgs::TriggerPrimitive> tps;
+  for (int i = 0; i < n_trigger_primitives; ++i) {
+    triggeralgs::TriggerPrimitive tp;
+    tp.time_start = 1234963454;
+    tp.time_peak = tp.time_start + 10000;
+    tp.time_over_threshold = uniform(generator);
+    tp.channel = uniform(generator);
+    tp.adc_integral = uniform(generator);
+    tp.adc_peak = uniform(generator);
+    tp.detid = i;
+    tp.type = triggeralgs::TriggerPrimitive::Type::kUnknown;
+    tp.algorithm = triggeralgs::TriggerPrimitive::Algorithm::kTPCDefault;
+    tp.version = 1;
+    tp.flag = 1;
+    tps.push_back(tp);
+  }
+
+  std::unique_ptr<dataformats::Fragment> frag = dunedaq::trigger::make_fragment(tps);
+  dataformats::TriggerPrimitivesFragment* tpf =
+    reinterpret_cast<dataformats::TriggerPrimitivesFragment*>(frag->get_data());
+
+  BOOST_REQUIRE_EQUAL(tpf->n_trigger_primitives, n_trigger_primitives);
+  BOOST_REQUIRE_EQUAL(tpf->version, 1);
+
+  std::vector<triggeralgs::TriggerPrimitive> tps_out = trigger::read_fragment_to_trigger_primitives(frag.get());
+  BOOST_REQUIRE_EQUAL(tps_out.size(), tps.size());
+
+  for (int i = 0; i < n_trigger_primitives; ++i) {
+    BOOST_CHECK_EQUAL(tps[i].time_start, tps_out[i].time_start);
+    BOOST_CHECK_EQUAL(tps[i].time_peak, tps_out[i].time_peak);
+    BOOST_CHECK_EQUAL(tps[i].time_over_threshold, tps_out[i].time_over_threshold);
+    BOOST_CHECK_EQUAL(tps[i].channel, tps_out[i].channel);
+    BOOST_CHECK_EQUAL(tps[i].adc_integral, tps_out[i].adc_integral);
+    BOOST_CHECK_EQUAL(tps[i].adc_peak, tps_out[i].adc_peak);
+    BOOST_CHECK_EQUAL(tps[i].detid, tps_out[i].detid);
+    BOOST_CHECK_EQUAL(tps[i].type, tps_out[i].type);
+    BOOST_CHECK_EQUAL(tps[i].algorithm, tps_out[i].algorithm);
+    BOOST_CHECK_EQUAL(tps[i].version, tps_out[i].version);
+    BOOST_CHECK_EQUAL(tps[i].flag, tps_out[i].flag);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds code to convert vectors of TriggerPrimitives into a contiguous-in-memory representation suitable for putting in a Fragment. Depends on DUNE-DAQ/dataformats#78.