### PR TITLE
check if run is paused before complaining about inhibitted triggers

### DIFF
--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -206,14 +206,14 @@ ModuleLevelTrigger::send_trigger_decisions()
         m_td_queue_timeout_expired_err_count++;
       }
 
-    } else if (!tokens_allow_triggers) {
+    } else if (m_paused.load()) {
+      ++m_td_paused_count;
+      TLOG_DEBUG(1) << "Triggers are paused. Not sending a TriggerDecision ";
+    } else {
       ers::warning(TriggerInhibited(ERS_HERE, m_run_number));
       TLOG_DEBUG(1) << "There are no Tokens available. Not sending a TriggerDecision for candidate timestamp "
                     << tc.time_candidate;
       m_td_inhibited_count++;
-    }else {
-      ++m_td_paused_count;
-      TLOG_DEBUG(1) << "Triggers are paused. Not sending a TriggerDecision ";
     }
     m_td_total_count++;
   }


### PR DESCRIPTION
In some of the integration tests that I've run, I've noticed complaints about "trigger is inhibited" even when the run is paused.
That seems backward to me.  And, it generates spurious complaints that confused the integration test logfile checking.
It seems to me that if the run is paused, then we shouldn't complain about inhibits.
This code change reverses the order of the tests when such checks are made.