### PR TITLE
Added TriggerPrimitiveMaker config params for region_id and element_id

### DIFF
--- a/plugins/TriggerPrimitiveMaker.cpp
+++ b/plugins/TriggerPrimitiveMaker.cpp
@@ -76,11 +76,11 @@ TriggerPrimitiveMaker::do_configure(const nlohmann::json& obj)
         tpset.start_time = current_tpset_number * m_conf.tpset_time_width + m_conf.tpset_time_offset;
         tpset.end_time = tpset.start_time + m_conf.tpset_time_width;
         tpset.seqno = seqno++;
-        // fixme: Should set this and region/element IDs via
-        // configuration.  See trigger/#41 for some discusssion.  For
-        // now, we leave region as invalid and element is "last one
-        // wins".
-        tpset.origin.element_id = tp.detid;
+
+        // 12-Jul-2021, KAB: setting origin fields from configuration
+        tpset.origin.region_id = m_conf.region_id;
+        tpset.origin.element_id = m_conf.element_id;
+
         tpset.type = TPSet::Type::kPayload;
         tpset.objects.clear();
       }

--- a/schema/trigger/triggerprimitivemaker.jsonnet
+++ b/schema/trigger/triggerprimitivemaker.jsonnet
@@ -8,6 +8,8 @@ local types = {
     rows: s.number("rows", dtype="u8", doc="Number of rows"),
     freq: s.number("freq", dtype="u8", doc="A frequency"),
     microseconds: s.number("microseconds", dtype="u8", doc="Microseconds"),
+    region : s.number("region", "u2", doc="Region ID for GeoID"),
+    element : s.number("element", "u4", doc="Element ID for GeoID"),
 
     conf: s.record("ConfParams", [
         s.field("filename", self.pathname, "/tmp/example.csv",
@@ -22,6 +24,10 @@ local types = {
                 doc="Simulated clock frequency in Hz"),
         s.field("maximum_wait_time_us", self.microseconds, 1000,
                 doc="Maximum wait time until the running flag is checked in microseconds"),
+        s.field("region_id", self.region, 0,
+                doc="Detector region ID to be reported as the source of the TPs"),
+        s.field("element_id", self.element, 0,
+                doc="Detector element ID to be reported as the source of the TPs"),
     ], doc="TriggerPrimitiveMaker configuration"),
 
 };


### PR DESCRIPTION
Hopefully these changes look reasonable and useful.

I made them as part of testing a TPSetWriter in the _dfmodules_ package.