### PR TITLE
Replay multiple TP streams from file

### DIFF
--- a/plugins/TriggerPrimitiveMaker.cpp
+++ b/plugins/TriggerPrimitiveMaker.cpp
@@ -166,6 +166,7 @@ TriggerPrimitiveMaker::read_tpsets(std::string filename, int region, int element
     tpsets.push_back(tpset);
   }
 
+  TLOG_DEBUG(0) << "Read " << seqno << " TPs into " << tpsets.size() << " TPSets, from file " << filename;  
   return tpsets;
 }
 

--- a/plugins/TriggerPrimitiveMaker.cpp
+++ b/plugins/TriggerPrimitiveMaker.cpp
@@ -33,10 +33,12 @@ TriggerPrimitiveMaker::TriggerPrimitiveMaker(const std::string& name)
   : dunedaq::appfwk::DAQModule(name)
   , m_queue_timeout(100)
 {
-  register_command("conf", &TriggerPrimitiveMaker::do_configure);
+  // clang-format off
+  register_command("conf",  &TriggerPrimitiveMaker::do_configure);
   register_command("start", &TriggerPrimitiveMaker::do_start);
-  register_command("stop", &TriggerPrimitiveMaker::do_stop);
+  register_command("stop",  &TriggerPrimitiveMaker::do_stop);
   register_command("scrap", &TriggerPrimitiveMaker::do_scrap);
+  // clang-format on
 }
 
 void
@@ -57,10 +59,13 @@ TriggerPrimitiveMaker::do_configure(const nlohmann::json& obj)
     TPStream this_stream;
     this_stream.tpset_sink =
       std::make_unique<appfwk::DAQSink<TPSet>>(appfwk::queue_inst(m_init_obj, stream.output_sink_name));
+
     this_stream.tpsets = read_tpsets(stream.filename, stream.region_id, stream.element_id);
     m_earliest_first_tpset_timestamp =
       std::min(m_earliest_first_tpset_timestamp, this_stream.tpsets.front().start_time);
+
     m_latest_last_tpset_timestamp = std::max(m_latest_last_tpset_timestamp, this_stream.tpsets.back().start_time);
+
     m_tp_streams.push_back(std::move(this_stream));
   }
 }

--- a/plugins/TriggerPrimitiveMaker.hpp
+++ b/plugins/TriggerPrimitiveMaker.hpp
@@ -50,15 +50,28 @@ private:
   void do_scrap(const nlohmann::json& obj);
 
   // Threading
-  dunedaq::utilities::WorkerThread m_thread;
-  void do_work(std::atomic<bool>&);
+  void do_work(std::atomic<bool>&, std::vector<TPSet>& tpsets, std::unique_ptr<appfwk::DAQSink<TPSet>>& tpset_sink, std::chrono::steady_clock::time_point earliest_timestamp_time);
+  std::vector<std::thread> m_threads;
+  std::atomic<bool> m_running_flag;
+  
+  std::vector<TPSet> read_tpsets(std::string filename, int region, int element);
 
   // Configuration
   triggerprimitivemaker::ConfParams m_conf;
-  std::unique_ptr<appfwk::DAQSink<TPSet>> m_tpset_sink;
-  std::vector<TPSet> m_tpsets;
+  nlohmann::json m_init_obj; // Stash this so we know name -> instance mappings
+
+  struct TPStream {
+    std::unique_ptr<appfwk::DAQSink<TPSet>> tpset_sink;
+    std::vector<TPSet> tpsets;
+  };
+
+  std::vector<TPStream> m_tp_streams;
 
   std::chrono::milliseconds m_queue_timeout;
+
+  // Variables to keep track of the total time span of multiple TP streams
+  triggeralgs::timestamp_t m_earliest_first_tpset_timestamp;
+  triggeralgs::timestamp_t m_latest_last_tpset_timestamp;
 };
 } // namespace trigger
 } // namespace dunedaq

--- a/python/trigger/faketp_to_sink/faketp_to_sink.py
+++ b/python/trigger/faketp_to_sink/faketp_to_sink.py
@@ -7,145 +7,65 @@ from pprint import pprint
 pprint(moo.io.default_load_path)
 # Load configuration types
 import moo.otypes
-moo.otypes.load_types('rcif/cmd.jsonnet')
-moo.otypes.load_types('appfwk/cmd.jsonnet')
-moo.otypes.load_types('appfwk/app.jsonnet')
 
 moo.otypes.load_types('trigger/triggerprimitivemaker.jsonnet')
 moo.otypes.load_types('trigger/triggerzipper.jsonnet')
 moo.otypes.load_types('trigger/faketpcreatorheartbeatmaker.jsonnet')
 
 # Import new types
-import dunedaq.cmdlib.cmd as basecmd # AddressedCmd,
-import dunedaq.rcif.cmd as rccmd # AddressedCmd,
-import dunedaq.appfwk.cmd as cmd # AddressedCmd,
-import dunedaq.appfwk.app as app # AddressedCmd,
 import dunedaq.trigger.triggerprimitivemaker as tpm
 import dunedaq.trigger.triggerzipper as tzip
 import dunedaq.trigger.faketpcreatorheartbeatmaker as ftpchm
 
-from appfwk.utils import mcmd, mrccmd, mspec
+from appfwk.app import App, ModuleGraph
+from appfwk.daqmodule import DAQModule
+from appfwk.conf_utils import Direction, Connection
 
-import json
-import math
-from pprint import pprint
+class FakeTPToSinkApp(App):
+    def __init__(self,
+                 INPUT_FILES: [str],
+                 SLOWDOWN_FACTOR: float):
 
+        clock_frequency_hz = 50_000_000 / SLOWDOWN_FACTOR
+        modules = []
 
-#===============================================================================
-def acmd(mods: list) -> cmd.CmdObj:
-    """
-    Helper function to create appfwk's Commands addressed to modules.
+        n_streams = len(INPUT_FILES)
 
-    :param      cmdid:  The coommand id
-    :type       cmdid:  str
-    :param      mods:   List of module name/data structures
-    :type       mods:   list
+        tp_streams = [tpm.TPStream(filename=input_file,
+                                   region_id = 0,
+                                   element_id = istream,
+                                   output_sink_name = f"output{istream}")
+                      for istream,input_file in enumerate(INPUT_FILES)]
 
-    :returns:   A constructed Command object
-    :rtype:     dunedaq.appfwk.cmd.Command
-    """
-    return cmd.CmdObj(
-        modules=cmd.AddressedCmds(
-            cmd.AddressedCmd(match=m, data=o)
-            for m,o in mods
-        )
-    )
+        tpm_connections = { f"output{istream}" : Connection(f"ftpchm{istream}.tpset_source")
+                            for istream in range(n_streams) }
+        modules.append(DAQModule(name = "tpm",
+                                 plugin = "TriggerPrimitiveMaker",
+                                 conf = tpm.ConfParams(tp_streams = tp_streams,
+                                                       number_of_loops=-1, # Infinite
+                                                       tpset_time_offset=0,
+                                                       tpset_time_width=10000,
+                                                       clock_frequency_hz=clock_frequency_hz,
+                                                       maximum_wait_time_us=1000,),
+                                 connections = tpm_connections))
 
-#===============================================================================
-def generate(
-        OUTPUT_PATH: str,
-        INPUT_FILES: str,
-        SLOWDOWN_FACTOR: float
-):
-    cmd_data = {}
+        for istream in range(n_streams):
+            modules.append(DAQModule(name = f"ftpchm{istream}",
+                                     plugin = "FakeTPCreatorHeartbeatMaker",
+                                     conf = ftpchm.Conf(heartbeat_interval = 50000),
+                                     connections = {"tpset_sink" : Connection("zip.input")}))
 
-    # Derived parameters
-    CLOCK_FREQUENCY_HZ = 50000000 / SLOWDOWN_FACTOR
+        modules.append(DAQModule(name = "zip",
+                                 plugin = "TPZipper",
+                                 conf = tzip.ConfParams(cardinality=n_streams,
+                                                        max_latency_ms=10,
+                                                        region_id=0,
+                                                        element_id=0,),
+                                 connections = {"output" : Connection("tps_sink.tpset_source")}))
 
-    # Define modules and queues
-    queue_specs = [
-        app.QueueSpec(inst=f"tpset_q{i}", kind='FollySPSCQueue', capacity=1000)
-        for i in range(len(INPUT_FILES))
-    ] +    [
-        app.QueueSpec(inst="tpset_plus_hb_q", kind='FollyMPMCQueue', capacity=1000),
-        app.QueueSpec(inst="zipped_tpset_q", kind='FollyMPMCQueue', capacity=1000),
-    ]
-
-    mod_specs = [
-        mspec(f"tpm{i}", "TriggerPrimitiveMaker", [
-            app.QueueInfo(name="tpset_sink", inst=f"tpset_q{i}", dir="output"),
-        ]) for i in range(len(INPUT_FILES))
-    ] + [
-
-        mspec(f"ftpchm{i}", "FakeTPCreatorHeartbeatMaker", [
-            app.QueueInfo(name="tpset_source", inst=f"tpset_q{i}", dir="input"),
-            app.QueueInfo(name="tpset_sink", inst="tpset_plus_hb_q", dir="output"),
-        ]) for i in range(len(INPUT_FILES))
-
-    ] + [
-        mspec("zip", "TPZipper", [
-            app.QueueInfo(name="input", inst="tpset_plus_hb_q", dir="input"),
-            app.QueueInfo(name="output", inst="zipped_tpset_q", dir="output"),
-        ]),
-        mspec("tps_sink", "TPSetSink", [
-            app.QueueInfo(name="tpset_source", inst="zipped_tpset_q", dir="input"),
-        ]),
-    ]
-
-    cmd_data['init'] = app.Init(queues=queue_specs, modules=mod_specs)
-
-    cmd_data['conf'] = acmd([
-        (f"tpm{i}", tpm.ConfParams(
-            filename=input_file,
-            number_of_loops=-1, # Infinite
-            tpset_time_offset=0,
-            tpset_time_width=10000,
-            clock_frequency_hz=CLOCK_FREQUENCY_HZ,
-            maximum_wait_time_us=1000,
-            region_id=0,
-            element_id=i,
-        )) for i,input_file in enumerate(INPUT_FILES)
-    ] + [
-        (f"ftpchm{i}", ftpchm.Conf(
-          heartbeat_interval = 50000
-        )) for i in range(len(INPUT_FILES))
-    ] + [
-        ("zip", tzip.ConfParams(
-            cardinality=len(INPUT_FILES),
-            max_latency_ms=1000,
-            region_id=0,
-            element_id=0
-        ))
-    ])
-
-    startpars = rccmd.StartParams(run=1, disable_data_storage=False)
-    cmd_data['start'] = acmd(
-        [
-            ("zip", startpars),
-            ("tps_sink", startpars),
-        ] +
-        [ (f'ftpchm{i}', startpars) for i in range(len(INPUT_FILES)) ] +
-        [ (f'tpm{i}', startpars) for i in range(len(INPUT_FILES)) ]
-    )
-
-    cmd_data['pause'] = acmd([])
-
-    cmd_data['resume'] = acmd([])
-
-    cmd_data['stop'] = acmd(
-        [ (f'tpm{i}', None) for i in range(len(INPUT_FILES)) ] +
-        [ (f'ftpchm{i}', None) for i in range(len(INPUT_FILES)) ] +
-        [
-        ("zip", None),
-        ("tps_sink", None),
-    ])
-
-    cmd_data['scrap'] = acmd(
-        [ (f'ftpchm{i}', None) for i in range(len(INPUT_FILES)) ] +
-        [ (f'tpm{i}', None) for i in range(len(INPUT_FILES)) ] +
-        [
-            ("zip", None)
-        ]
-    )
-
-    return cmd_data
+        modules.append(DAQModule(name = "tps_sink",
+                                 plugin = "TPSetSink"))
+        
+        mgraph = ModuleGraph(modules)
+        super().__init__(modulegraph=mgraph, host="localhost", name='FakeTPToSinkApp')
+                                 

--- a/python/trigger/faketp_to_sink/toplevel.py
+++ b/python/trigger/faketp_to_sink/toplevel.py
@@ -2,154 +2,45 @@ import json
 import os
 import rich.traceback
 from rich.console import Console
-from os.path import exists, join
 
+from appfwk.system import System
 
 # Add -h as default help option
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 console = Console()
 
-def generate_boot( faketp_spec: dict) -> dict:
-    """
-    Generates boot informations
-
-    :param      faketp_spec:  The faketp specifications
-    :type       faketp_spec:  dict
-
-    :returns:   { description_of_the_return_value }
-    :rtype:     dict
-    """
-
-    # TODO: think how to best handle this bit.
-    # Who is responsible for this bit? Not minidaqapp?
-    # Is this an appfwk configuration fragment?
-    daq_app_specs = {
-        "daq_application_ups" : {
-            "comment": "Application profile based on a full dbt runtime environment",
-            "env": {
-               "DBT_AREA_ROOT": "getenv" 
-            },
-            "cmd": [
-                "CMD_FAC=rest://localhost:${APP_PORT}",
-                "INFO_SVC=file://info_${APP_ID}_${APP_PORT}.json",
-                "cd ${DBT_AREA_ROOT}",
-                "source dbt-setup-env.sh",
-                "dbt-setup-runtime-environment",
-                "cd ${APP_WD}",
-                "daq_application --name ${APP_ID} -c ${CMD_FAC} -i ${INFO_SVC}"
-            ]
-        },
-        "daq_application" : {
-            "comment": "Application profile using  PATH variables (lower start time)",
-            "env":{
-                "CET_PLUGIN_PATH": "getenv",
-                "DUNEDAQ_SHARE_PATH": "getenv",
-                "LD_LIBRARY_PATH": "getenv",
-                "PATH": "getenv",
-                "DUNEDAQ_ERS_DEBUG_LEVEL": "getenv"
-            },
-            "cmd": [
-                "CMD_FAC=rest://localhost:${APP_PORT}",
-                "INFO_SVC=file://info_${APP_NAME}_${APP_PORT}.json",
-                "cd ${APP_WD}",
-                "daq_application --name ${APP_NAME} -c ${CMD_FAC} -i ${INFO_SVC}"
-            ]
-        }
-    }
-
-    boot = {
-        "env": {
-            "DUNEDAQ_ERS_VERBOSITY_LEVEL": 1
-        },
-        "apps": {
-            faketp_spec["name"]: {
-                "exec": "daq_application",
-                "host": "host_faketp",
-                "port": faketp_spec["port"]
-            }
-        },
-        "hosts": {
-            "host_faketp": faketp_spec["host"]
-        },
-        "response_listener": {
-            "port": 56789
-        },
-        "exec": daq_app_specs
-    }
-
-    console.log("Boot data")
-    console.log(boot)
-    return boot
-
-
 import click
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-s', '--slowdown-factor', default=1.0)
-@click.option('-f', '--input-file', type=click.Path(), multiple=True)
+@click.option('-f', '--input-file', type=click.Path(exists=True, dir_okay=False), multiple=True)
 @click.argument('json_dir', type=click.Path())
 def cli(slowdown_factor, input_file, json_dir):
     """
       JSON_DIR: Json file output folder
     """
+
+    the_system = System("faketp_to_sink_partition")
+    
     console.log("Loading faketp config generator")
-    from . import faketp_to_sink
+    from .faketp_to_sink import FakeTPToSinkApp
     console.log(f"Generating configs")
 
-    cmd_data_faketp = faketp_to_sink.generate(
+    the_system.apps["faketp_to_sink"] = FakeTPToSinkApp(
         INPUT_FILES = input_file,
         SLOWDOWN_FACTOR = slowdown_factor,
-        OUTPUT_PATH = json_dir,
     )
 
-    console.log("faketp cmd data:", cmd_data_faketp)
-
-    if exists(json_dir):
-        raise RuntimeError(f"Directory {json_dir} already exists")
-
-    data_dir = join(json_dir, 'data')
-    os.makedirs(data_dir)
-
-    app_faketp="faketp"
-
-    jf_faketp = join(data_dir, app_faketp)
-
-    cmd_set = ["init", "conf", "start", "stop", "pause", "resume", "scrap"]
-    for app,data in ((app_faketp, cmd_data_faketp),):
-        console.log(f"Generating {app} command data json files")
-        for c in cmd_set:
-            with open(f'{join(data_dir, app)}_{c}.json', 'w') as f:
-                json.dump(data[c].pod(), f, indent=4, sort_keys=True)
-
-
-    console.log(f"Generating top-level command json files")
-    start_order = [app_faketp]
-    for c in cmd_set:
-        with open(join(json_dir,f'{c}.json'), 'w') as f:
-            cfg = {
-                "apps": { app: f'data/{app}_{c}' for app in (app_faketp, ) }
-            }
-            if c == 'start':
-                cfg['order'] = start_order
-            elif c == 'stop':
-                cfg['order'] = start_order[::-1]
-
-            json.dump(cfg, f, indent=4, sort_keys=True)
-
-
-    console.log(f"Generating boot json file")
-    with open(join(json_dir,'boot.json'), 'w') as f:
-        cfg = generate_boot(
-            faketp_spec = {
-                "name": app_faketp,
-                "host": "localhost",
-                "port": 3333
-            },
-        )
-        json.dump(cfg, f, indent=4, sort_keys=True)
-    console.log(f"MDAapp config generated in {json_dir}")
-
+    from appfwk.conf_utils import make_app_command_data, make_system_command_datas, generate_boot, write_json_files
+    # Arrange per-app command data into the format used by util.write_json_files()
+    app_command_datas = {
+        name : make_app_command_data(the_system, app)
+        for name,app in the_system.apps.items()
+    }
+    system_command_datas = make_system_command_datas(the_system)
+    boot = generate_boot(the_system.apps)
+    write_json_files(app_command_datas, system_command_datas, json_dir)
 
 if __name__ == '__main__':
 

--- a/schema/trigger/triggerprimitivemaker.jsonnet
+++ b/schema/trigger/triggerprimitivemaker.jsonnet
@@ -10,10 +10,24 @@ local types = {
     microseconds: s.number("microseconds", dtype="u8", doc="Microseconds"),
     region : s.number("region", "u2", doc="Region ID for GeoID"),
     element : s.number("element", "u4", doc="Element ID for GeoID"),
+    output_name: s.string("output_name", doc="An output sink name"),
+  
+    tpstream: s.record("TPStream", [
+        s.field("filename", self.pathname,
+                doc="File name of input file for trigger primitives"),
+        s.field("region_id", self.region, 0,
+                doc="Detector region ID to be reported as the source of the TPs"),
+        s.field("element_id", self.element, 0,
+                doc="Detector element ID to be reported as the source of the TPs"),
+        s.field("output_sink_name", self.output_name,
+                doc="The name (not inst) of the output for this stream"),
+    ], doc="Configuration for a stream of TPs replayed from file"),
 
+    tpstreams: s.sequence("TPStreams", self.tpstream),
+  
     conf: s.record("ConfParams", [
-        s.field("filename", self.pathname, "/tmp/example.csv",
-                doc="File name of input csv file for trigger primitives"),
+        s.field("tp_streams", self.tpstreams,
+                doc="The streams to read and replay"),
         s.field("number_of_loops", self.loops, 1,
                 doc="Number of times the data in the csv file are sent"),
         s.field("tpset_time_offset", self.rows, 1,
@@ -24,10 +38,6 @@ local types = {
                 doc="Simulated clock frequency in Hz"),
         s.field("maximum_wait_time_us", self.microseconds, 1000,
                 doc="Maximum wait time until the running flag is checked in microseconds"),
-        s.field("region_id", self.region, 0,
-                doc="Detector region ID to be reported as the source of the TPs"),
-        s.field("element_id", self.element, 0,
-                doc="Detector element ID to be reported as the source of the TPs"),
     ], doc="TriggerPrimitiveMaker configuration"),
 
 };


### PR DESCRIPTION
This PR adds functionality to `TriggerPrimitiveMaker` to allow it to replay TP streams from multiple files, while keeping them all (approximately) in sync, based on timestamp.