### PR TITLE
HSI trigger type passthrough changes (ICEBERG) 

### DIFF
--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -90,4 +90,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: linting_log_${{ matrix.os_name }}
-        path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*.log
+        path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ daq_add_plugin(TASetNQ duneNetworkQueue LINK_LIBRARIES trigger nwqueueadapters::
 daq_add_application( set_serialization_speed set_serialization_speed.cxx TEST LINK_LIBRARIES trigger)
 daq_add_application( taset_serialization taset_serialization.cxx TEST LINK_LIBRARIES trigger)
 daq_add_application( check_fragment_TPs check_fragment_TPs.cxx TEST LINK_LIBRARIES trigger hdf5libs::hdf5libs CLI11::CLI11)
+daq_add_application( print_trigger_type print_trigger_type.cxx TEST LINK_LIBRARIES trigger hdf5libs::hdf5libs CLI11::CLI11)
 
 ##############################################################################
 # Unit Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(trigger VERSION 1.2.0)
+project(trigger VERSION 1.3.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -145,7 +145,7 @@ ERS_DECLARE_ISSUE_BASE(trigger,
                        appfwk::GeneralDAQModuleIssue,
                        "The trigger type contains high bits: " << trigger_type,
                        ((std::string)name),
-                       ((std::bitset<8>)trigger_type))
+                       ((std::bitset<16>)trigger_type))
 
 } // namespace dunedaq
 

--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -16,6 +16,7 @@
 #include "triggeralgs/Types.hpp"
 
 #include <string>
+#include <bitset>
 
 // NOLINTNEXTLINE(build/define_used)
 #define TLVL_ENTER_EXIT_METHODS 10
@@ -138,6 +139,13 @@ ERS_DECLARE_ISSUE_BASE(trigger,
                                              << "is higher than time_start of last TP and will be ignored.",
                        ((std::string)name),
                        ((int64_t)time_start))
+
+ERS_DECLARE_ISSUE_BASE(trigger,
+                       BadTriggerBitmask,
+                       appfwk::GeneralDAQModuleIssue,
+                       "The trigger type contains high bits: " << trigger_type,
+                       ((std::string)name),
+                       ((std::bitset<8>)trigger_type))
 
 } // namespace dunedaq
 

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -148,9 +148,17 @@ ModuleLevelTrigger::create_decision(const triggeralgs::TriggerCandidate& tc)
   decision.trigger_number = m_last_trigger_number + 1;
   decision.run_number = m_run_number;
   decision.trigger_timestamp = tc.time_candidate;
-  // TODO: work out what to set this to
-  decision.trigger_type = 1; // m_trigger_type;
   decision.readout_type = dfmessages::ReadoutType::kLocalized;
+
+  // TODO: work out what to set this to
+  decision.trigger_type = (tc.type == triggeralgs::TriggerCandidate::Type::kTiming) ? tc.detid : 1; // m_trigger_type;
+  std::cout << std::endl;
+  std::cout << "!!!!! TESTING MLT !!!!!" << std::endl;
+  std::cout << "candidate detid: " << tc.detid << std::endl;
+  std::cout << "type: " << (int)tc.type << std::endl;
+  std::cout << "trigger type: " << decision.trigger_type << std::endl;
+  std::cout << std::endl << std::endl;
+
 
   for (auto link : m_links) {
     dfmessages::ComponentRequest request;

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -155,10 +155,17 @@ ModuleLevelTrigger::create_decision(const triggeralgs::TriggerCandidate& tc)
 
   // TODO: work out what to set this to
   if (m_hsi_passthrough == true){
-  	TLOG_DEBUG(3) << "HSI PT IS TRUE!";
-  	decision.trigger_type = (tc.type == triggeralgs::TriggerCandidate::Type::kTiming) ? tc.detid : 1;
+    TLOG_DEBUG(3) << "HSI PT IS TRUE!";
+    TLOG_DEBUG(3) << "TCTYPE: " << (int)tc.type;
+    if (tc.type != triggeralgs::TriggerCandidate::Type::kTiming){
+      decision.trigger_type = tc.detid;
+    } else {
+      dfmessages::trigger_type_t trigger_type_shifted = ((int)tc.type << 8);
+      decision.trigger_type = trigger_type_shifted;
+    }
+  TLOG_DEBUG(3) << "DEC TYPE: " << decision.trigger_type;
   } else {
-	decision.trigger_type = 1; // m_trigger_type;
+    decision.trigger_type = 1; // m_trigger_type;
   }
 
   TLOG_DEBUG(3) << "!!!!! TESTING MLT !!!!!";

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -157,7 +157,7 @@ ModuleLevelTrigger::create_decision(const triggeralgs::TriggerCandidate& tc)
   if (m_hsi_passthrough == true){
     TLOG_DEBUG(3) << "HSI PT IS TRUE!";
     TLOG_DEBUG(3) << "TCTYPE: " << (int)tc.type;
-    if (tc.type != triggeralgs::TriggerCandidate::Type::kTiming){
+    if (tc.type == triggeralgs::TriggerCandidate::Type::kTiming){
       decision.trigger_type = tc.detid;
     } else {
       dfmessages::trigger_type_t trigger_type_shifted = ((int)tc.type << 8);

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -85,6 +85,9 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
   }
   m_trigger_decision_connection = params.dfo_connection;
   m_inhibit_connection = params.dfo_busy_connection;
+  m_hsi_passthrough = params.hsi_trigger_type_passthrough;
+
+  TLOG_DEBUG(3) << "HSI passthrough: " << m_hsi_passthrough; 
 
   networkmanager::NetworkManager::get().start_listening(m_inhibit_connection);
   m_configured_flag.store(true);
@@ -151,14 +154,17 @@ ModuleLevelTrigger::create_decision(const triggeralgs::TriggerCandidate& tc)
   decision.readout_type = dfmessages::ReadoutType::kLocalized;
 
   // TODO: work out what to set this to
-  decision.trigger_type = (tc.type == triggeralgs::TriggerCandidate::Type::kTiming) ? tc.detid : 1; // m_trigger_type;
-  std::cout << std::endl;
-  std::cout << "!!!!! TESTING MLT !!!!!" << std::endl;
-  std::cout << "candidate detid: " << tc.detid << std::endl;
-  std::cout << "type: " << (int)tc.type << std::endl;
-  std::cout << "trigger type: " << decision.trigger_type << std::endl;
-  std::cout << std::endl << std::endl;
+  if (m_hsi_passthrough == true){
+  	TLOG_DEBUG(3) << "HSI PT IS TRUE!";
+  	decision.trigger_type = (tc.type == triggeralgs::TriggerCandidate::Type::kTiming) ? tc.detid : 1;
+  } else {
+	decision.trigger_type = 1; // m_trigger_type;
+  }
 
+  TLOG_DEBUG(3) << "!!!!! TESTING MLT !!!!!";
+  TLOG_DEBUG(3) << "candidate detid: " << tc.detid;
+  TLOG_DEBUG(3) << "type: " << (int)tc.type;
+  TLOG_DEBUG(3) << "trigger type: " << decision.trigger_type;
 
   for (auto link : m_links) {
     dfmessages::ComponentRequest request;

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -151,13 +151,12 @@ ModuleLevelTrigger::create_decision(const triggeralgs::TriggerCandidate& tc)
   decision.trigger_timestamp = tc.time_candidate;
   decision.readout_type = dfmessages::ReadoutType::kLocalized;
 
-  // TODO: work out what to set this to
   if (m_hsi_passthrough == true){
     if (tc.type == triggeralgs::TriggerCandidate::Type::kTiming){
-      decision.trigger_type = tc.detid;
+      decision.trigger_type = tc.detid & 0xff;
     } else {
-      dfmessages::trigger_type_t trigger_type_shifted = ((int)tc.type << 8);
-      decision.trigger_type = trigger_type_shifted;
+      m_trigger_type_shifted = ((int)tc.type << 8);
+      decision.trigger_type = m_trigger_type_shifted;
     }
   } else {
     decision.trigger_type = 1; // m_trigger_type;

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -87,8 +87,6 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
   m_inhibit_connection = params.dfo_busy_connection;
   m_hsi_passthrough = params.hsi_trigger_type_passthrough;
 
-  TLOG_DEBUG(3) << "HSI passthrough: " << m_hsi_passthrough; 
-
   networkmanager::NetworkManager::get().start_listening(m_inhibit_connection);
   m_configured_flag.store(true);
 }
@@ -155,23 +153,17 @@ ModuleLevelTrigger::create_decision(const triggeralgs::TriggerCandidate& tc)
 
   // TODO: work out what to set this to
   if (m_hsi_passthrough == true){
-    TLOG_DEBUG(3) << "HSI PT IS TRUE!";
-    TLOG_DEBUG(3) << "TCTYPE: " << (int)tc.type;
     if (tc.type == triggeralgs::TriggerCandidate::Type::kTiming){
       decision.trigger_type = tc.detid;
     } else {
       dfmessages::trigger_type_t trigger_type_shifted = ((int)tc.type << 8);
       decision.trigger_type = trigger_type_shifted;
     }
-  TLOG_DEBUG(3) << "DEC TYPE: " << decision.trigger_type;
   } else {
     decision.trigger_type = 1; // m_trigger_type;
   }
 
-  TLOG_DEBUG(3) << "!!!!! TESTING MLT !!!!!";
-  TLOG_DEBUG(3) << "candidate detid: " << tc.detid;
-  TLOG_DEBUG(3) << "type: " << (int)tc.type;
-  TLOG_DEBUG(3) << "trigger type: " << decision.trigger_type;
+  TLOG_DEBUG(3) << "HSI passthrough: " << m_hsi_passthrough << ", TC detid: " << tc.detid << ", TC type: " << (int)tc.type << ", DECISION trigger type: " << decision.trigger_type;
 
   for (auto link : m_links) {
     dfmessages::ComponentRequest request;

--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -92,6 +92,7 @@ private:
   std::atomic<bool> m_dfo_is_busy;
   std::string m_trigger_decision_connection;
   std::string m_inhibit_connection;
+  std::atomic<bool> m_hsi_passthrough;
 
   dfmessages::trigger_number_t m_last_trigger_number;
 

--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -77,6 +77,7 @@ private:
 
   // Create the next trigger decision
   dfmessages::TriggerDecision create_decision(const triggeralgs::TriggerCandidate& tc);
+  dfmessages::trigger_type_t m_trigger_type_shifted;
 
   void dfo_busy_callback(ipm::Receiver::Response message);
 

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -49,11 +49,9 @@ TimingTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEve
   candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
   candidate.inputs = {};
 
-  std::cout << std::endl;
-  std::cout << "!!! TESTING !!!" << std::endl;
-  std::cout << "header: " << data.header << std::endl;
-  std::cout << "signal: " << data.signal_map << std::endl;
-  std::cout << std::endl << std::endl;
+  TLOG_DEBUG(3) << "!!! TESTING !!!";
+  TLOG_DEBUG(3) << "header: " << data.header;
+  TLOG_DEBUG(3) << "signal: " << data.signal_map;
 
   return candidate;
 }

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -34,7 +34,7 @@ TimingTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEve
   triggeralgs::TriggerCandidate candidate;
   // TODO Trigger Team <dune-daq@github.com> Nov-18-2021: the signal field ia now a signal bit map, rather than unique value -> change logic of below?
   if (m_hsi_passthrough == true){
-    TLOG_DEBUG(3) << "changing the readout window due to PT condition";
+    TLOG_DEBUG(3) << "HSI passthrough applied, modified readout window is set";
     candidate.time_start = data.timestamp - hsi_pt_before;
     candidate.time_end   = data.timestamp + hsi_pt_after;
   } else {
@@ -54,11 +54,6 @@ TimingTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEve
 
   candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
   candidate.inputs = {};
-
-  TLOG_DEBUG(3) << "!!! TESTING !!!";
-  TLOG_DEBUG(3) << "HSI PT: " << m_hsi_passthrough;  
-  TLOG_DEBUG(3) << "header: " << data.header;
-  TLOG_DEBUG(3) << "signal: " << data.signal_map;
 
   return candidate;
 }
@@ -160,12 +155,9 @@ TimingTriggerCandidateMaker::receive_hsievent(ipm::Receiver::Response message)
   ++m_tsd_received_count;
   
   if (m_hsi_passthrough == true){
-    TLOG_DEBUG(3) << data.signal_map;
     trigger_bitmask = MakeBitmask16(data.signal_map);
     LowHighBits = SplitBits(data.signal_map);   
-    TLOG_DEBUG(3) << trigger_bitmask;
-    TLOG_DEBUG(3) << LowHighBits[0];
-    TLOG_DEBUG(3) << LowHighBits[1];
+    TLOG_DEBUG(3) << "Signal_map: " << data.signal_map << ", trigger bits: " << LowHighBits[1] << " " << LowHighBits[0];
     try {
       AnyBitSet(LowHighBits[1]);
     } catch (BadTriggerBitmask& e) {

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -44,7 +44,7 @@ TimingTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEve
       candidate.time_end   = data.timestamp + m_detid_offsets_map[data.signal_map].second; // time_end,
       // clang-format on    
     } else {
-      ers::error(dunedaq::trigger::SignalTypeError(ERS_HERE, get_name(), data.signal_map));
+      throw dunedaq::trigger::SignalTypeError(ERS_HERE, get_name(), data.signal_map);
     }
   }
   candidate.time_candidate = data.timestamp;

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -43,11 +43,17 @@ TimingTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEve
   }
   candidate.time_candidate = data.timestamp;
   // throw away bits 31-16 of header, that's OK for now
-  candidate.detid = { static_cast<triggeralgs::detid_t>(data.header) }; // NOLINT(build/unsigned)
+  candidate.detid = { static_cast<triggeralgs::detid_t>(data.signal_map) }; // NOLINT(build/unsigned)
   candidate.type = triggeralgs::TriggerCandidate::Type::kTiming;
 
   candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
   candidate.inputs = {};
+
+  std::cout << std::endl;
+  std::cout << "!!! TESTING !!!" << std::endl;
+  std::cout << "header: " << data.header << std::endl;
+  std::cout << "signal: " << data.signal_map << std::endl;
+  std::cout << std::endl << std::endl;
 
   return candidate;
 }

--- a/plugins/TimingTriggerCandidateMaker.hpp
+++ b/plugins/TimingTriggerCandidateMaker.hpp
@@ -55,6 +55,17 @@ private:
 
   std::string m_hsievent_receive_connection;
 
+  // HSI Passthrough changes
+  std::atomic<bool> m_hsi_passthrough;
+  int hsi_pt_before;
+  int hsi_pt_after;
+  std::bitset<16> trigger_bitmask;
+  std::vector< std::bitset<8> > LowHighBits;
+  std::bitset<16> MakeBitmask16(uint16_t signal_map);
+  std::bitset<8> MakeBitmask8(unsigned short signal_map);
+  std::vector< std::bitset<8> > SplitBits(uint16_t signal_map);
+  void AnyBitSet(std::bitset<8> bitmap);
+
   triggeralgs::TriggerCandidate HSIEventToTriggerCandidate(const dfmessages::HSIEvent& data);
   void receive_hsievent(ipm::Receiver::Response message);
 

--- a/plugins/TimingTriggerCandidateMaker.hpp
+++ b/plugins/TimingTriggerCandidateMaker.hpp
@@ -57,14 +57,8 @@ private:
 
   // HSI Passthrough changes
   std::atomic<bool> m_hsi_passthrough;
-  int hsi_pt_before;
-  int hsi_pt_after;
-  std::bitset<16> trigger_bitmask;
-  std::vector< std::bitset<8> > LowHighBits;
-  std::bitset<16> MakeBitmask16(uint16_t signal_map);
-  std::bitset<8> MakeBitmask8(unsigned short signal_map);
-  std::vector< std::bitset<8> > SplitBits(uint16_t signal_map);
-  void AnyBitSet(std::bitset<8> bitmap);
+  int m_hsi_pt_before;
+  int m_hsi_pt_after;
 
   triggeralgs::TriggerCandidate HSIEventToTriggerCandidate(const dfmessages::HSIEvent& data);
   void receive_hsievent(ipm::Receiver::Response message);

--- a/schema/trigger/moduleleveltrigger.jsonnet
+++ b/schema/trigger/moduleleveltrigger.jsonnet
@@ -7,6 +7,7 @@ local types = {
   element_id : s.number("element_id", "u4"),
   system_type : s.string("system_type"),
   connection_name : s.string("connection_name"),
+  hsi_tt_pt : s.boolean("hsi_tt_pt"),
 
   geoid : s.record("GeoID", [s.field("region", self.region_id, doc="" ),
       s.field("element", self.element_id, doc="" ),
@@ -20,6 +21,7 @@ local types = {
       doc="List of link identifiers that may be included into trigger decision"),
       s.field("dfo_connection", self.connection_name, doc="Connection name to use for sending TDs to DFO"),
       s.field("dfo_busy_connection", self.connection_name, doc="Connection name to use for receiving inhibits from DFO"),
+      s.field("hsi_trigger_type_passthrough", self.hsi_tt_pt, doc="Option to override the trigger type inside MLT"),
 
   ], doc="ModuleLevelTrigger configuration parameters"),
 

--- a/schema/trigger/timingtriggercandidatemaker.jsonnet
+++ b/schema/trigger/timingtriggercandidatemaker.jsonnet
@@ -6,6 +6,7 @@ local types = {
 	time_t : s.number("time_t", "i8", doc="Time"),
 	signal_type_t : s.number("signal_type_t", "u4", doc="Signal type"),
 	connection_name : s.string("connection_name"),
+	hsi_tt_pt : s.boolean("hsi_tt_pt"),
 	map_t : s.record("map_t", [
 			s.field("signal_type",
 				self.signal_type_t,
@@ -47,7 +48,8 @@ local types = {
 			doc="Example 2"),
 		s.field("hsievent_connection_name", 
 			self.connection_name, 
-			doc="Connection name to be used to send hsievent to")
+			doc="Connection name to be used to send hsievent to"),
+		s.field("hsi_trigger_type_passthrough", self.hsi_tt_pt, doc="Option to override the trigger type values")
 	], doc="Configuration of the different readout time maps"),
 
 };

--- a/test/apps/print_trigger_type.cxx
+++ b/test/apps/print_trigger_type.cxx
@@ -30,7 +30,6 @@ main(int argc, char** argv)
 
   auto trigger_record_numbers = decoder.get_all_trigger_record_numbers();
   
-  // Populate the map with the TRHs and DS fragments
   for (auto trigger_number : trigger_record_numbers){
 
     auto header = decoder.get_trh_ptr(trigger_number);

--- a/test/apps/print_trigger_type.cxx
+++ b/test/apps/print_trigger_type.cxx
@@ -1,0 +1,39 @@
+/**
+ * @file check_fragment_TPs.cxx Read TP fragments from file and check that they have start times within the request window
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#include "CLI/CLI.hpp"
+
+#include "detdataformats/trigger/TriggerPrimitive.hpp"
+#include "hdf5libs/HDF5RawDataFile.hpp"
+
+#include <daqdataformats/Fragment.hpp>
+#include <daqdataformats/FragmentHeader.hpp>
+#include <daqdataformats/TriggerRecordHeader.hpp>
+#include <daqdataformats/Types.hpp>
+#include <iostream>
+
+int
+main(int argc, char** argv)
+{
+  CLI::App app{ "App description" };
+
+  std::string filename;
+  app.add_option("-f,--file", filename, "Input HDF5 file");
+
+  CLI11_PARSE(app, argc, argv);
+
+  dunedaq::hdf5libs::HDF5RawDataFile decoder(filename);
+
+  auto trigger_record_numbers = decoder.get_all_trigger_record_numbers();
+  
+  // Populate the map with the TRHs and DS fragments
+  for (auto trigger_number : trigger_record_numbers){
+
+    auto header = decoder.get_trh_ptr(trigger_number);
+    std::cout << "Trigger record " << trigger_number << " has type 0x" << std::hex << header->get_trigger_type() << std::dec << std::endl;
+  }
+}


### PR DESCRIPTION
Main:
-> Command-line argument `--hsi-trigger-type-passthrough` added which affects the trigger decision type assignment in MLT, and the size of the readout window in the TTCM
Other:
-> in TTCM, candidate.detid is now set to the signal_map of the event, not just the header
-> TTCM now contains a check on the trigger type for HSI events
-> MLT shifts the TC type left by 8 bits for TC type other than kTiming (if the HSI flag is active)
-> test app to read the hdf5 files and print the trigger type (Phil)