### PR TITLE
Use trigger objects from detdataformats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,8 @@ daq_add_application( taset_serialization taset_serialization.cxx TEST LINK_LIBRA
 daq_add_unit_test(TokenManager_test              LINK_LIBRARIES trigger)
 daq_add_unit_test(TxSet_test                     LINK_LIBRARIES trigger)
 daq_add_unit_test(BufferManager_test             LINK_LIBRARIES trigger)
-daq_add_unit_test(TriggerZipper_test LINK_LIBRARIES trigger)
+daq_add_unit_test(TriggerZipper_test             LINK_LIBRARIES trigger)
+daq_add_unit_test(TriggerObjectOverlay_test      LINK_LIBRARIES trigger)
 
 ##############################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ find_package(utilities REQUIRED)
 find_package(networkmanager REQUIRED)
 find_package(daqdataformats REQUIRED)
 find_package(detdataformats REQUIRED)
+find_package(hdf5libs REQUIRED)
+find_package(CLI11 REQUIRED)
 
 ##############################################################################
 # Main library
@@ -98,6 +100,7 @@ daq_add_plugin(TASetNQ duneNetworkQueue LINK_LIBRARIES trigger nwqueueadapters::
 
 daq_add_application( set_serialization_speed set_serialization_speed.cxx TEST LINK_LIBRARIES trigger)
 daq_add_application( taset_serialization taset_serialization.cxx TEST LINK_LIBRARIES trigger)
+daq_add_application( check_fragment_TPs check_fragment_TPs.cxx TEST LINK_LIBRARIES trigger hdf5libs::hdf5libs CLI11::CLI11)
 
 ##############################################################################
 # Unit Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,19 @@ find_package(nwqueueadapters REQUIRED)
 find_package(utilities REQUIRED)
 find_package(networkmanager REQUIRED)
 find_package(daqdataformats REQUIRED)
+find_package(detdataformats REQUIRED)
 
 ##############################################################################
 # Main library
 
-daq_add_library(TokenManager.cpp LINK_LIBRARIES appfwk::appfwk logging::logging dfmessages::dfmessages triggeralgs::triggeralgs utilities::utilities)
+daq_add_library(TokenManager.cpp
+  LINK_LIBRARIES
+  appfwk::appfwk
+  logging::logging
+  dfmessages::dfmessages
+  triggeralgs::triggeralgs
+  utilities::utilities
+  detdataformats::detdataformats)
 
 ##############################################################################
 # Codegen

--- a/cmake/triggerConfig.cmake.in
+++ b/cmake/triggerConfig.cmake.in
@@ -12,6 +12,7 @@ find_dependency(dfmessages)
 find_dependency(timinglibs)
 find_dependency(nwqueueadapters)
 find_dependency(daqdataformats)
+find_dependency(detdataformats)
 find_dependency(networkmanager)
 find_dependency(utilities)
 

--- a/cmake/triggerConfig.cmake.in
+++ b/cmake/triggerConfig.cmake.in
@@ -15,6 +15,8 @@ find_dependency(daqdataformats)
 find_dependency(detdataformats)
 find_dependency(networkmanager)
 find_dependency(utilities)
+find_dependency(hdf5libs)
+find_dependency(CLI11)
 
 if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 

--- a/include/trigger/Set.hpp
+++ b/include/trigger/Set.hpp
@@ -11,7 +11,7 @@
 
 #include "daqdataformats/GeoID.hpp"
 #include "daqdataformats/Types.hpp"
-#include "triggeralgs/Types.hpp"
+#include "detdataformats/trigger/Types.hpp"
 
 #include <cstdint>
 #include <vector>

--- a/include/trigger/TPSet.hpp
+++ b/include/trigger/TPSet.hpp
@@ -13,11 +13,11 @@
 #include "serialization/Serialization.hpp"
 #include "trigger/Set.hpp"
 #include "trigger/TriggerPrimitive_serialization.hpp"
-#include "triggeralgs/TriggerPrimitive.hpp"
+#include "detdataformats/trigger/TriggerPrimitive.hpp"
 
 namespace dunedaq::trigger {
 
-using TPSet = Set<triggeralgs::TriggerPrimitive>;
+using TPSet = Set<detdataformats::trigger::TriggerPrimitive>;
 
 } // namespace dunedaq::trigger
 

--- a/include/trigger/TriggerActivity_serialization.hpp
+++ b/include/trigger/TriggerActivity_serialization.hpp
@@ -17,6 +17,22 @@ MSGPACK_ADD_ENUM(triggeralgs::TriggerActivity::Type)
 
 MSGPACK_ADD_ENUM(triggeralgs::TriggerActivity::Algorithm)
 
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(dunedaq::detdataformats::trigger,
+                                 TriggerActivityData,
+                                 time_start,
+                                 time_end,
+                                 time_peak,
+                                 time_activity,
+                                 channel_start,
+                                 channel_end,
+                                 channel_peak,
+                                 adc_integral,
+                                 adc_peak,
+                                 detid,
+                                 type,
+                                 algorithm,
+                                 version)
+
 DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs,
                                  TriggerActivity,
                                  time_start,
@@ -32,6 +48,6 @@ DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs,
                                  type,
                                  algorithm,
                                  version,
-                                 tp_list)
+                                 inputs)
 
 #endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERACTIVITY_SERIALIZATION_HPP_

--- a/include/trigger/TriggerCandidate_serialization.hpp
+++ b/include/trigger/TriggerCandidate_serialization.hpp
@@ -21,6 +21,7 @@ MSGPACK_ADD_ENUM(triggeralgs::TriggerCandidate::Type)
 
 MSGPACK_ADD_ENUM(triggeralgs::TriggerCandidate::Algorithm)
 
+                                 
 DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs,
                                  TriggerCandidate,
                                  time_start,
@@ -30,6 +31,6 @@ DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs,
                                  type,
                                  algorithm,
                                  version,
-                                 ta_list)
+                                 inputs)
 
 #endif // TRIGGER_INCLUDE_TRIGGER_TRIGGERCANDIDATE_SERIALIZATION_HPP_

--- a/include/trigger/TriggerPrimitive_serialization.hpp
+++ b/include/trigger/TriggerPrimitive_serialization.hpp
@@ -11,13 +11,13 @@
 
 #include "serialization/Serialization.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
-#include "triggeralgs/Types.hpp"
+#include "detdataformats/trigger/Types.hpp"
 
-MSGPACK_ADD_ENUM(triggeralgs::TriggerPrimitive::Type)
+MSGPACK_ADD_ENUM(dunedaq::detdataformats::trigger::TriggerPrimitive::Type)
 
-MSGPACK_ADD_ENUM(triggeralgs::TriggerPrimitive::Algorithm)
+MSGPACK_ADD_ENUM(dunedaq::detdataformats::trigger::TriggerPrimitive::Algorithm)
 
-DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(triggeralgs,
+DUNE_DAQ_SERIALIZE_NON_INTRUSIVE(dunedaq::detdataformats::trigger,
                                  TriggerPrimitive,
                                  time_start,
                                  time_peak,

--- a/plugins/RandomTriggerCandidateMaker.cpp
+++ b/plugins/RandomTriggerCandidateMaker.cpp
@@ -25,7 +25,7 @@
 
 #include "appfwk/DAQModuleHelper.hpp"
 #include "appfwk/app/Nljs.hpp"
-#include "triggeralgs/Types.hpp"
+#include "detdataformats/trigger/Types.hpp"
 
 #include <algorithm>
 #include <cassert>

--- a/plugins/RandomTriggerCandidateMaker.cpp
+++ b/plugins/RandomTriggerCandidateMaker.cpp
@@ -121,7 +121,6 @@ RandomTriggerCandidateMaker::create_candidate(dfmessages::timestamp_t timestamp)
   candidate.detid = { 0 };
   candidate.type = triggeralgs::TriggerCandidate::Type::kRandom;
   candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
-  candidate.version = 0;
 
   return candidate;
 }

--- a/plugins/TPSetBufferCreator.cpp
+++ b/plugins/TPSetBufferCreator.cpp
@@ -150,8 +150,11 @@ TPSetBufferCreator::convert_to_fragment(TPSetBuffer::DataRequestOutput ds_output
   
   for(auto const& tpset : ds_output.txsets_in_window) {
     for(auto const& tp: tpset.objects) {
-      *tp_out = tp;
-      ++tp_out;
+      if(tp.time_start >= input_data_request.request_information.window_begin &&
+         tp.time_start <= input_data_request.request_information.window_end) {
+        *tp_out = tp;
+        ++tp_out;
+      }
     }
   }
   

--- a/plugins/TPSetBufferCreator.cpp
+++ b/plugins/TPSetBufferCreator.cpp
@@ -102,7 +102,7 @@ TPSetBufferCreator::do_stop(const nlohmann::json& /*args*/)
     while (it != m_dr_on_hold.end()) {
 
       requested_tpset.txsets_in_window = it->second;
-      std::unique_ptr<daqdataformats::Fragment> frag_out = convert_to_fragment(requested_tpset, it->first);
+      std::unique_ptr<daqdataformats::Fragment> frag_out = convert_to_fragment(requested_tpset.txsets_in_window, it->first);
       TLOG() << get_name() << ": Sending late requested data (" << (it->first).request_information.window_begin << ", "
              << (it->first).request_information.window_end << "), containing "
              << requested_tpset.txsets_in_window.size() << " TPSets.";
@@ -311,7 +311,7 @@ TPSetBufferCreator::do_work(std::atomic<bool>& running_flag)
                     << input_data_request.request_information.window_begin << ", "
                     << input_data_request.request_information.window_end << ")";
 
-      auto frag_out = convert_to_fragment(requested_tpset, input_data_request);
+      auto frag_out = convert_to_fragment(requested_tpset.txsets_in_window, input_data_request);
 
       switch (requested_tpset.ds_outcome) {
         case TPSetBuffer::kEmpty:

--- a/plugins/TPSetBufferCreator.cpp
+++ b/plugins/TPSetBufferCreator.cpp
@@ -133,31 +133,30 @@ TPSetBufferCreator::do_scrap(const nlohmann::json& /*args*/)
 }
 
 std::unique_ptr<daqdataformats::Fragment>
-TPSetBufferCreator::convert_to_fragment(std::vector<TPSet>& tpsets,
-                                        dfmessages::DataRequest input_data_request)
+TPSetBufferCreator::convert_to_fragment(std::vector<TPSet>& tpsets, dfmessages::DataRequest input_data_request)
 {
 
   using detdataformats::trigger::TriggerPrimitive;
   size_t n_tps = 0;
-  for(auto const& tpset: tpsets) {
+  for (auto const& tpset : tpsets) {
     n_tps += tpset.objects.size();
   }
-  
-  size_t payload_n_bytes = sizeof(TriggerPrimitive)*n_tps;
+
+  size_t payload_n_bytes = sizeof(TriggerPrimitive) * n_tps;
 
   auto payload = std::make_unique<uint8_t[]>(payload_n_bytes);
   TriggerPrimitive* tp_out = reinterpret_cast<TriggerPrimitive*>(payload.get());
-  
-  for(auto const& tpset : tpsets) {
-    for(auto const& tp: tpset.objects) {
-      if(tp.time_start >= input_data_request.request_information.window_begin &&
-         tp.time_start <= input_data_request.request_information.window_end) {
+
+  for (auto const& tpset : tpsets) {
+    for (auto const& tp : tpset.objects) {
+      if (tp.time_start >= input_data_request.request_information.window_begin &&
+          tp.time_start <= input_data_request.request_information.window_end) {
         *tp_out = tp;
         ++tp_out;
       }
     }
   }
-  
+
   auto ret = std::make_unique<daqdataformats::Fragment>(payload.get(), payload_n_bytes);
   auto& frag = *ret.get();
 
@@ -176,7 +175,6 @@ TPSetBufferCreator::convert_to_fragment(std::vector<TPSet>& tpsets,
 
   return ret;
 }
-
 
 void
 TPSetBufferCreator::send_out_fragment(std::unique_ptr<daqdataformats::Fragment> frag_out,
@@ -281,7 +279,8 @@ TPSetBufferCreator::do_work(std::atomic<bool>& running_flag)
               input_tpset
                 .start_time) { // If more TPSet aren't expected to arrive then push and remove pending data request
             requested_tpset.txsets_in_window = std::move(it->second);
-            std::unique_ptr<daqdataformats::Fragment> frag_out = convert_to_fragment(requested_tpset.txsets_in_window, it->first);
+            std::unique_ptr<daqdataformats::Fragment> frag_out =
+              convert_to_fragment(requested_tpset.txsets_in_window, it->first);
             TLOG() << get_name() << ": Sending late requested data (" << (it->first).request_information.window_begin
                    << ", " << (it->first).request_information.window_end << "), containing "
                    << requested_tpset.txsets_in_window.size() << " TPSets.";

--- a/plugins/TPSetBufferCreator.hpp
+++ b/plugins/TPSetBufferCreator.hpp
@@ -95,7 +95,7 @@ private:
   std::map<dfmessages::DataRequest, std::vector<trigger::TPSet>, DataRequestComp>
     m_dr_on_hold; ///< Holds data request when data has not arrived in the buffer yet
 
-  std::unique_ptr<daqdataformats::Fragment> convert_to_fragment(TPSetBuffer::DataRequestOutput,
+  std::unique_ptr<daqdataformats::Fragment> convert_to_fragment(std::vector<TPSet>&,
                                                                 dfmessages::DataRequest);
 
   void send_out_fragment(std::unique_ptr<daqdataformats::Fragment>, std::string, size_t&, std::atomic<bool>&);

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -47,7 +47,6 @@ TimingTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEve
   candidate.type = triggeralgs::TriggerCandidate::Type::kTiming;
 
   candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
-  candidate.version = 0;
   candidate.inputs = {};
 
   return candidate;

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "TimingTriggerCandidateMaker.hpp"
-#include "triggeralgs/Types.hpp"
+#include "detdataformats/trigger/Types.hpp"
 #include "networkmanager/NetworkManager.hpp"
 
 #include <string>
@@ -48,7 +48,7 @@ TimingTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEve
 
   candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
   candidate.version = 0;
-  candidate.ta_list = {};
+  candidate.inputs = {};
 
   return candidate;
 }

--- a/src/trigger/TriggerGenericMaker.hpp
+++ b/src/trigger/TriggerGenericMaker.hpp
@@ -23,7 +23,7 @@
 #include "daqdataformats/GeoID.hpp"
 
 #include "logging/Logging.hpp"
-#include "triggeralgs/Types.hpp"
+#include "detdataformats/trigger/Types.hpp"
 
 #include <algorithm>
 #include <memory>

--- a/test/apps/check_fragment_TPs.cxx
+++ b/test/apps/check_fragment_TPs.cxx
@@ -1,0 +1,114 @@
+/**
+ * @file check_fragment_TPs.cxx Read TP fragments from file and check that they have start times within the request window
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#include "CLI/CLI.hpp"
+
+#include "detdataformats/trigger/TriggerPrimitive.hpp"
+#include "hdf5libs/DAQDecoder.hpp"
+
+#include <daqdataformats/Fragment.hpp>
+#include <daqdataformats/FragmentHeader.hpp>
+#include <daqdataformats/TriggerRecordHeader.hpp>
+#include <daqdataformats/Types.hpp>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <regex>
+
+// A little struct to hold a TriggerRecordHeader along with the
+// corresponding TP fragments
+struct MyTriggerRecord
+{
+  std::unique_ptr<dunedaq::daqdataformats::TriggerRecordHeader> header;
+  std::vector<std::unique_ptr<dunedaq::daqdataformats::Fragment>> fragments;
+};
+
+int
+main(int argc, char** argv)
+{
+  CLI::App app{ "App description" };
+
+  std::string filename;
+  app.add_option("-f,--file", filename, "Input HDF5 file");
+
+  CLI11_PARSE(app, argc, argv);
+
+  // Map from trigger number to struct of header/fragments
+  std::map<int, MyTriggerRecord> trigger_records;
+
+  std::regex header_regex("^//TriggerRecord([0-9]+)/TriggerRecordHeader$", std::regex::extended);
+  std::regex trigger_fragment_regex("^//TriggerRecord([0-9]+)/Trigger/Region[0-9]+/Element[0-9]+$",
+                                    std::regex::extended);
+
+  unsigned int num_events;
+  dunedaq::hdf5libs::DAQDecoder decoder(filename, num_events);
+
+  // Populate the map with the TRHs and DS fragments
+  auto datasets = decoder.get_datasets();
+  for (auto const& dataset : datasets) {
+    // std::cout << dataset << std::endl;
+    std::smatch m;
+    if (std::regex_match(dataset, m, header_regex)) {
+      int trigger_number = std::atoi(m[1].str().c_str());
+      trigger_records[trigger_number].header = decoder.get_trh_ptr(dataset);
+      // std::cout << "Header match: " << dataset << " m[1] = " <<  << std::endl;
+    }
+    if (std::regex_match(dataset, m, trigger_fragment_regex)) {
+      int trigger_number = std::atoi(m[1].str().c_str());
+      trigger_records[trigger_number].fragments.push_back(decoder.get_frag_ptr(dataset));
+      // std::cout << "Trigger fragment match: " << dataset << std::endl;
+    }
+  }
+
+  int n_failures = 0;
+
+  using dunedaq::detdataformats::trigger::TriggerPrimitive;
+  for (auto const& [trigger_number, record] : trigger_records) {
+    std::cout << "Trigger number " << trigger_number << " with TRH pointer " << record.header.get() << " and "
+              << record.fragments.size() << " fragments" << std::endl;
+
+    // Find the window start and end requested for this trigger
+    // record. In principle the request windows for each data
+    // selection component could be different, but we'll assume
+    // they're the same for now, because matching up the component
+    // request to the fragment is too difficult
+    size_t n_requests = record.header->get_num_requested_components();
+    dunedaq::daqdataformats::timestamp_t window_begin = 0, window_end = 0;
+    for (size_t i = 0; i < n_requests; ++i) {
+      auto request = record.header->at(i);
+      if (request.component.system_type == dunedaq::daqdataformats::GeoID::SystemType::kDataSelection) {
+        window_begin = request.window_begin;
+        window_end = request.window_end;
+      }
+    }
+    if (window_begin == 0 || window_end == 0) {
+      // We didn't find a component request for a dataselection item, so skip
+      continue;
+    }
+    // Check that each primitive in each fragment falls within the request window
+    for (auto const& frag : record.fragments) {
+      const size_t n_prim =
+        (frag->get_size() - sizeof(dunedaq::daqdataformats::FragmentHeader)) / sizeof(TriggerPrimitive);
+      std::cout << "  Fragment has " << n_prim << " primitives" << std::endl;
+      const TriggerPrimitive* prim = reinterpret_cast<TriggerPrimitive*>(frag->get_data());
+      for (size_t i = 0; i < n_prim; ++i) {
+        if (prim->time_start < window_begin || prim->time_start > window_end) {
+          std::cout << "Primitive with time_start " << prim->time_start << " is outside request window of ("
+                    << window_begin << ", " << window_end << ")" << std::endl;
+          ++n_failures;
+        }
+        ++prim;
+      }
+    }
+  }
+  if (n_failures > 0) {
+    std::cout << "Found " << n_failures << " TPs outside window in " << num_events << " trigger records" << std::endl;
+  } else {
+    std::cout << "Test passed" << std::endl;
+  }
+  return (n_failures != 0);
+}

--- a/test/apps/set_serialization_speed.cxx
+++ b/test/apps/set_serialization_speed.cxx
@@ -11,7 +11,7 @@
 #include "trigger/TASet.hpp"
 #include "trigger/TPSet.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
-#include "triggeralgs/Types.hpp"
+#include "detdataformats/trigger/Types.hpp"
 
 #include <chrono>
 #include <iostream>

--- a/test/apps/set_serialization_speed.cxx
+++ b/test/apps/set_serialization_speed.cxx
@@ -53,7 +53,6 @@ time_serialization(int tps_per_set)
       tp.detid = 1;
       tp.type = triggeralgs::TriggerPrimitive::Type::kUnknown;
       tp.algorithm = triggeralgs::TriggerPrimitive::Algorithm::kTPCDefault;
-      tp.version = 1;
       tp.flag = 1;
 
       set.objects.push_back(tp);

--- a/test/plugins/IntervalTCCreator.cpp
+++ b/test/plugins/IntervalTCCreator.cpp
@@ -24,7 +24,7 @@
 
 #include "appfwk/DAQModuleHelper.hpp"
 #include "appfwk/app/Nljs.hpp"
-#include "triggeralgs/Types.hpp"
+#include "detdataformats/trigger/Types.hpp"
 
 #include <algorithm>
 #include <cassert>

--- a/test/plugins/IntervalTCCreator.cpp
+++ b/test/plugins/IntervalTCCreator.cpp
@@ -117,7 +117,7 @@ IntervalTCCreator::create_candidate(dfmessages::timestamp_t timestamp)
   candidate.detid = { 1 };
   candidate.type = triggeralgs::TriggerCandidate::Type::kTiming;
   candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
-  candidate.version = 1;
+
 
   return candidate;
 }

--- a/unittest/TriggerObjectOverlay_test.cxx
+++ b/unittest/TriggerObjectOverlay_test.cxx
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(TriggerCandidateOverlay_in_out) {
 
   write_overlay(candidate, buffer);
 
-  const TriggerCandidateOverlay& candidate_overlay = *reinterpret_cast<const TriggerCandidateOverlay*>(buffer);
+  const TriggerCandidate& candidate_overlay = *reinterpret_cast<const TriggerCandidate*>(buffer);
   BOOST_CHECK_EQUAL(candidate.time_start,     candidate_overlay.data.time_start);
   
   triggeralgs::TriggerCandidate candidate_read = triggeralgs::read_overlay_from_buffer<triggeralgs::TriggerCandidate>(buffer);
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(TriggerActivityOverlay_in_out) {
 
   write_overlay(activity, buffer);
 
-  TriggerActivity activity_read = triggeralgs::read_overlay_from_buffer<TriggerActivity>(buffer);
+  triggeralgs::TriggerActivity activity_read = triggeralgs::read_overlay_from_buffer<triggeralgs::TriggerActivity>(buffer);
 
   BOOST_CHECK_EQUAL(activity.time_start,     activity_read.time_start);
   BOOST_CHECK_EQUAL(activity.time_end,       activity_read.time_end);

--- a/unittest/TriggerObjectOverlay_test.cxx
+++ b/unittest/TriggerObjectOverlay_test.cxx
@@ -1,0 +1,179 @@
+/**
+ * @file TriggerObjectoverlay_test.cxx TriggerObjectoverlay class Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "detdataformats/trigger/TriggerActivityData.hpp"
+#include "detdataformats/trigger/TriggerCandidate.hpp"
+#include "detdataformats/trigger/TriggerPrimitive.hpp"
+#include "detdataformats/trigger/TriggerObjectOverlay.hpp"
+
+/**
+ * @brief Name of this test module
+ */
+#define BOOST_TEST_MODULE TriggerObjectOverlay_test // NOLINT
+
+#include "boost/test/data/test_case.hpp"
+#include "boost/test/unit_test.hpp"
+
+using namespace dunedaq::detdataformats::trigger;
+
+BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerCandidate)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerCandidateData)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerActivityData)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerPrimitive::Algorithm)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerActivityData::Algorithm)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerCandidateData::Algorithm)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerPrimitive::Type)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerActivityData::Type)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerCandidateData::Type)
+
+BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+
+BOOST_AUTO_TEST_CASE(TriggerCandidateOverlay_in_out) {
+  TriggerCandidate candidate;
+  candidate.time_start = 5;
+  candidate.time_end = 6;
+  candidate.time_candidate = 7;
+  candidate.detid = 8;
+  candidate.type = TriggerCandidateData::Type::kSupernova;
+  candidate.algorithm = TriggerCandidateData::Algorithm::kPrescale;
+  candidate.version = 1;
+
+  const size_t n_activity = 5;
+  
+  for(size_t i=0; i<n_activity; ++i){
+    TriggerActivityData activity;
+    activity.time_start = i;
+    activity.time_end = i+1;
+    activity.time_peak = i+2;
+
+    activity.channel_start = i;
+    activity.channel_end = 2*i;
+    activity.channel_peak = 3*i;
+    activity.adc_integral =  i;
+    activity.adc_peak = 2*i;
+    activity.detid = i;
+    activity.type = TriggerActivityData::Type::kTPC;
+    activity.algorithm = TriggerActivityData::Algorithm::kSupernova;
+    activity.version = 1;
+
+    candidate.inputs.push_back(activity);
+  }
+
+  size_t nbytes = get_overlay_nbytes(candidate);
+
+  char* buffer = new char[nbytes];
+
+  write_overlay(candidate, buffer);
+
+  const TriggerCandidateOverlay& candidate_overlay = *reinterpret_cast<const TriggerCandidateOverlay*>(buffer);
+  BOOST_CHECK_EQUAL(candidate.time_start,     candidate_overlay.data.time_start);
+  
+  TriggerCandidate candidate_read = read_overlay_from_buffer<TriggerCandidate>(buffer);
+
+  BOOST_CHECK_EQUAL(candidate.time_start,     candidate_read.time_start);
+  BOOST_CHECK_EQUAL(candidate.time_end,       candidate_read.time_end);
+  BOOST_CHECK_EQUAL(candidate.time_candidate, candidate_read.time_candidate);
+  BOOST_CHECK_EQUAL(candidate.detid,          candidate_read.detid);
+  BOOST_CHECK_EQUAL(candidate.type,           candidate_read.type);
+  BOOST_CHECK_EQUAL(candidate.algorithm,      candidate_read.algorithm);
+  BOOST_CHECK_EQUAL(candidate.version,        candidate_read.version);
+
+  for(size_t i=0; i<n_activity; ++i){
+    BOOST_CHECK_EQUAL(candidate.inputs[i].time_start,    candidate_read.inputs[i].time_start);
+    BOOST_CHECK_EQUAL(candidate.inputs[i].time_end,      candidate_read.inputs[i].time_end);
+    BOOST_CHECK_EQUAL(candidate.inputs[i].time_peak,     candidate_read.inputs[i].time_peak);
+    BOOST_CHECK_EQUAL(candidate.inputs[i].channel_start, candidate_read.inputs[i].channel_start);
+    BOOST_CHECK_EQUAL(candidate.inputs[i].channel_end,   candidate_read.inputs[i].channel_end);
+    BOOST_CHECK_EQUAL(candidate.inputs[i].channel_peak,  candidate_read.inputs[i].channel_peak);
+    BOOST_CHECK_EQUAL(candidate.inputs[i].adc_integral,  candidate_read.inputs[i].adc_integral);
+    BOOST_CHECK_EQUAL(candidate.inputs[i].adc_peak,      candidate_read.inputs[i].adc_peak);
+    BOOST_CHECK_EQUAL(candidate.inputs[i].detid,         candidate_read.inputs[i].detid);
+    BOOST_CHECK_EQUAL(candidate.inputs[i].type,          candidate_read.inputs[i].type);
+    BOOST_CHECK_EQUAL(candidate.inputs[i].algorithm,     candidate_read.inputs[i].algorithm);
+    BOOST_CHECK_EQUAL(candidate.inputs[i].version,       candidate_read.inputs[i].version);
+  }
+
+  delete[] buffer;
+}
+
+BOOST_AUTO_TEST_CASE(TriggerActivityOverlay_in_out) {
+  TriggerActivity activity;
+  activity.time_start = 1;
+  activity.time_end = 2;
+  activity.time_peak = 3;
+  
+  activity.channel_start = 4;
+  activity.channel_end = 5;
+  activity.channel_peak = 6;
+  activity.adc_integral = 7;
+  activity.adc_peak = 8;
+  activity.detid = 9;
+  activity.type = TriggerActivityData::Type::kTPC;
+  activity.algorithm = TriggerActivityData::Algorithm::kSupernova;
+  activity.version = 1;
+
+  const size_t n_primitive = 5;
+  
+  for(size_t i=0; i<n_primitive; ++i){
+    TriggerPrimitive primitive;
+
+    primitive.time_start = i;
+    primitive.time_peak = i+1;
+    primitive.time_over_threshold = i+2;
+    primitive.channel = i+3;
+    primitive.adc_integral = i+4; // NOLINT(build/unsigned)
+    primitive.adc_peak = i+5;     // NOLINT(build/unsigned)
+    primitive.detid = i+65;
+    primitive.type = TriggerPrimitive::Type::kPDS;
+    primitive.algorithm = TriggerPrimitive::Algorithm::kTPCDefault;
+    primitive.version = 1;      // NOLINT(build/unsigned)
+    primitive.flag = 1;
+
+    activity.inputs.push_back(primitive);
+  }
+
+  size_t nbytes = get_overlay_nbytes(activity);
+
+  char* buffer = new char[nbytes];
+
+  write_overlay(activity, buffer);
+
+  TriggerActivity activity_read = read_overlay_from_buffer<TriggerActivity>(buffer);
+
+  BOOST_CHECK_EQUAL(activity.time_start,     activity_read.time_start);
+  BOOST_CHECK_EQUAL(activity.time_end,       activity_read.time_end);
+  BOOST_CHECK_EQUAL(activity.time_peak,      activity_read.time_peak);
+  BOOST_CHECK_EQUAL(activity.time_activity,  activity_read.time_activity);
+  BOOST_CHECK_EQUAL(activity.channel_start,  activity_read.channel_start);
+  BOOST_CHECK_EQUAL(activity.channel_end,    activity_read.channel_end);
+  BOOST_CHECK_EQUAL(activity.channel_peak,   activity_read.channel_peak);
+  BOOST_CHECK_EQUAL(activity.adc_integral,   activity_read.adc_integral);
+  BOOST_CHECK_EQUAL(activity.adc_peak,       activity_read.adc_peak);
+  BOOST_CHECK_EQUAL(activity.detid,          activity_read.detid);
+  BOOST_CHECK_EQUAL(activity.type,           activity_read.type);
+  BOOST_CHECK_EQUAL(activity.algorithm,      activity_read.algorithm);
+  BOOST_CHECK_EQUAL(activity.version,        activity_read.version);
+
+  for(size_t i=0; i<n_primitive; ++i){
+    BOOST_CHECK_EQUAL(activity.inputs[i].time_start,          activity_read.inputs[i].time_start);
+    BOOST_CHECK_EQUAL(activity.inputs[i].time_over_threshold, activity_read.inputs[i].time_over_threshold);
+    BOOST_CHECK_EQUAL(activity.inputs[i].time_peak,           activity_read.inputs[i].time_peak);
+    BOOST_CHECK_EQUAL(activity.inputs[i].channel,             activity_read.inputs[i].channel);
+    BOOST_CHECK_EQUAL(activity.inputs[i].adc_integral,        activity_read.inputs[i].adc_integral);
+    BOOST_CHECK_EQUAL(activity.inputs[i].adc_peak,            activity_read.inputs[i].adc_peak);
+    BOOST_CHECK_EQUAL(activity.inputs[i].detid,               activity_read.inputs[i].detid);
+    BOOST_CHECK_EQUAL(activity.inputs[i].type,                activity_read.inputs[i].type);
+    BOOST_CHECK_EQUAL(activity.inputs[i].algorithm,           activity_read.inputs[i].algorithm);
+    BOOST_CHECK_EQUAL(activity.inputs[i].version,             activity_read.inputs[i].version);
+    BOOST_CHECK_EQUAL(activity.inputs[i].flag,                activity_read.inputs[i].flag);
+  }
+
+  delete[] buffer;
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/TriggerObjectOverlay_test.cxx
+++ b/unittest/TriggerObjectOverlay_test.cxx
@@ -6,10 +6,10 @@
  * received with this code.
  */
 
-#include "detdataformats/trigger/TriggerActivityData.hpp"
-#include "detdataformats/trigger/TriggerCandidate.hpp"
-#include "detdataformats/trigger/TriggerPrimitive.hpp"
-#include "detdataformats/trigger/TriggerObjectOverlay.hpp"
+#include "triggeralgs/TriggerActivity.hpp"
+#include "triggeralgs/TriggerCandidate.hpp"
+#include "triggeralgs/TriggerPrimitive.hpp"
+#include "triggeralgs/TriggerObjectOverlay.hpp"
 
 /**
  * @brief Name of this test module
@@ -19,9 +19,11 @@
 #include "boost/test/data/test_case.hpp"
 #include "boost/test/unit_test.hpp"
 
+using triggeralgs::TriggerActivity;
+
 using namespace dunedaq::detdataformats::trigger;
 
-BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerCandidate)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(triggeralgs::TriggerCandidate)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerCandidateData)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerActivityData)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerPrimitive::Algorithm)
@@ -34,7 +36,7 @@ BOOST_TEST_DONT_PRINT_LOG_VALUE(TriggerCandidateData::Type)
 BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 
 BOOST_AUTO_TEST_CASE(TriggerCandidateOverlay_in_out) {
-  TriggerCandidate candidate;
+  triggeralgs::TriggerCandidate candidate;
   candidate.time_start = 5;
   candidate.time_end = 6;
   candidate.time_candidate = 7;
@@ -73,7 +75,7 @@ BOOST_AUTO_TEST_CASE(TriggerCandidateOverlay_in_out) {
   const TriggerCandidateOverlay& candidate_overlay = *reinterpret_cast<const TriggerCandidateOverlay*>(buffer);
   BOOST_CHECK_EQUAL(candidate.time_start,     candidate_overlay.data.time_start);
   
-  TriggerCandidate candidate_read = read_overlay_from_buffer<TriggerCandidate>(buffer);
+  triggeralgs::TriggerCandidate candidate_read = triggeralgs::read_overlay_from_buffer<triggeralgs::TriggerCandidate>(buffer);
 
   BOOST_CHECK_EQUAL(candidate.time_start,     candidate_read.time_start);
   BOOST_CHECK_EQUAL(candidate.time_end,       candidate_read.time_end);
@@ -102,7 +104,7 @@ BOOST_AUTO_TEST_CASE(TriggerCandidateOverlay_in_out) {
 }
 
 BOOST_AUTO_TEST_CASE(TriggerActivityOverlay_in_out) {
-  TriggerActivity activity;
+  triggeralgs::TriggerActivity activity;
   activity.time_start = 1;
   activity.time_end = 2;
   activity.time_peak = 3;
@@ -120,7 +122,7 @@ BOOST_AUTO_TEST_CASE(TriggerActivityOverlay_in_out) {
   const size_t n_primitive = 5;
   
   for(size_t i=0; i<n_primitive; ++i){
-    TriggerPrimitive primitive;
+    triggeralgs::TriggerPrimitive primitive;
 
     primitive.time_start = i;
     primitive.time_peak = i+1;
@@ -143,7 +145,7 @@ BOOST_AUTO_TEST_CASE(TriggerActivityOverlay_in_out) {
 
   write_overlay(activity, buffer);
 
-  TriggerActivity activity_read = read_overlay_from_buffer<TriggerActivity>(buffer);
+  TriggerActivity activity_read = triggeralgs::read_overlay_from_buffer<TriggerActivity>(buffer);
 
   BOOST_CHECK_EQUAL(activity.time_start,     activity_read.time_start);
   BOOST_CHECK_EQUAL(activity.time_end,       activity_read.time_end);

--- a/unittest/TriggerObjectOverlay_test.cxx
+++ b/unittest/TriggerObjectOverlay_test.cxx
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(TriggerCandidateOverlay_in_out) {
   candidate.detid = 8;
   candidate.type = TriggerCandidateData::Type::kSupernova;
   candidate.algorithm = TriggerCandidateData::Algorithm::kPrescale;
-  candidate.version = 1;
+
 
   const size_t n_activity = 5;
   
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(TriggerCandidateOverlay_in_out) {
     activity.detid = i;
     activity.type = TriggerActivityData::Type::kTPC;
     activity.algorithm = TriggerActivityData::Algorithm::kSupernova;
-    activity.version = 1;
+
 
     candidate.inputs.push_back(activity);
   }
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(TriggerActivityOverlay_in_out) {
   activity.detid = 9;
   activity.type = TriggerActivityData::Type::kTPC;
   activity.algorithm = TriggerActivityData::Algorithm::kSupernova;
-  activity.version = 1;
+
 
   const size_t n_primitive = 5;
   
@@ -133,7 +133,6 @@ BOOST_AUTO_TEST_CASE(TriggerActivityOverlay_in_out) {
     primitive.detid = i+65;
     primitive.type = TriggerPrimitive::Type::kPDS;
     primitive.algorithm = TriggerPrimitive::Algorithm::kTPCDefault;
-    primitive.version = 1;      // NOLINT(build/unsigned)
     primitive.flag = 1;
 
     activity.inputs.push_back(primitive);


### PR DESCRIPTION
This PR updates `trigger` to use the trigger objects defined in detdataformats, via `triggeralgs`. The detdataformats changes are in https://github.com/DUNE-DAQ/detdataformats/pull/9 and the `triggeralgs` changes are in https://github.com/DUNE-DAQ/triggeralgs/pull/22