### PR TITLE
Added try/catch around queue push in TPSetReceiver dispatch method

### DIFF
--- a/plugins/TPSetReceiver.cpp
+++ b/plugins/TPSetReceiver.cpp
@@ -160,7 +160,13 @@ TPSetReceiver::dispatch_tpset(ipm::Receiver::Response message)
   auto component = tpset.origin;
   if (m_tpset_output_queues.count(component)) {
     TLOG_DEBUG(10) << get_name() << "Dispatch tpset to queue " << m_tpset_output_queues.at(component)->get_name();
-    m_tpset_output_queues.at(component)->push(tpset, m_queue_timeout);
+    try {
+      m_tpset_output_queues.at(component)->push(tpset, m_queue_timeout);
+    } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
+      std::ostringstream oss_warn;
+      oss_warn << "push to output queue \"" << m_tpset_output_queues.at(component)->get_name() << "\"";
+      ers::warning(dunedaq::appfwk::QueueTimeoutExpired(ERS_HERE, get_name(), oss_warn.str(), m_queue_timeout.count()));
+    }
   } else {
     ers::error(UnknownGeoID(ERS_HERE, component));
   }


### PR DESCRIPTION
While running some stress tests of the system, I noticed a crash of the trigger app that I believe was caused by an uncaught exception when trying to push a received TPSet onto the appropriate queue.  

This change simply adds a try/catch block around the queue push method, and with the change I no longer see the crash.