### PR TITLE
Clear `streams` data structure in `zipper::clear()`

### DIFF
--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -77,6 +77,17 @@ ERS_DECLARE_ISSUE_BASE(trigger,
                        ((std::string)algorithm)
                        ((dataformats::timestamp_t)output_time)
                        ((dataformats::timestamp_t)last_sent_time))
+
+ERS_DECLARE_ISSUE_BASE(trigger,
+                       TardyInputSet,
+                       appfwk::GeneralDAQModuleIssue,
+                       "Tardy input set from region " << region << " element " << element
+                       << ". Set start time " << start_time << " but last sent time " << last_sent_time,
+                       ((std::string)name),
+                       ((uint16_t)region)
+                       ((uint32_t)element)
+                       ((dataformats::timestamp_t)start_time)
+                       ((dataformats::timestamp_t)last_sent_time))
 // clang-format on
 
 ERS_DECLARE_ISSUE_BASE(trigger,

--- a/plugins/zipper.hpp
+++ b/plugins/zipper.hpp
@@ -118,6 +118,7 @@ public:
   {
     std::vector<node_t> got;
     drain_full(std::back_inserter(got));
+    streams.clear();
     origin = 0;
   }
 

--- a/plugins/zipper.hpp
+++ b/plugins/zipper.hpp
@@ -111,6 +111,8 @@ public:
    */
   void set_max_latency(duration_t max_latency) { latency = max_latency; }
 
+  ordering_t get_origin() const { return origin; }
+
   /**
      Clear the zipper merge buffer.
   */


### PR DESCRIPTION
To get stop/start working, we need to also clear the `streams` data structure when we stop. Otherwise we end up with erroneously tardy messages in the subsequent runs. This PR fixes the problem reported by @floriangroetschla and @bieryAtFnal in which trigger rates in the subsequent runs are lower.

I also added an ers::warning when a tardy set is received, and counts of tardy sets per source.