### PR TITLE
Improve stop/start behaviour in TriggerZipper and TriggerGeneric*

### DIFF
--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -10,6 +10,7 @@
 #define TRIGGER_INCLUDE_TRIGGER_ISSUES_HPP_
 
 #include "appfwk/DAQModule.hpp"
+#include "dataformats/Types.hpp"
 #include "ers/Issue.hpp"
 #include "triggeralgs/Types.hpp"
 
@@ -66,12 +67,17 @@ ERS_DECLARE_ISSUE_BASE(trigger,
                        ((std::string)name),
                        ((std::string)algorithm))
 
+// clang-format off
 ERS_DECLARE_ISSUE_BASE(trigger,
                        TardyOutputError,
                        appfwk::GeneralDAQModuleIssue,
-                       "The " << algorithm << " maker generated a tardy output, which will be dropped.",
+                       "The " << algorithm << " maker generated a tardy output, which will be dropped."
+                       << " Output's time is " << output_time << ", last sent time is " << last_sent_time,
                        ((std::string)name),
-                       ((std::string)algorithm))
+                       ((std::string)algorithm)
+                       ((dataformats::timestamp_t)output_time)
+                       ((dataformats::timestamp_t)last_sent_time))
+// clang-format on
 
 ERS_DECLARE_ISSUE_BASE(trigger,
                        OutOfOrderSets,

--- a/plugins/TriggerZipper.hpp
+++ b/plugins/TriggerZipper.hpp
@@ -81,8 +81,6 @@ public:
         register_command("conf",   &TriggerZipper<TSET>::do_configure);
         register_command("start",  &TriggerZipper<TSET>::do_start);
         register_command("stop",   &TriggerZipper<TSET>::do_stop);
-        register_command("pause",  &TriggerZipper<TSET>::do_pause);
-        register_command("resume", &TriggerZipper<TSET>::do_resume);
         register_command("scrap",  &TriggerZipper<TSET>::do_scrap);
     // clang-format on
   }
@@ -121,14 +119,6 @@ public:
     m_thread.join();
     flush();
   }
-
-  void do_pause(const nlohmann::json& /*pauseobj*/)
-  {
-    // fixme: need a 2nd flag?
-    m_running.store(false);
-  }
-
-  void do_resume(const nlohmann::json& /*resumeobj*/) { m_running.store(true); }
 
   // thread worker
   void worker()

--- a/src/trigger/TimeSliceOutputBuffer.hpp
+++ b/src/trigger/TimeSliceOutputBuffer.hpp
@@ -59,7 +59,7 @@ public:
     }
     for (const T& x : in) {
       if (x.time_start < m_next_window_start) {
-        ers::warning(TardyOutputError(ERS_HERE, m_name, m_algorithm));
+        ers::warning(TardyOutputError(ERS_HERE, m_name, m_algorithm, x.time_start, m_next_window_start));
         // x is discarded
       } else {
         m_buffer.push(x);

--- a/src/trigger/TimeSliceOutputBuffer.hpp
+++ b/src/trigger/TimeSliceOutputBuffer.hpp
@@ -70,6 +70,8 @@ public:
     }
   }
 
+  void reset() { m_next_window_start = 0; }
+
   void set_window_time(const dataformats::timestamp_t window_time)
   {
     m_window_time = window_time;

--- a/src/trigger/TriggerGenericMaker.hpp
+++ b/src/trigger/TriggerGenericMaker.hpp
@@ -144,19 +144,14 @@ private:
   void do_work(std::atomic<bool>& running_flag)
   {
     // Loop until a stop is received
-    while (true) {
+    while (running_flag.load()) {
       // While there are items in the input queue, continue draining even if
       // the running_flag is false, but stop _immediately_ when input is empty
       IN in;
-      bool got = receive(in);
-      if (got) {
+      while (receive(in)) {
         worker.process(in);
-      } else {
-        if (!running_flag.load()) {
-          break;
-        }
       }
-    } // end while(true)
+    }
     worker.drain();
     TLOG() << ": Exiting do_work() method, received " << m_received_count << " inputs and successfully sent "
            << m_sent_count << " outputs. ";


### PR DESCRIPTION
A case we have to be able to handle is taking two runs in one process, ie the daq_application receives commands " ... start 1 stop start 2 stop ...". So that means we have to drain input queues at stop, and reset any relevant state before starting the next run. This PR has some changes to do that in `TriggerZipper` and `TriggerGeneric(Maker|Worker)`. In the latter, I've introduced `reset()` methods which are called at stop, but one could do it other ways.

I've also removed the pause/resume handling from TriggerZipper (the idea of pause/resume is that they're commands issued by a human from, eg the run control, rather than having to do with backpressure, etc, so they just get handled by the MLT).