### PR TITLE
set zipper latency

### DIFF
--- a/plugins/TriggerZipper.hpp
+++ b/plugins/TriggerZipper.hpp
@@ -70,7 +70,7 @@ public:
 
   // We store input TSETs in a list and send iterator though the
   // zipper as payload so as to not suffer copy overhead.
-  cache_type cache;
+  cache_type m_cache;
   seqno_type m_next_seqno{ 0 };
 
   explicit TriggerZipper(const std::string& name)
@@ -139,19 +139,19 @@ public:
 
   void proc_one()
   {
-    cache.emplace_front(); // to be filled
-    auto& tset = cache.front();
+    m_cache.emplace_front(); // to be filled
+    auto& tset = m_cache.front();
     try {
       m_inq->pop(tset, std::chrono::milliseconds(10));
     } catch (appfwk::QueueTimeoutExpired&) {
-      cache.pop_front(); // vestigial
+      m_cache.pop_front(); // vestigial
       drain();
       return;
     }
 
-    bool accepted = m_zm.feed(cache.begin(), tset.start_time, zipper_stream_id(tset.origin));
+    bool accepted = m_zm.feed(m_cache.begin(), tset.start_time, zipper_stream_id(tset.origin));
     if (!accepted) {
-      cache.pop_front(); // vestigial
+      m_cache.pop_front(); // vestigial
     }
     drain();
   }
@@ -174,7 +174,7 @@ public:
         // here than simply complain and drop?
         ers::error(err);
       }
-      cache.erase(lit);
+      m_cache.erase(lit);
     }
   }
 

--- a/plugins/TriggerZipper.hpp
+++ b/plugins/TriggerZipper.hpp
@@ -99,6 +99,7 @@ public:
   void do_configure(const nlohmann::json& cfgobj)
   {
     m_cfg = cfgobj.get<cfg_t>();
+    m_zm.set_max_latency(std::chrono::milliseconds(m_cfg.max_latency_ms));
     m_zm.set_cardinality(m_cfg.cardinality);
   }
 

--- a/plugins/zipper.hpp
+++ b/plugins/zipper.hpp
@@ -71,7 +71,7 @@ public:
      See @ref set_cardinality() for the "k" parameter.
 
      A nonzero max_latency must be supplied to enable latency
-     guaratees.
+     guarantees.
    */
   explicit merge(size_t k = 0, duration_t max_latency = duration_t::zero())
     : cardinality(k)
@@ -105,6 +105,11 @@ public:
       undefined behavior as described above.
   */
   void set_cardinality(size_t k) { cardinality = k; }
+
+  /**
+     Set the maximum latency
+   */
+  void set_max_latency(duration_t max_latency) { latency = max_latency; }
 
   /**
      Clear the zipper merge buffer.
@@ -294,7 +299,7 @@ public:
 
 private:
   size_t cardinality;
-  const duration_t latency{ 0 };
+  duration_t latency{ 0 };
   ordering_t origin;
   struct Stream
   {


### PR DESCRIPTION
Add a `merge::set_max_latency()` function and use it in `TriggerZipper`. Fixes #68 .

(I've made this PR to merge into `philiprodrigues/apply-clang-format` in the hope that this makes the diff readable, _and_ will make it easy to merge into `develop` once the clang-format changes in PR #69 are merged.)