### PR TITLE
Some fixes to buffer implementation

### DIFF
--- a/python/trigger/readout_tp_to_sink/__main__.py
+++ b/python/trigger/readout_tp_to_sink/__main__.py
@@ -1,0 +1,188 @@
+import json
+import os
+import rich.traceback
+from rich.console import Console
+from os.path import exists, join
+
+
+# Add -h as default help option
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+console = Console()
+
+def generate_boot( tp_sink_spec: dict, readout_spec: dict) -> dict:
+    """
+    Generates boot informations
+
+    :param      tp_sink_spec:  The tp_sink specifications
+    :type       tp_sink_spec:  dict
+
+    :returns:   { description_of_the_return_value }
+    :rtype:     dict
+    """
+
+    # TODO: think how to best handle this bit.
+    # Who is responsible for this bit? Not minidaqapp?
+    # Is this an appfwk configuration fragment?
+    daq_app_specs = {
+        "daq_application_ups" : {
+            "comment": "Application profile based on a full dbt runtime environment",
+            "env": {
+               "DBT_AREA_ROOT": "getenv" 
+            },
+            "cmd": [
+                "CMD_FAC=rest://localhost:${APP_PORT}",
+                "INFO_SVC=file://info_${APP_ID}_${APP_PORT}.json",
+                "cd ${DBT_AREA_ROOT}",
+                "source dbt-setup-env.sh",
+                "dbt-setup-runtime-environment",
+                "cd ${APP_WD}",
+                "daq_application --name ${APP_ID} -c ${CMD_FAC} -i ${INFO_SVC}"
+            ]
+        },
+        "daq_application" : {
+            "comment": "Application profile using  PATH variables (lower start time)",
+            "env":{
+                "CET_PLUGIN_PATH": "getenv",
+                "DUNEDAQ_SHARE_PATH": "getenv",
+                "LD_LIBRARY_PATH": "getenv",
+                "PATH": "getenv",
+                "DUNEDAQ_ERS_DEBUG_LEVEL": "getenv"
+            },
+            "cmd": [
+                "CMD_FAC=rest://localhost:${APP_PORT}",
+                "INFO_SVC=file://info_${APP_NAME}_${APP_PORT}.json",
+                "cd ${APP_WD}",
+                "daq_application --name ${APP_NAME} -c ${CMD_FAC} -i ${INFO_SVC}"
+            ]
+        }
+    }
+
+    boot = {
+        "env": {
+            "DUNEDAQ_ERS_VERBOSITY_LEVEL": "getenv"
+        },
+        "apps": {
+            tp_sink_spec["name"]: {
+                "exec": "daq_application",
+                "host": "host_tp_sink",
+                "port": tp_sink_spec["port"]
+            },
+            readout_spec["name"]: {
+                "exec": "daq_application",
+                "host": "host_readout",
+                "port": readout_spec["port"]
+            }
+        },
+        "hosts": {
+            "host_tp_sink": tp_sink_spec["host"],
+            "host_readout": readout_spec["host"]
+        },
+        "response_listener": {
+            "port": 56789
+        },
+        "exec": daq_app_specs
+    }
+
+    console.log("Boot data")
+    console.log(boot)
+    return boot
+
+
+import click
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option('-s', '--slowdown-factor', default=1.0)
+@click.option('-d', '--data-file', type=click.Path(), default='./frames.bin')
+@click.argument('json_dir', type=click.Path())
+def cli(slowdown_factor, data_file, json_dir):
+    """
+      JSON_DIR: Json file output folder
+    """
+
+    if exists(json_dir):
+        raise RuntimeError(f"Directory {json_dir} already exists")
+    data_dir = join(json_dir, 'data')
+    os.makedirs(data_dir)
+
+    ##########################################################
+    # TP sink app generation
+
+    console.log("Loading tp_sink_app config generator")
+    from . import tp_sink_app
+    console.log(f"Generating configs")
+
+    cmd_data_tp_sink = tp_sink_app.generate(
+    )
+
+    app_tp_sink="tp_sink"
+
+    jf_tp_sink = join(data_dir, app_tp_sink)
+
+    ##########################################################
+    # readout app generation
+
+    console.log("Loading readout_app config generator")
+    from . import readout_app
+    console.log(f"Generating configs")
+
+    cmd_data_readout = readout_app.generate(
+        DATA_FILE = data_file,
+        DATA_RATE_SLOWDOWN_FACTOR = slowdown_factor
+    )
+
+    app_readout="readout"
+
+    jf_readout = join(data_dir, app_readout)
+
+    ##########################################################
+    # json file creation
+
+    
+    cmd_set = ["init", "conf", "start", "stop", "pause", "resume", "scrap"]
+    for app,data in ((app_tp_sink, cmd_data_tp_sink),(app_readout, cmd_data_readout),):
+        console.log(f"Generating {app} command data json files")
+        for c in cmd_set:
+            with open(f'{join(data_dir, app)}_{c}.json', 'w') as f:
+                json.dump(data[c].pod(), f, indent=4, sort_keys=True)
+
+
+    console.log(f"Generating top-level command json files")
+    start_order = [app_tp_sink, app_readout]
+    for c in cmd_set:
+        with open(join(json_dir,f'{c}.json'), 'w') as f:
+            cfg = {
+                "apps": { app: f'data/{app}_{c}' for app in (app_tp_sink, app_readout,) }
+            }
+            if c == 'start':
+                cfg['order'] = start_order
+            elif c == 'stop':
+                cfg['order'] = start_order[::-1]
+
+            json.dump(cfg, f, indent=4, sort_keys=True)
+
+
+    console.log(f"Generating boot json file")
+    with open(join(json_dir,'boot.json'), 'w') as f:
+        cfg = generate_boot(
+            tp_sink_spec = {
+                "name": app_tp_sink,
+                "host": "localhost",
+                "port": 3333
+            },
+            readout_spec = {
+                "name": app_readout,
+                "host": "localhost",
+                "port": 3334
+            },
+        )
+        json.dump(cfg, f, indent=4, sort_keys=True)
+    console.log(f"MDAapp config generated in {json_dir}")
+
+
+if __name__ == '__main__':
+
+    try:
+            cli(show_default=True, standalone_mode=True)
+    except Exception as e:
+            console.print_exception()

--- a/python/trigger/readout_tp_to_sink/readout_app.py
+++ b/python/trigger/readout_tp_to_sink/readout_app.py
@@ -1,0 +1,263 @@
+# Set moo schema search path
+from dunedaq.env import get_moo_model_path
+import moo.io
+moo.io.default_load_path = get_moo_model_path()
+
+# Load configuration types
+import moo.otypes
+moo.otypes.load_types('cmdlib/cmd.jsonnet')
+moo.otypes.load_types('rcif/cmd.jsonnet')
+moo.otypes.load_types('appfwk/cmd.jsonnet')
+moo.otypes.load_types('appfwk/app.jsonnet')
+
+moo.otypes.load_types('readout/fakecardreader.jsonnet')
+moo.otypes.load_types('readout/datalinkhandler.jsonnet')
+moo.otypes.load_types('readout/datarecorder.jsonnet')
+moo.otypes.load_types('nwqueueadapters/queuetonetwork.jsonnet')
+moo.otypes.load_types('nwqueueadapters/networkobjectsender.jsonnet')
+
+# Import new types
+import dunedaq.cmdlib.cmd as basecmd # AddressedCmd, 
+import dunedaq.rcif.cmd as rccmd # AddressedCmd, 
+import dunedaq.appfwk.app as app # AddressedCmd, 
+import dunedaq.appfwk.cmd as cmd # AddressedCmd, 
+
+import dunedaq.readout.fakecardreader as fcr
+import dunedaq.readout.datalinkhandler as dlh
+import dunedaq.readout.datarecorder as bfs
+import dunedaq.nwqueueadapters.queuetonetwork as qton
+import dunedaq.nwqueueadapters.networkobjectsender as nos
+
+from appfwk.utils import mcmd, mrccmd, mspec
+
+import json
+import math
+# Time to waait on pop()
+QUEUE_POP_WAIT_MS=100;
+# local clock speed Hz
+CLOCK_SPEED_HZ = 50000000;
+
+#===============================================================================
+def acmd(mods: list) -> cmd.CmdObj:
+    """ 
+    Helper function to create appfwk's Commands addressed to modules.
+        
+    :param      cmdid:  The coommand id
+    :type       cmdid:  str
+    :param      mods:   List of module name/data structures 
+    :type       mods:   list
+    
+    :returns:   A constructed Command object
+    :rtype:     dunedaq.appfwk.cmd.Command
+    """
+    return cmd.CmdObj(
+        modules=cmd.AddressedCmds(
+            cmd.AddressedCmd(match=m, data=o)
+            for m,o in mods
+        )
+    )
+
+def generate(
+        FRONTEND_TYPE='wib',
+        NUMBER_OF_DATA_PRODUCERS=1,          
+        NUMBER_OF_TP_PRODUCERS=1,          
+        DATA_RATE_SLOWDOWN_FACTOR = 1,
+        RUN_NUMBER = 333, 
+        DATA_FILE="./frames.bin"
+    ):
+
+    cmd_data = {}
+    
+    # Define modules and queues
+    queue_specs = [
+            app.QueueSpec(inst="time_sync_q", kind='FollyMPMCQueue', capacity=100),
+            app.QueueSpec(inst="data_fragments_q", kind='FollyMPMCQueue', capacity=100),
+        ] + [
+            app.QueueSpec(inst=f"data_requests_{idx}", kind='FollySPSCQueue', capacity=1000)
+                for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ] + [
+            app.QueueSpec(inst=f"{FRONTEND_TYPE}_link_{idx}", kind='FollySPSCQueue', capacity=100000)
+                for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ] + [
+            app.QueueSpec(inst=f"tp_link_{idx}", kind='FollySPSCQueue', capacity=100000)
+                for idx in range(NUMBER_OF_DATA_PRODUCERS, NUMBER_OF_DATA_PRODUCERS+NUMBER_OF_TP_PRODUCERS)
+        ] + [
+            app.QueueSpec(inst=f"{FRONTEND_TYPE}_recording_link_{idx}", kind='FollySPSCQueue', capacity=100000)
+                for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ] + [
+            app.QueueSpec(inst=f"tp_queue_{idx}", kind='FollySPSCQueue', capacity=100000)
+                for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ] + [
+            app.QueueSpec(inst=f"tp_data_requests", kind='FollySPSCQueue', capacity=1000)
+        ] + [
+            app.QueueSpec(inst="tp_recording_link", kind='FollySPSCQueue', capacity=1000)
+        ] + [
+            app.QueueSpec(inst=f"tpset_link_{idx}", kind='FollySPSCQueue', capacity=10000)
+                for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ]
+    
+    mod_specs = [
+        mspec("fake_source", "FakeCardReader", [
+                        app.QueueInfo(name=f"output_{idx}", inst=f"{FRONTEND_TYPE}_link_{idx}", dir="output")
+                            for idx in range(NUMBER_OF_DATA_PRODUCERS)
+                        ]),
+        ] + [
+                mspec(f"datahandler_{idx}", "DataLinkHandler", [
+                            app.QueueInfo(name="raw_input", inst=f"{FRONTEND_TYPE}_link_{idx}", dir="input"),
+                            app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
+                            app.QueueInfo(name="requests", inst=f"data_requests_{idx}", dir="input"),
+                            app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
+                            app.QueueInfo(name="raw_recording", inst=f"{FRONTEND_TYPE}_recording_link_{idx}", dir="output"),
+                            app.QueueInfo(name="tp_out", inst=f"tp_queue_{idx}", dir="output"),
+                            app.QueueInfo(name="tpset_out", inst=f"tpset_link_{idx}", dir="output")
+                ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ] + [
+                mspec(f"data_recorder_{idx}", "DataRecorder", [
+                            app.QueueInfo(name="raw_recording", inst=f"{FRONTEND_TYPE}_recording_link_{idx}", dir="input")
+                            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ] + [
+                mspec(f"timesync_consumer", "TimeSyncConsumer", [
+                                            app.QueueInfo(name="input_queue", inst=f"time_sync_q", dir="input")
+                                            ])
+        ] + [
+                mspec(f"fragment_consumer", "FragmentConsumer", [
+                                            app.QueueInfo(name="input_queue", inst=f"data_fragments_q", dir="input")
+                                            ])
+        ] + [
+                mspec(f"tp_handler_{idx}", "DataLinkHandler", [
+                                            app.QueueInfo(name="raw_input", inst=f"tp_queue_{idx}", dir="input"),
+                                            app.QueueInfo(name="timesync", inst="time_sync_q", dir="output"),
+                                            app.QueueInfo(name="requests", inst="tp_data_requests", dir="input"),
+                                            app.QueueInfo(name="fragments", inst="data_fragments_q", dir="output"),
+                                            app.QueueInfo(name="raw_recording", inst="tp_recording_link", dir="output")
+                                            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ] + [
+                mspec(f"tpset_publisher_{idx}", "QueueToNetwork", [
+                                            app.QueueInfo(name="input", inst=f"tpset_link_{idx}", dir="input")
+                                            ]) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+        ]
+
+    cmd_data['init'] = app.Init(queues=queue_specs, modules=mod_specs)
+    
+
+    cmd_data['conf'] = acmd([
+        ("fake_source",fcr.Conf(
+            link_confs=[fcr.LinkConfiguration(
+                geoid=fcr.GeoID(system="TPC", region=0, element=idx),
+                slowdown=DATA_RATE_SLOWDOWN_FACTOR,
+                queue_name=f"output_{idx}",
+                data_filename=DATA_FILE,
+                input_limit=10000000000,
+            ) for idx in range(NUMBER_OF_DATA_PRODUCERS)],
+            # input_limit=10485100, # default
+            queue_timeout_ms = QUEUE_POP_WAIT_MS,
+	    set_t0_to = 0
+        )),
+    ] + [
+        (f"datahandler_{idx}", dlh.Conf(
+            source_queue_timeout_ms= QUEUE_POP_WAIT_MS,
+            fake_trigger_flag=1,
+            latency_buffer_size = 3*CLOCK_SPEED_HZ/(25*12*DATA_RATE_SLOWDOWN_FACTOR),
+            pop_limit_pct = 0.8,
+            pop_size_pct = 0.1,
+            apa_number = 0,
+            link_number = idx
+        )) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+    ] + [
+        (f"data_recorder_{idx}", bfs.Conf(
+            output_file = f"output_{idx}.out",
+            stream_buffer_size = 8388608
+        )) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+    ] + [
+        (f"tp_handler_{idx}", dlh.Conf(
+            source_queue_timeout_ms= QUEUE_POP_WAIT_MS,
+            fake_trigger_flag=1,
+            latency_buffer_size = 3*CLOCK_SPEED_HZ/(25*12*DATA_RATE_SLOWDOWN_FACTOR),
+            pop_limit_pct = 0.8,
+            pop_size_pct = 0.1,
+            apa_number = 0,
+            link_number = 0
+        )) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+    ] + [
+        (f"tpset_publisher_{idx}", qton.Conf(msg_type="dunedaq::trigger::TPSet",
+                                             msg_module_name="TPSetNQ",
+                                             sender_config=nos.Conf(ipm_plugin_type="ZmqPublisher",
+                                                                    address='tcp://127.0.0.1:' + str(5000 + idx),
+                                                                    topic="foo",
+                                                                    stype="msgpack")
+                                             )
+         ) for idx in range(NUMBER_OF_DATA_PRODUCERS)
+    ])
+    
+    startpars = rccmd.StartParams(run=RUN_NUMBER)
+    cmd_data['start'] = acmd([
+            ("datahandler_.*", startpars),
+            ("fake_source", startpars),
+            ("data_recorder_.*", startpars),
+            ("timesync_consumer", startpars),
+            ("fragment_consumer", startpars),
+            ("tp_handler_.*", startpars),
+            ("tpset_publisher_.*", startpars)
+    ])
+
+    cmd_data['pause'] = acmd([])
+
+    cmd_data['resume'] = acmd([])
+
+    cmd_data['stop'] = acmd([
+            ("fake_source", None),
+            ("datahandler_.*", None),
+            ("data_recorder_.*", None),
+            ("timesync_consumer", None),
+            ("fragment_consumer", None),
+            ("tp_handler_.*", None),
+            ("tpset_publisher_.*", None)
+        ])
+
+    cmd_data['scrap'] = acmd([
+            ("fake_source", None),
+            ("datahandler_.*", None),
+            ("data_recorder_.*", None),
+            ("timesync_consumer", None),
+            ("fragment_consumer", None),
+            ("tp_handler_.*", None),
+            ("tpset_publisher_.*", None)
+    ])
+
+    return cmd_data
+        
+# if __name__ == '__main__':
+#     # Add -h as default help option
+#     CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+#     import click
+
+#     @click.command(context_settings=CONTEXT_SETTINGS)
+#     @click.option('-f', '--frontend-type', type=click.Choice(['wib', 'wib2', 'pds_queue', 'pds_list'], case_sensitive=True), default='wib')
+#     @click.option('-n', '--number-of-data-producers', default=1)
+#     @click.option('-t', '--number-of-tp-producers', default=0)
+#     @click.option('-s', '--data-rate-slowdown-factor', default=10)
+#     @click.option('-r', '--run-number', default=333)
+#     @click.option('-d', '--data-file', type=click.Path(), default='./frames.bin')
+#     # @click.option('--tp-data-file') TBA
+#     @click.argument('json_file', type=click.Path(), default='fake_readout.json')
+#     def cli(frontend_type, number_of_data_producers, number_of_tp_producers, data_rate_slowdown_factor, run_number, data_file, json_file):
+#         """
+#           JSON_FILE: Input raw data file.
+#           JSON_FILE: Output json configuration file.
+#         """
+
+#         with open(json_file, 'w') as f:
+#             f.write(generate(
+#                     FRONTEND_TYPE = frontend_type,
+#                     NUMBER_OF_DATA_PRODUCERS = number_of_data_producers,
+#                     NUMBER_OF_TP_PRODUCERS = number_of_tp_producers,
+#                     DATA_RATE_SLOWDOWN_FACTOR = data_rate_slowdown_factor,
+#                     RUN_NUMBER = run_number, 
+#                     DATA_FILE = data_file,
+#                 ))
+
+#         print(f"'{json_file}' generation completed.")
+
+#     cli()
+    

--- a/python/trigger/readout_tp_to_sink/tp_sink_app.py
+++ b/python/trigger/readout_tp_to_sink/tp_sink_app.py
@@ -1,0 +1,106 @@
+# Set moo schema search path
+from dunedaq.env import get_moo_model_path
+import moo.io
+moo.io.default_load_path = get_moo_model_path()
+
+from pprint import pprint
+pprint(moo.io.default_load_path)
+# Load configuration types
+import moo.otypes
+moo.otypes.load_types('rcif/cmd.jsonnet')
+moo.otypes.load_types('appfwk/cmd.jsonnet')
+moo.otypes.load_types('appfwk/app.jsonnet')
+
+moo.otypes.load_types('nwqueueadapters/networktoqueue.jsonnet')
+moo.otypes.load_types('nwqueueadapters/networkobjectreceiver.jsonnet')
+
+moo.otypes.load_types('trigger/triggerprimitivemaker.jsonnet')
+
+# Import new types
+import dunedaq.cmdlib.cmd as basecmd # AddressedCmd, 
+import dunedaq.rcif.cmd as rccmd # AddressedCmd, 
+import dunedaq.appfwk.cmd as cmd # AddressedCmd, 
+import dunedaq.appfwk.app as app # AddressedCmd,
+import dunedaq.trigger.triggerprimitivemaker as tpm
+import dunedaq.nwqueueadapters.networktoqueue as ntoq
+import dunedaq.nwqueueadapters.networkobjectreceiver as nor
+
+from appfwk.utils import mcmd, mrccmd, mspec
+
+import json
+import math
+from pprint import pprint
+
+
+#===============================================================================
+def acmd(mods: list) -> cmd.CmdObj:
+    """ 
+    Helper function to create appfwk's Commands addressed to modules.
+        
+    :param      cmdid:  The coommand id
+    :type       cmdid:  str
+    :param      mods:   List of module name/data structures 
+    :type       mods:   list
+    
+    :returns:   A constructed Command object
+    :rtype:     dunedaq.appfwk.cmd.Command
+    """
+    return cmd.CmdObj(
+        modules=cmd.AddressedCmds(
+            cmd.AddressedCmd(match=m, data=o)
+            for m,o in mods
+        )
+    )
+
+#===============================================================================
+def generate(
+):
+    cmd_data = {}
+
+    # Define modules and queues
+    queue_specs = [
+        app.QueueSpec(inst="tpset_q", kind='FollySPSCQueue', capacity=1000),
+    ]
+
+    mod_specs = [
+
+        mspec(f"tpset_subscriber", "NetworkToQueue", [
+            app.QueueInfo(name="output", inst=f"tpset_q", dir="output")
+        ]),
+
+        mspec("tps_sink", "TPSetSink", [
+            app.QueueInfo(name="tpset_source", inst="tpset_q", dir="input"),
+        ]),
+    ]
+
+    cmd_data['init'] = app.Init(queues=queue_specs, modules=mod_specs)
+
+    cmd_data['conf'] = acmd([
+        ("tpset_subscriber", ntoq.Conf(msg_type="dunedaq::trigger::TPSet",
+                                             msg_module_name="TPSetNQ",
+                                             receiver_config=nor.Conf(ipm_plugin_type="ZmqSubscriber",
+                                                                      address='tcp://127.0.0.1:5000',
+                                                                      subscriptions=["foo"]))
+         ),
+    ])
+
+    startpars = rccmd.StartParams(run=1, disable_data_storage=False)
+    cmd_data['start'] = acmd([
+        ("tpm", startpars),
+        ("tps_sink", startpars),
+    ])
+
+    cmd_data['pause'] = acmd([])
+
+    cmd_data['resume'] = acmd([])
+    
+    cmd_data['stop'] = acmd([
+        ("tpm", None),
+        ("tps_sink", None),
+    ])
+
+    cmd_data['scrap'] = acmd([
+        ("tpm", None),
+    ])
+
+    return cmd_data

--- a/src/trigger/BufferManager.hpp
+++ b/src/trigger/BufferManager.hpp
@@ -29,7 +29,7 @@ public:
   BufferManager(long unsigned int buffer_size)
     : m_buffer_max_size(buffer_size)
     , m_buffer_earliest_start_time(0)
-    ,  m_buffer_latest_end_time(0) 
+    ,  m_buffer_latest_end_time(0)
   {
   }
 
@@ -50,17 +50,17 @@ public:
    */
   bool add(BSET& txs)
   {
-    if(m_txset_buffer.size() >= m_buffer_max_size) //delete oldest TxSet if buffer full (and updating earliest start time) -> circular buffer 
+    if(m_txset_buffer.size() >= m_buffer_max_size) //delete oldest TxSet if buffer full (and updating earliest start time) -> circular buffer
     {
       auto firstIt = m_txset_buffer.begin();
       m_txset_buffer.erase(firstIt);
-      firstIt++; 
+      firstIt++;
       m_buffer_earliest_start_time = (*firstIt).start_time;
     }
     if( (m_buffer_earliest_start_time == 0) || (txs.start_time < m_buffer_earliest_start_time))
       m_buffer_earliest_start_time = txs.start_time;
 
-    if( (m_buffer_latest_end_time == 0) || (txs.end_time > m_buffer_latest_end_time) ) 
+    if( (m_buffer_latest_end_time == 0) || (txs.end_time > m_buffer_latest_end_time) )
       m_buffer_latest_end_time = txs.end_time;
 
     return m_txset_buffer.insert(txs).second; //false if txs with same start_time already exists
@@ -85,42 +85,42 @@ public:
     BufferManager::data_request_output ds_out;
     std::vector<BSET> txsets_output;
 
-    if(end_time < m_buffer_earliest_start_time) 
+    if(end_time < m_buffer_earliest_start_time)
     {
       ds_out.txsets_in_window = txsets_output;
       ds_out.ds_outcome = BufferManager::kEmpty;
-      return ds_out;  
+      return ds_out;
     }
 
     if(start_time > m_buffer_latest_end_time)
     {
       ds_out.txsets_in_window = txsets_output;
       ds_out.ds_outcome = BufferManager::kLate;
-      return ds_out; 
+      return ds_out;
     }
 
     BSET txset_low, txset_up;
     txset_low.start_time = start_time;
-    txset_up.start_time  = end_time; 
+    txset_up.start_time  = end_time;
 
     typename std::set<BSET,TxSetCmp>::iterator it, it_low,it_up;
 
     //checking first and last TxSet of buffer that have a start_time within data request limits
-    it_low = m_txset_buffer.lower_bound(txset_low); 
+    it_low = m_txset_buffer.lower_bound(txset_low);
     it_up  = m_txset_buffer.upper_bound(txset_up);
-    it     = it_low; 
+    it     = it_low;
 
-    //checking if previous TxSet has a end_time that is after the data request's start time 
-    if(!(it == m_txset_buffer.begin()) ){  
-      it--; 
-      if((*it).end_time > start_time) txsets_output.push_back(*it);  
-      it++; 
+    //checking if previous TxSet has a end_time that is after the data request's start time
+    if(!(it == m_txset_buffer.begin()) ){
+      it--;
+      if((*it).end_time > start_time) txsets_output.push_back(*it);
+      it++;
     }
 
     //loading TxSets
     while(it != it_up){
       txsets_output.push_back(*it);
-      it++; 
+      it++;
     }
 
     ds_out.txsets_in_window = txsets_output;
@@ -129,6 +129,9 @@ public:
     return ds_out;
 
   }
+
+  dataformats::timestamp_t get_earliest_start_time() const { return m_buffer_earliest_start_time; }
+  dataformats::timestamp_t get_latest_end_time() const { return m_buffer_latest_end_time; }
 
 private:
 
@@ -149,7 +152,7 @@ private:
 
   //Earliest start time stored in the buffer
   dataformats::timestamp_t m_buffer_earliest_start_time;
-  
+
   //Latest end time stored in the buffer
   dataformats::timestamp_t m_buffer_latest_end_time;
 

--- a/test/plugins/TPSetBufferCreator.hpp
+++ b/test/plugins/TPSetBufferCreator.hpp
@@ -77,10 +77,10 @@ private:
   using dr_source_t = dunedaq::appfwk::DAQSource<dfmessages::DataRequest>;
   std::unique_ptr<dr_source_t> m_input_queue_dr;
 
-  using fragment_sink_t = dunedaq::appfwk::DAQSink<dataformats::Fragment>;
+  using fragment_sink_t = dunedaq::appfwk::DAQSink<std::unique_ptr<dataformats::Fragment>>;
   std::unique_ptr<fragment_sink_t> m_output_queue_frag;
 
-  trigger::TPSetBuffer* m_tps_buffer;
+  std::unique_ptr<trigger::TPSetBuffer> m_tps_buffer;
 
   uint64_t m_tps_buffer_size;
 
@@ -90,11 +90,11 @@ private:
     }
   };
 
-  std::map<dfmessages::DataRequest, std::vector<trigger::TPSet>, DataRequestComp>* m_dr_on_hold; ///< Holds data request when data has not arrived in the buffer yet
+  std::map<dfmessages::DataRequest, std::vector<trigger::TPSet>, DataRequestComp> m_dr_on_hold; ///< Holds data request when data has not arrived in the buffer yet
 
-  dataformats::Fragment convert_to_fragment(TPSetBuffer::data_request_output, dfmessages::DataRequest);
+  std::unique_ptr<dataformats::Fragment> convert_to_fragment(TPSetBuffer::data_request_output, dfmessages::DataRequest);
 
-  void send_out_fragment(dataformats::Fragment&, size_t&, std::atomic<bool>&);
+  void send_out_fragment(std::unique_ptr<dataformats::Fragment>, size_t&, std::atomic<bool>&);
 
 };
 } // namespace trigger


### PR DESCRIPTION
Some fixes to issues in the buffer implementation that I found while testing:

* Replace some raw pointers with std::unique_ptr and make sure they're initialized before use
* Pass std::unique_ptr<Fragment> to output queue: required by the receiver in DF
* Don't initialize Fragment with a nullptr, since it doesn't appear to like that