### PR TITLE
Increment TP timestamps after the first send, instead of before

### DIFF
--- a/plugins/TriggerPrimitiveMaker.cpp
+++ b/plugins/TriggerPrimitiveMaker.cpp
@@ -147,16 +147,6 @@ TriggerPrimitiveMaker::do_work(std::atomic<bool>& running_flag)
       if (!running_flag.load()) {
         break;
       }
-
-      // Increase seqno and the timestamps in the TPSet and TPs so they don't
-      // repeat when we do multiple loops over the file
-      tpset.start_time += input_file_duration;
-      tpset.end_time += input_file_duration;
-      for (auto& tp : tpset.objects) {
-        tp.time_start += input_file_duration;
-        tp.time_peak += input_file_duration;
-      }
-      tpset.seqno = seqno++;
       
       // We send out the first TPSet right away. After that we space each TPSet in time by their start time
       auto wait_time_us = 0;
@@ -195,6 +185,16 @@ TriggerPrimitiveMaker::do_work(std::atomic<bool>& running_flag)
         ers::warning(e);
         ++push_failed_count;
       }
+
+      // Increase seqno and the timestamps in the TPSet and TPs so they don't
+      // repeat when we do multiple loops over the file
+      tpset.start_time += input_file_duration;
+      tpset.end_time += input_file_duration;
+      for (auto& tp : tpset.objects) {
+        tp.time_start += input_file_duration;
+        tp.time_peak += input_file_duration;
+      }
+      tpset.seqno = seqno++;
 
     } // end loop over tpsets
     ++current_iteration;


### PR DESCRIPTION
When we replay the TPs multiple times, we increment their timestamps
each time, so that the receiver sees always-increasing timestamps
(instead of jumping back to the start each time). The code was
previously doing that increment _before_ sending the TPs, which meant
that they were never sent with their original timestamp values from
the file. Not really a problem, but it made debugging a bit harder, so
now we increment timestamps only after the first send. Then, the first
loop over the TPs sends them out with their origin timestamp values.