### PR TITLE
Add TPFilter module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(utilities REQUIRED)
 find_package(networkmanager REQUIRED)
 find_package(daqdataformats REQUIRED)
 find_package(detdataformats REQUIRED)
+find_package(detchannelmaps REQUIRED)
 find_package(hdf5libs REQUIRED)
 find_package(CLI11 REQUIRED)
 
@@ -31,7 +32,8 @@ daq_add_library(TokenManager.cpp
   dfmessages::dfmessages
   triggeralgs::triggeralgs
   utilities::utilities
-  detdataformats::detdataformats)
+  detdataformats::detdataformats
+  detchannelmaps::detchannelmaps)
 
 ##############################################################################
 # Codegen
@@ -55,6 +57,7 @@ daq_codegen(
   triggerzipper.jsonnet
   tpsetbuffercreator.jsonnet
   tpsetreceiver.jsonnet
+  tpchannelfilter.jsonnet
   TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 
 daq_codegen( *info.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp.j2 opmonlib/InfoNljs.hpp.j2 )
@@ -75,6 +78,7 @@ daq_add_plugin(FakeTimeStampedDataGenerator duneDAQModule LINK_LIBRARIES trigger
 daq_add_plugin(FakeDataFlow duneDAQModule LINK_LIBRARIES trigger TEST)
 daq_add_plugin(FakeTPCreatorHeartbeatMaker duneDAQModule LINK_LIBRARIES trigger)
 daq_add_plugin(TPSetBufferCreator duneDAQModule LINK_LIBRARIES trigger)
+daq_add_plugin(TPChannelFilter duneDAQModule LINK_LIBRARIES trigger)
 
 daq_add_plugin(TPZipper duneDAQModule LINK_LIBRARIES trigger)
 daq_add_plugin(TAZipper duneDAQModule LINK_LIBRARIES trigger)

--- a/plugins/TPChannelFilter.cpp
+++ b/plugins/TPChannelFilter.cpp
@@ -1,0 +1,119 @@
+/**
+ * @file TPChannelFilter.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "TPChannelFilter.hpp"
+#include "triggeralgs/TriggerPrimitive.hpp"
+
+#include <string>
+
+namespace dunedaq {
+namespace trigger {
+TPChannelFilter::TPChannelFilter(const std::string& name)
+  : DAQModule(name)
+  , m_thread(std::bind(&TPChannelFilter::do_work, this, std::placeholders::_1))
+  , m_input_queue(nullptr)
+  , m_output_queue(nullptr)
+  , m_queue_timeout(100)
+{
+
+  register_command("conf", &TPChannelFilter::do_conf);
+  register_command("start", &TPChannelFilter::do_start);
+  register_command("stop", &TPChannelFilter::do_stop);
+  register_command("scrap", &TPChannelFilter::do_scrap);
+}
+
+void
+TPChannelFilter::init(const nlohmann::json& iniobj)
+{
+  try {
+    m_input_queue.reset(new source_t(appfwk::queue_inst(iniobj, "tpset_source")));
+    m_output_queue.reset(new sink_t(appfwk::queue_inst(iniobj, "tpset_sink")));
+  } catch (const ers::Issue& excpt) {
+    throw dunedaq::trigger::InvalidQueueFatalError(ERS_HERE, get_name(), "input/output", excpt);
+  }
+}
+
+void
+TPChannelFilter::get_info(opmonlib::InfoCollector& /* ci */, int /*level*/)
+{}
+
+void
+TPChannelFilter::do_conf(const nlohmann::json& conf_arg)
+{
+  m_conf = conf_arg.get<dunedaq::trigger::tpchannelfilter::Conf>();
+  m_channel_map = dunedaq::detchannelmaps::make_map(m_conf.channel_map_name);
+}
+
+void
+TPChannelFilter::do_start(const nlohmann::json&)
+{
+  m_thread.start_working_thread("channelfilter");
+  TLOG_DEBUG(2) << get_name() + " successfully started.";
+}
+
+void
+TPChannelFilter::do_stop(const nlohmann::json&)
+{
+  m_thread.stop_working_thread();
+  TLOG_DEBUG(2) << get_name() + " successfully stopped.";
+}
+
+void
+TPChannelFilter::do_scrap(const nlohmann::json&)
+{}
+
+bool
+TPChannelFilter::channel_should_be_removed(int channel) const
+{
+  // The plane numbering convention is found in detchannelmaps/plugins/VDColdboxChannelMap.cpp and is:
+  // U = 0, Y = 1, Z = 2
+  uint plane = m_channel_map->get_plane_from_offline_channel(channel);
+  return ((plane == 0 || plane == 1) && m_conf.keep_induction) || (plane == 2 && m_conf.keep_collection);
+}
+
+void
+TPChannelFilter::do_work(std::atomic<bool>& running_flag)
+{
+  while (true) {
+    TPSet tpset;
+    try {
+      m_input_queue->pop(tpset, m_queue_timeout);
+    } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
+      // The condition to exit the loop is that we've been stopped and
+      // there's nothing left on the input queue
+      if (!running_flag.load()) {
+        break;
+      } else {
+        continue;
+      }
+    }
+
+    // Actually do the removal for payload TPSets. Leave heartbeat TPSets unmolested
+    if (tpset.type == TPSet::kPayload) {
+      auto it = std::remove_if(tpset.objects.begin(), tpset.objects.end(), [this](triggeralgs::TriggerPrimitive p) {
+        return channel_should_be_removed(p.channel);
+      });
+      tpset.objects.erase(it, tpset.objects.end());
+    }
+    
+    try {
+      m_output_queue->push(tpset, m_queue_timeout);
+    } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
+      std::ostringstream oss_warn;
+      oss_warn << "push to output queue \"" << m_output_queue->get_name() << "\"";
+      ers::warning(dunedaq::appfwk::QueueTimeoutExpired(ERS_HERE, get_name(), oss_warn.str(), m_queue_timeout.count()));
+    }
+    
+  } // while(true)
+  TLOG_DEBUG(2) << "Exiting do_work() method";
+}
+
+} // namespace trigger
+} // namespace dunedaq
+
+DEFINE_DUNE_DAQ_MODULE(dunedaq::trigger::TPChannelFilter)

--- a/plugins/TPChannelFilter.cpp
+++ b/plugins/TPChannelFilter.cpp
@@ -71,15 +71,19 @@ bool
 TPChannelFilter::channel_should_be_removed(int channel) const
 {
   // The plane numbering convention is found in detchannelmaps/plugins/VDColdboxChannelMap.cpp and is:
-  // U = 0, Y = 1, Z =2
+  // U (induction) = 0, Y (induction) = 1, Z (induction) = 2, unconnected channel = 9999
   uint plane = m_channel_map->get_plane_from_offline_channel(channel);
   // Check for collection
   if (plane == 0 || plane == 1) {
-    return !m_conf.keep_collection;
+    return !m_conf.keep_induction;
   }
   // Check for induction
   if (plane == 2) {
-    return !m_conf.keep_induction;
+    return !m_conf.keep_collection;
+  }
+  // Always remove unconnected channels
+  if (plane == 9999 ) {
+    return true;
   }
   // Unknown plane?!
   TLOG() << "Encountered unexpected plane " << plane << " from channel " << channel << ", check channel map?";

--- a/plugins/TPChannelFilter.cpp
+++ b/plugins/TPChannelFilter.cpp
@@ -94,11 +94,15 @@ TPChannelFilter::do_work(std::atomic<bool>& running_flag)
     }
 
     // Actually do the removal for payload TPSets. Leave heartbeat TPSets unmolested
+    
     if (tpset.type == TPSet::kPayload) {
+      size_t n_before = tpset.objects.size();
       auto it = std::remove_if(tpset.objects.begin(), tpset.objects.end(), [this](triggeralgs::TriggerPrimitive p) {
         return channel_should_be_removed(p.channel);
       });
       tpset.objects.erase(it, tpset.objects.end());
+      size_t n_after = tpset.objects.size();
+      TLOG_DEBUG(2) << "Removed " << (n_before - n_after) << " TPs out of " << n_before;
     }
     
     try {

--- a/plugins/TPChannelFilter.cpp
+++ b/plugins/TPChannelFilter.cpp
@@ -104,13 +104,16 @@ TPChannelFilter::do_work(std::atomic<bool>& running_flag)
       size_t n_after = tpset.objects.size();
       TLOG_DEBUG(2) << "Removed " << (n_before - n_after) << " TPs out of " << n_before;
     }
-    
-    try {
-      m_output_queue->push(tpset, m_queue_timeout);
-    } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
-      std::ostringstream oss_warn;
-      oss_warn << "push to output queue \"" << m_output_queue->get_name() << "\"";
-      ers::warning(dunedaq::appfwk::QueueTimeoutExpired(ERS_HERE, get_name(), oss_warn.str(), m_queue_timeout.count()));
+
+    // The rule is that we don't send empty TPSets, so ensure that
+    if (!tpset.objects.empty()) {
+      try {
+        m_output_queue->push(tpset, m_queue_timeout);
+      } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
+        std::ostringstream oss_warn;
+        oss_warn << "push to output queue \"" << m_output_queue->get_name() << "\"";
+        ers::warning(dunedaq::appfwk::QueueTimeoutExpired(ERS_HERE, get_name(), oss_warn.str(), m_queue_timeout.count()));
+      }
     }
     
   } // while(true)

--- a/plugins/TPChannelFilter.hpp
+++ b/plugins/TPChannelFilter.hpp
@@ -1,0 +1,69 @@
+/**
+ * @file TPChannelFilter.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGER_PLUGINS_TPCHANNELFILTER_HPP_
+#define TRIGGER_PLUGINS_TPCHANNELFILTER_HPP_
+
+#include "appfwk/DAQModule.hpp"
+#include "appfwk/DAQModuleHelper.hpp"
+#include "appfwk/DAQSink.hpp"
+#include "appfwk/DAQSource.hpp"
+#include "utilities/WorkerThread.hpp"
+
+#include "detchannelmaps/TPCChannelMap.hpp"
+#include "trigger/Issues.hpp"
+#include "trigger/TPSet.hpp"
+
+#include "trigger/tpchannelfilter/Nljs.hpp"
+
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <unordered_set>
+
+namespace dunedaq {
+namespace trigger {
+class TPChannelFilter : public dunedaq::appfwk::DAQModule
+{
+public:
+  explicit TPChannelFilter(const std::string& name);
+
+  TPChannelFilter(const TPChannelFilter&) = delete;
+  TPChannelFilter& operator=(const TPChannelFilter&) = delete;
+  TPChannelFilter(TPChannelFilter&&) = delete;
+  TPChannelFilter& operator=(TPChannelFilter&&) = delete;
+
+  void init(const nlohmann::json& iniobj) override;
+  void get_info(opmonlib::InfoCollector& ci, int level) override;
+
+private:
+  void do_conf(const nlohmann::json& config);
+  void do_start(const nlohmann::json& obj);
+  void do_stop(const nlohmann::json& obj);
+  void do_scrap(const nlohmann::json& obj);
+  void do_work(std::atomic<bool>&);
+
+  bool channel_should_be_removed(int channel) const;
+  dunedaq::utilities::WorkerThread m_thread;
+
+  using source_t = dunedaq::appfwk::DAQSource<TPSet>;
+  std::unique_ptr<source_t> m_input_queue;
+  using sink_t = dunedaq::appfwk::DAQSink<TPSet>;
+  std::unique_ptr<sink_t> m_output_queue;
+  std::chrono::milliseconds m_queue_timeout;
+
+  std::shared_ptr<detchannelmaps::TPCChannelMap> m_channel_map;
+
+  dunedaq::trigger::tpchannelfilter::Conf m_conf;
+};
+} // namespace trigger
+} // namespace dunedaq
+
+#endif // TRIGGER_PLUGINS_TPCHANNELFILTER_HPP_

--- a/python/trigger/test_channel_filter/test_channel_filter.py
+++ b/python/trigger/test_channel_filter/test_channel_filter.py
@@ -28,7 +28,7 @@ class TestChannelFilterApp(App):
                  INPUT_FILES: [str],
                  SLOWDOWN_FACTOR: float,
                  CHANNEL_MAP_NAME: str,
-                 KEEP_COLLECTION: bool
+                 KEEP_COLLECTION: bool,
                  KEEP_INDUCTION: bool):
 
         clock_frequency_hz = 50_000_000 / SLOWDOWN_FACTOR
@@ -60,11 +60,11 @@ class TestChannelFilterApp(App):
                                      conf = chan_filter.Conf(channel_map_name=CHANNEL_MAP_NAME,
                                                              keep_collection=KEEP_COLLECTION,
                                                              keep_induction=KEEP_INDUCTION),
-                                     connections = {"tpset_sink" : Connection(f"ftpchm{istream}.input")}))
+                                     connections = {"tpset_sink" : Connection(f"ftpchm{istream}.tpset_source")}))
 
             modules.append(DAQModule(name = f"ftpchm{istream}",
                                      plugin = "FakeTPCreatorHeartbeatMaker",
-                                     conf = ftpchm.Conf(heartbeat_interval = 50000),
+                                     conf = ftpchm.Conf(heartbeat_interval = 500_000),
                                      connections = {"tpset_sink" : Connection("zip.input")}))
 
         modules.append(DAQModule(name = "zip",

--- a/python/trigger/test_channel_filter/test_channel_filter.py
+++ b/python/trigger/test_channel_filter/test_channel_filter.py
@@ -1,0 +1,83 @@
+# Set moo schema search path
+from dunedaq.env import get_moo_model_path
+import moo.io
+moo.io.default_load_path = get_moo_model_path()
+
+from pprint import pprint
+pprint(moo.io.default_load_path)
+# Load configuration types
+import moo.otypes
+
+moo.otypes.load_types('trigger/triggerprimitivemaker.jsonnet')
+moo.otypes.load_types('trigger/triggerzipper.jsonnet')
+moo.otypes.load_types('trigger/faketpcreatorheartbeatmaker.jsonnet')
+moo.otypes.load_types('trigger/tpchannelfilter.jsonnet')
+
+# Import new types
+import dunedaq.trigger.triggerprimitivemaker as tpm
+import dunedaq.trigger.triggerzipper as tzip
+import dunedaq.trigger.faketpcreatorheartbeatmaker as ftpchm
+import dunedaq.trigger.tpchannelfilter as chan_filter
+
+from appfwk.app import App, ModuleGraph
+from appfwk.daqmodule import DAQModule
+from appfwk.conf_utils import Direction, Connection
+
+class TestChannelFilterApp(App):
+    def __init__(self,
+                 INPUT_FILES: [str],
+                 SLOWDOWN_FACTOR: float,
+                 CHANNEL_MAP_NAME: str,
+                 KEEP_COLLECTION: bool
+                 KEEP_INDUCTION: bool):
+
+        clock_frequency_hz = 50_000_000 / SLOWDOWN_FACTOR
+        modules = []
+
+        n_streams = len(INPUT_FILES)
+
+        tp_streams = [tpm.TPStream(filename=input_file,
+                                   region_id = 0,
+                                   element_id = istream,
+                                   output_sink_name = f"output{istream}")
+                      for istream,input_file in enumerate(INPUT_FILES)]
+
+        tpm_connections = { f"output{istream}" : Connection(f"chan_filter{istream}.tpset_source")
+                            for istream in range(n_streams) }
+        modules.append(DAQModule(name = "tpm",
+                                 plugin = "TriggerPrimitiveMaker",
+                                 conf = tpm.ConfParams(tp_streams = tp_streams,
+                                                       number_of_loops=-1, # Infinite
+                                                       tpset_time_offset=0,
+                                                       tpset_time_width=10000,
+                                                       clock_frequency_hz=clock_frequency_hz,
+                                                       maximum_wait_time_us=1000,),
+                                 connections = tpm_connections))
+
+        for istream in range(n_streams):
+            modules.append(DAQModule(name = f"chan_filter{istream}",
+                                     plugin = "TPChannelFilter",
+                                     conf = chan_filter.Conf(channel_map_name=CHANNEL_MAP_NAME,
+                                                             keep_collection=KEEP_COLLECTION,
+                                                             keep_induction=KEEP_INDUCTION),
+                                     connections = {"tpset_sink" : Connection(f"ftpchm{istream}.input")}))
+
+            modules.append(DAQModule(name = f"ftpchm{istream}",
+                                     plugin = "FakeTPCreatorHeartbeatMaker",
+                                     conf = ftpchm.Conf(heartbeat_interval = 50000),
+                                     connections = {"tpset_sink" : Connection("zip.input")}))
+
+        modules.append(DAQModule(name = "zip",
+                                 plugin = "TPZipper",
+                                 conf = tzip.ConfParams(cardinality=n_streams,
+                                                        max_latency_ms=10,
+                                                        region_id=0,
+                                                        element_id=0,),
+                                 connections = {"output" : Connection("tps_sink.tpset_source")}))
+
+        modules.append(DAQModule(name = "tps_sink",
+                                 plugin = "TPSetSink"))
+        
+        mgraph = ModuleGraph(modules)
+        super().__init__(modulegraph=mgraph, host="localhost", name='FakeTPToSinkApp')
+                                 

--- a/python/trigger/test_channel_filter/toplevel.py
+++ b/python/trigger/test_channel_filter/toplevel.py
@@ -1,0 +1,56 @@
+import json
+import os
+import rich.traceback
+from rich.console import Console
+
+from appfwk.system import System
+
+# Add -h as default help option
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+console = Console()
+
+import click
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option('-s', '--slowdown-factor', default=1.0)
+@click.option('-f', '--input-file', type=click.Path(exists=True, dir_okay=False), multiple=True)
+@click.option('--keep-collection', is_flag=True, default=True, show_default=True, help="Keep collection TPs")
+@click.option('--keep-induction', is_flag=True, default=True, show_default=True, help="Keep induction TPs")
+@click.option('--channel-map-name', type=click.Choice(["VDColdboxChannelMap", "ProtoDUNESP1ChannelMap"]), default="ProtoDUNESP1ChannelMap", help="Channel map name")
+@click.argument('json_dir', type=click.Path())
+def cli(slowdown_factor, input_file, keep_collection, keep_induction, channel_map_name, json_dir):
+    """
+      JSON_DIR: Json file output folder
+    """
+
+    the_system = System("test_channel_filter_partition")
+    
+    console.log("Loading faketp config generator")
+    from .test_channel_filter import TPChannelFilterApp
+    console.log(f"Generating configs")
+
+    the_system.apps["test_channel_filter"] = TPChannelFilterApp(
+        INPUT_FILES = input_file,
+        SLOWDOWN_FACTOR = slowdown_factor,
+        KEEP_COLLECTION = keep_collection,
+        KEEP_INDUCTION = keep_induction,
+        CHANNEL_MAP_NAME = channel_map_name
+    )
+
+    from appfwk.conf_utils import make_app_command_data, make_system_command_datas, generate_boot, write_json_files
+    # Arrange per-app command data into the format used by util.write_json_files()
+    app_command_datas = {
+        name : make_app_command_data(the_system, app)
+        for name,app in the_system.apps.items()
+    }
+    system_command_datas = make_system_command_datas(the_system)
+    boot = generate_boot(the_system.apps)
+    write_json_files(app_command_datas, system_command_datas, json_dir)
+
+if __name__ == '__main__':
+
+    try:
+            cli(show_default=True, standalone_mode=True)
+    except Exception as e:
+            console.print_exception()

--- a/python/trigger/test_channel_filter/toplevel.py
+++ b/python/trigger/test_channel_filter/toplevel.py
@@ -15,8 +15,8 @@ import click
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-s', '--slowdown-factor', default=1.0)
 @click.option('-f', '--input-file', type=click.Path(exists=True, dir_okay=False), multiple=True)
-@click.option('--keep-collection', is_flag=True, default=True, show_default=True, help="Keep collection TPs")
-@click.option('--keep-induction', is_flag=True, default=True, show_default=True, help="Keep induction TPs")
+@click.option('--keep-collection/--discard-collection', is_flag=True, default=True, show_default=True, help="Keep/discard collection TPs")
+@click.option('--keep-induction/--discard-induction', is_flag=True, default=True, show_default=True, help="Keep/discard induction TPs")
 @click.option('--channel-map-name', type=click.Choice(["VDColdboxChannelMap", "ProtoDUNESP1ChannelMap"]), default="ProtoDUNESP1ChannelMap", help="Channel map name")
 @click.argument('json_dir', type=click.Path())
 def cli(slowdown_factor, input_file, keep_collection, keep_induction, channel_map_name, json_dir):

--- a/python/trigger/test_channel_filter/toplevel.py
+++ b/python/trigger/test_channel_filter/toplevel.py
@@ -27,10 +27,10 @@ def cli(slowdown_factor, input_file, keep_collection, keep_induction, channel_ma
     the_system = System("test_channel_filter_partition")
     
     console.log("Loading faketp config generator")
-    from .test_channel_filter import TPChannelFilterApp
+    from .test_channel_filter import TestChannelFilterApp
     console.log(f"Generating configs")
 
-    the_system.apps["test_channel_filter"] = TPChannelFilterApp(
+    the_system.apps["test_channel_filter"] = TestChannelFilterApp(
         INPUT_FILES = input_file,
         SLOWDOWN_FACTOR = slowdown_factor,
         KEEP_COLLECTION = keep_collection,

--- a/schema/trigger/tpchannelfilter.jsonnet
+++ b/schema/trigger/tpchannelfilter.jsonnet
@@ -1,0 +1,21 @@
+local moo = import "moo.jsonnet";
+local ns = "dunedaq.trigger.tpchannelfilter";
+local s = moo.oschema.schema(ns);
+
+local types = {
+  bool: s.boolean("Boolean"),
+  string : s.string("String", moo.re.ident,
+    doc="A string field"),
+  
+  conf : s.record("Conf", [
+    s.field("keep_collection", self.bool,
+      doc="Whether to keep collection-channel TPs"),
+    s.field("keep_induction", self.bool,
+      doc="Whether to keep induction-channel TPs"),
+    s.field("channel_map_name", self.string,
+      doc="Name of channel map"),    
+  ], doc="FakeTPCreatorHeartbeatMaker configuration parameters."),
+
+};
+
+moo.oschema.sort_select(types, ns)


### PR DESCRIPTION
This PR addresses #96 by adding `TPFilter`, a DAQModule which takes in `TPSet`s and modifies them to contain only `TriggerPrimitive`s from collection or induction channels (depending on configuration). The motivation for this module is the VD coldbox, where collection and induction channels are all mixed up, but the current trigger algorithms want to work on only collection channels. 