### PR TITLE
Addition of LivetimeCounter for trigger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(CLI11 REQUIRED)
 ##############################################################################
 # Main library
 
-daq_add_library(TokenManager.cpp
+daq_add_library(TokenManager.cpp LivetimeCounter.cpp
   LINK_LIBRARIES
   appfwk::appfwk
   logging::logging

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -257,7 +257,7 @@ ModuleLevelTrigger::send_trigger_decisions()
          << m_td_paused_count << " TDs were created during pause, and " << m_td_inhibited_count.load()
          << " TDs were inhibited.";
 
-  deadtime = m_livetime_counter->get_time(LivetimeCounter::State::kDead);
+  deadtime = m_livetime_counter->get_time(LivetimeCounter::State::kDead) + m_livetime_counter->get_time(LivetimeCounter::State::kPaused);
   m_lc_total_deadtime = deadtime;
 }
 

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -19,6 +19,7 @@
 
 #include "trigger/Issues.hpp"
 #include "trigger/moduleleveltrigger/Nljs.hpp"
+#include "trigger/LivetimeCounter.hpp"
 
 #include "timinglibs/TimestampEstimator.hpp"
 
@@ -69,6 +70,7 @@ ModuleLevelTrigger::get_info(opmonlib::InfoCollector& ci, int /*level*/)
   i.td_inhibited_count = m_td_inhibited_count.load();
   i.td_paused_count = m_td_paused_count.load();
   i.td_total_count = m_td_total_count.load();
+  i.lc_total_deadtime = m_lc_total_deadtime.load(); 
 
   ci.add(i);
 }
@@ -100,6 +102,8 @@ ModuleLevelTrigger::do_start(const nlohmann::json& startobj)
   m_running_flag.store(true);
   m_dfo_is_busy.store(false);
 
+  m_livetime_counter.reset(new LivetimeCounter(LivetimeCounter::State::kPaused));
+
   networkmanager::NetworkManager::get().register_callback(
     m_inhibit_connection, std::bind(&ModuleLevelTrigger::dfo_busy_callback, this, std::placeholders::_1));
 
@@ -114,6 +118,9 @@ ModuleLevelTrigger::do_stop(const nlohmann::json& /*stopobj*/)
   m_running_flag.store(false);
   m_send_trigger_decisions_thread.join();
 
+  TLOG(3) << "LivetimeCounter - total deadtime: " << deadtime << std::endl;
+  m_livetime_counter.reset(); // Calls LivetimeCounter dtor?
+
   networkmanager::NetworkManager::get().clear_callback(m_inhibit_connection);
   ers::info(TriggerEndOfRun(ERS_HERE, m_run_number));
 }
@@ -122,6 +129,7 @@ void
 ModuleLevelTrigger::do_pause(const nlohmann::json& /*pauseobj*/)
 {
   m_paused.store(true);
+  m_livetime_counter->set_state(LivetimeCounter::State::kPaused);
   TLOG() << "******* Triggers PAUSED! *********";
   ers::info(TriggerPaused(ERS_HERE));
 }
@@ -131,6 +139,7 @@ ModuleLevelTrigger::do_resume(const nlohmann::json& /*resumeobj*/)
 {
   ers::info(TriggerActive(ERS_HERE));
   TLOG() << "******* Triggers RESUMED! *********";
+  m_livetime_counter->set_state(LivetimeCounter::State::kLive);
   m_paused.store(false);
 }
 
@@ -173,6 +182,8 @@ ModuleLevelTrigger::create_decision(const triggeralgs::TriggerCandidate& tc)
     decision.components.push_back(request);
   }
 
+  
+
   return decision;
 }
 
@@ -189,6 +200,7 @@ ModuleLevelTrigger::send_trigger_decisions()
   m_td_inhibited_count.store(0);
   m_td_paused_count.store(0);
   m_td_total_count.store(0);
+  m_lc_total_deadtime.store(0);
 
   while (true) {
     triggeralgs::TriggerCandidate tc;
@@ -244,6 +256,9 @@ ModuleLevelTrigger::send_trigger_decisions()
          << "Received " << m_tc_received_count << " TCs. Sent " << m_td_sent_count.load() << " TDs. "
          << m_td_paused_count << " TDs were created during pause, and " << m_td_inhibited_count.load()
          << " TDs were inhibited.";
+
+  deadtime = m_livetime_counter->get_time(LivetimeCounter::State::kDead);
+  m_lc_total_deadtime = deadtime;
 }
 
 void
@@ -254,6 +269,7 @@ ModuleLevelTrigger::dfo_busy_callback(ipm::Receiver::Response message)
 
   if (inhibit.run_number == m_run_number) {
     m_dfo_is_busy = inhibit.busy;
+    m_livetime_counter->set_state(LivetimeCounter::State::kDead);
   }
 }
 

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -66,13 +66,15 @@ ModuleLevelTrigger::get_info(opmonlib::InfoCollector& ci, int /*level*/)
   moduleleveltriggerinfo::Info i;
 
   i.tc_received_count = m_tc_received_count.load();
+
   i.td_sent_count = m_td_sent_count.load();
   i.td_inhibited_count = m_td_inhibited_count.load();
   i.td_paused_count = m_td_paused_count.load();
   i.td_total_count = m_td_total_count.load();
-  i.lc_kLive = m_lc_kLive.load(); 
-  i.lc_kPaused = m_lc_kPaused.load();
-  i.lc_kDead = m_lc_kDead.load();
+
+  i.lc_kLive = m_livetime_counter->get_time(LivetimeCounter::State::kLive);
+  m_lc_kPaused = m_livetime_counter->get_time(LivetimeCounter::State::kPaused);
+  m_lc_kDead = m_livetime_counter->get_time(LivetimeCounter::State::kDead);
 
   ci.add(i);
 }
@@ -121,7 +123,7 @@ ModuleLevelTrigger::do_stop(const nlohmann::json& /*stopobj*/)
   m_send_trigger_decisions_thread.join();
   
   m_lc_deadtime = m_livetime_counter->get_time(LivetimeCounter::State::kDead) + m_livetime_counter->get_time(LivetimeCounter::State::kPaused);
-  TLOG(3) << "LivetimeCounter - total deadtime: " << m_lc_deadtime << std::endl;
+  TLOG(3) << "LivetimeCounter - total deadtime+paused: " << m_lc_deadtime << std::endl;
   m_livetime_counter.reset(); // Calls LivetimeCounter dtor?
 
   networkmanager::NetworkManager::get().clear_callback(m_inhibit_connection);

--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -107,7 +107,10 @@ private:
 
   // LivetimeCounter
   std::shared_ptr<LivetimeCounter> m_livetime_counter;
-  LivetimeCounter::state_time_t deadtime;
+  LivetimeCounter::state_time_t m_lc_kLive_count;
+  LivetimeCounter::state_time_t m_lc_kPaused_count;
+  LivetimeCounter::state_time_t m_lc_kDead_count;
+  LivetimeCounter::state_time_t m_lc_deadtime;
 
   // Opmon variables
   using metric_counter_type = decltype(moduleleveltriggerinfo::Info::tc_received_count);
@@ -117,7 +120,9 @@ private:
   std::atomic<metric_counter_type> m_td_paused_count{ 0 };
   std::atomic<metric_counter_type> m_td_total_count{ 0 };
   std::atomic<metric_counter_type> m_td_queue_timeout_expired_err_count{ 0 };
-  std::atomic<metric_counter_type> m_lc_total_deadtime{ 0 };
+  std::atomic<metric_counter_type> m_lc_kLive{ 0 };
+  std::atomic<metric_counter_type> m_lc_kPaused{ 0 };
+  std::atomic<metric_counter_type> m_lc_kDead{ 0 };
 };
 } // namespace trigger
 } // namespace dunedaq

--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -15,6 +15,7 @@
 #define TRIGGER_PLUGINS_MODULELEVELTRIGGER_HPP_
 
 #include "trigger/TokenManager.hpp"
+#include "trigger/LivetimeCounter.hpp"
 #include "trigger/moduleleveltriggerinfo/InfoNljs.hpp"
 
 #include "triggeralgs/TriggerCandidate.hpp"
@@ -104,6 +105,10 @@ private:
   // Are we in a configured state, ie after conf and before scrap?
   std::atomic<bool> m_configured_flag{ false };
 
+  // LivetimeCounter
+  std::shared_ptr<LivetimeCounter> m_livetime_counter;
+  LivetimeCounter::state_time_t deadtime;
+
   // Opmon variables
   using metric_counter_type = decltype(moduleleveltriggerinfo::Info::tc_received_count);
   std::atomic<metric_counter_type> m_tc_received_count{ 0 };
@@ -112,6 +117,7 @@ private:
   std::atomic<metric_counter_type> m_td_paused_count{ 0 };
   std::atomic<metric_counter_type> m_td_total_count{ 0 };
   std::atomic<metric_counter_type> m_td_queue_timeout_expired_err_count{ 0 };
+  std::atomic<metric_counter_type> m_lc_total_deadtime{ 0 };
 };
 } // namespace trigger
 } // namespace dunedaq

--- a/schema/trigger/moduleleveltriggerinfo.jsonnet
+++ b/schema/trigger/moduleleveltriggerinfo.jsonnet
@@ -16,7 +16,9 @@ local info = {
        s.field("td_inhibited_count",                 self.uint8, 0, doc="Number of trigger decisions inhibited."), 
        s.field("td_paused_count",                    self.uint8, 0, doc="Number of trigger decisions created during pause mode."), 
        s.field("td_total_count",                     self.uint8, 0, doc="Total number of trigger decisions created."),
-       s.field("lc_total_deadtime",		     self.uint8, 0, doc="Total deadtime accumulated this run.") 
+       s.field("lc_kLive",			     self.uint8, 0, doc="Total time [ms] spent in Live state - alive to triggers."),
+       s.field("lc_kPaused",                         self.uint8, 0, doc="Total time [ms] spent in Paused state - paused to triggers."),
+       s.field("lc_kDead",                           self.uint8, 0, doc="Total time [ms[ spent in Dead state - dead to triggers.") 
    ], doc="Module level trigger information")
 };
 

--- a/schema/trigger/moduleleveltriggerinfo.jsonnet
+++ b/schema/trigger/moduleleveltriggerinfo.jsonnet
@@ -15,7 +15,8 @@ local info = {
        s.field("td_queue_timeout_expired_err_count", self.uint8, 0, doc="Number of trigger decisions failed to be added to queue due to timeout."),
        s.field("td_inhibited_count",                 self.uint8, 0, doc="Number of trigger decisions inhibited."), 
        s.field("td_paused_count",                    self.uint8, 0, doc="Number of trigger decisions created during pause mode."), 
-       s.field("td_total_count",                     self.uint8, 0, doc="Total number of trigger decisions created."), 
+       s.field("td_total_count",                     self.uint8, 0, doc="Total number of trigger decisions created."),
+       s.field("lc_total_deadtime",		     self.uint8, 0, doc="Total deadtime accumulated this run.") 
    ], doc="Module level trigger information")
 };
 

--- a/src/LivetimeCounter.cpp
+++ b/src/LivetimeCounter.cpp
@@ -1,0 +1,93 @@
+#include "trigger/LivetimeCounter.hpp"
+
+#include "logging/Logging.hpp"
+
+#include <sstream>
+
+namespace dunedaq::trigger {
+
+LivetimeCounter::LivetimeCounter(LivetimeCounter::State state)
+  : m_state(state)
+  , m_last_state_change_time(now())
+{
+  TLOG_DEBUG(1) << "Starting LivetimeCounter in state " << get_state_name(state);
+  m_state_times[State::kLive]=0;
+  m_state_times[State::kDead]=0;
+  m_state_times[State::kPaused]=0;
+}
+
+LivetimeCounter::~LivetimeCounter()
+{
+  std::string report=get_report_string();
+  TLOG() << "LivetimeCounter stopping. Counts: " << report;
+}
+
+void
+LivetimeCounter::update_map()
+{
+  // Caller must lock the mutex, so we don't here
+  auto current_time=now();
+  auto delta=(current_time-m_last_state_change_time);
+  m_state_times[m_state]+=delta;
+  m_last_state_change_time=current_time;
+}
+
+
+void
+LivetimeCounter::set_state(LivetimeCounter::State state)
+{
+  std::lock_guard<std::mutex> l(m_mutex);
+  update_map(); // Add the time to the old state
+  TLOG_DEBUG(1) << "Changing state from " << get_state_name(m_state) << " to " << get_state_name(state);
+  m_state=state;
+}
+
+std::map<LivetimeCounter::State, LivetimeCounter::state_time_t>
+LivetimeCounter::get_time_map()
+{
+  std::lock_guard<std::mutex> l(m_mutex);
+  update_map();
+  return m_state_times;
+}
+
+LivetimeCounter::state_time_t
+LivetimeCounter::get_time(LivetimeCounter::State state)
+{
+  std::lock_guard<std::mutex> l(m_mutex);
+  update_map();
+  return m_state_times[state];
+}
+
+LivetimeCounter::state_time_t
+LivetimeCounter::now() const
+{
+  using namespace std::chrono;
+  return duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
+std::string
+LivetimeCounter::get_report_string()
+{
+  std::lock_guard<std::mutex> l(m_mutex);
+  update_map();
+  std::ostringstream oss;
+  for(auto const& [state, t]: m_state_times){
+    oss << get_state_name(state) << ": " << t << "ms ";
+  }
+  return oss.str();
+}
+
+
+std::string
+LivetimeCounter::get_state_name(LivetimeCounter::State state) const
+{
+  switch(state){
+  case State::kLive: return "live";
+  case State::kDead: return "dead";
+  case State::kPaused: return "paused";
+  default:
+    return "UNKNOWN";
+  }
+}
+
+} // namespace dunedaq::trigger

--- a/src/TokenManager.cpp
+++ b/src/TokenManager.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "trigger/TokenManager.hpp"
+#include "trigger/LivetimeCounter.hpp"
 
 #include "networkmanager/NetworkManager.hpp"
 
@@ -17,10 +18,12 @@ namespace dunedaq::trigger {
 
 TokenManager::TokenManager(const std::string& connection_name,
                            int initial_tokens,
-                           daqdataformats::run_number_t run_number)
+                           daqdataformats::run_number_t run_number,
+                           std::shared_ptr<LivetimeCounter> livetime_counter)
   : m_n_tokens(initial_tokens)
   , m_connection_name(connection_name)
   , m_run_number(run_number)
+  , m_livetime_counter(livetime_counter)
 
 {
 
@@ -74,6 +77,9 @@ TokenManager::trigger_sent(dfmessages::trigger_number_t trigger_number)
   std::lock_guard<std::mutex> lk(m_open_trigger_decisions_mutex);
   m_open_trigger_decisions.insert(trigger_number);
   m_n_tokens--;
+  if(m_n_tokens.load()==0) {
+    m_livetime_counter->set_state(LivetimeCounter::State::kDead);
+  }
 }
 
 void
@@ -84,6 +90,9 @@ TokenManager::receive_token(ipm::Receiver::Response message)
 
   TLOG_DEBUG(1) << "Received token with run number " << token.run_number << ", current run number " << m_run_number;
   if (token.run_number == m_run_number) {
+    if(m_n_tokens.load()==0){
+      m_livetime_counter->set_state(LivetimeCounter::State::kLive);
+    }
     m_n_tokens++;
     TLOG_DEBUG(1) << "There are now " << m_n_tokens.load() << " tokens available";
 

--- a/src/trigger/LivetimeCounter.hpp
+++ b/src/trigger/LivetimeCounter.hpp
@@ -1,0 +1,80 @@
+#ifndef TRIGGER_PLUGINS_LIVETIMECOUNTER_HPP_
+#define TRIGGER_PLUGINS_LIVETIMECOUNTER_HPP_
+#include <chrono>
+#include <map>
+#include <mutex>
+#include <string>
+
+namespace dunedaq::trigger {
+
+/**
+ *  * @brief LivetimeCounter counts the total time in milliseconds spent in each of the available states
+ *   *
+ *    * The current state is set at construction, and can be changed with
+ *     * set_state(). The accumulated time in a particular state can be
+ *      * retrieved with get_time(State), and the times spent in all the
+ *       * states with get_time_map()
+ *        */
+class LivetimeCounter
+{
+public:
+  enum class State {
+    kLive,  // Live to triggers
+    kDead,  // Dead to triggers due to a problem
+    kPaused // Triggers paused (so we are dead to triggers, but intentionally)
+  };
+
+  /**
+ *    * @brief A type to store a time duration in milliseconds
+ *       */
+  using state_time_t = uint64_t;
+
+
+  /**
+ *    * @brief Construct a LivetimeCounter in the given state
+ *       *
+ *          * Counting the time in the initial state begins immediately
+ *             */
+  LivetimeCounter(State state);
+
+  ~LivetimeCounter();
+
+
+  /**
+ *    * @brief Set the current state to @a state
+ *       *
+ *          * Updates the accumulated time in the previous state and switches the state
+ *             */
+  void set_state(State state);
+
+  /**
+ *    * @brief Get a map of accumulated time in milliseconds in each state
+ *       */
+  std::map<State, state_time_t> get_time_map();
+
+  /**
+ *    * @brief Get the accumulated time in milliseconds spent in a particular state
+ *       */
+  state_time_t get_time(State state);
+
+  /**
+ *    * @brief Get a nicely-formatted string of the time spent in each state
+ *       */
+  std::string get_report_string();
+
+  std::string get_state_name(State state) const;
+  
+private:
+  state_time_t now() const;
+  // Precondition:  m_mutex is locked by caller
+     void update_map();
+       
+     std::mutex m_mutex;
+     State m_state;
+     std::map<State, state_time_t> m_state_times;
+     state_time_t m_last_state_change_time;
+  
+};
+} // namespace dunedaq::trigger
+ 
+#endif // TRIGGER_PLUGINS_LIVETIMECOUNTER_HPP_

--- a/src/trigger/LivetimeCounter.hpp
+++ b/src/trigger/LivetimeCounter.hpp
@@ -8,13 +8,13 @@
 namespace dunedaq::trigger {
 
 /**
- *  * @brief LivetimeCounter counts the total time in milliseconds spent in each of the available states
- *   *
- *    * The current state is set at construction, and can be changed with
- *     * set_state(). The accumulated time in a particular state can be
- *      * retrieved with get_time(State), and the times spent in all the
- *       * states with get_time_map()
- *        */
+ ** @brief LivetimeCounter counts the total time in milliseconds spent in each of the available states
+ **
+ ** The current state is set at construction, and can be changed with
+ ** set_state(). The accumulated time in a particular state can be
+ ** retrieved with get_time(State), and the times spent in all the
+ ** states with get_time_map()
+ **/
 class LivetimeCounter
 {
 public:
@@ -24,42 +24,42 @@ public:
     kPaused // Triggers paused (so we are dead to triggers, but intentionally)
   };
 
-  /**
- *    * @brief A type to store a time duration in milliseconds
- *       */
+ /**
+ ** @brief A type to store a time duration in milliseconds
+ **/
   using state_time_t = uint64_t;
 
 
-  /**
- *    * @brief Construct a LivetimeCounter in the given state
- *       *
- *          * Counting the time in the initial state begins immediately
- *             */
+ /**
+ ** @brief Construct a LivetimeCounter in the given state
+ **
+ ** Counting the time in the initial state begins immediately
+ **/
   LivetimeCounter(State state);
 
   ~LivetimeCounter();
 
 
-  /**
- *    * @brief Set the current state to @a state
- *       *
- *          * Updates the accumulated time in the previous state and switches the state
- *             */
+ /**
+ ** @brief Set the current state to @a state
+ **
+ ** Updates the accumulated time in the previous state and switches the state
+ **/
   void set_state(State state);
 
-  /**
- *    * @brief Get a map of accumulated time in milliseconds in each state
- *       */
+ /**
+ ** @brief Get a map of accumulated time in milliseconds in each state
+ **/
   std::map<State, state_time_t> get_time_map();
 
-  /**
- *    * @brief Get the accumulated time in milliseconds spent in a particular state
- *       */
+ /**
+ ** @brief Get the accumulated time in milliseconds spent in a particular state
+ **/
   state_time_t get_time(State state);
 
-  /**
- *    * @brief Get a nicely-formatted string of the time spent in each state
- *       */
+ /**
+ ** @brief Get a nicely-formatted string of the time spent in each state
+ **/
   std::string get_report_string();
 
   std::string get_state_name(State state) const;

--- a/src/trigger/TokenManager.hpp
+++ b/src/trigger/TokenManager.hpp
@@ -17,6 +17,8 @@
 
 #include "ipm/Receiver.hpp"
 
+#include "LivetimeCounter.hpp"
+
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -41,7 +43,7 @@ namespace trigger {
 class TokenManager
 {
 public:
-  TokenManager(const std::string& connection_name, int initial_tokens, daqdataformats::run_number_t run_number);
+  TokenManager(const std::string& connection_name, int initial_tokens, daqdataformats::run_number_t run_number, std::shared_ptr<LivetimeCounter> livetime_counter);
 
   virtual ~TokenManager();
 
@@ -82,6 +84,8 @@ private:
   // The currently-in-flight trigger decisions, and a mutex to guard it
   std::set<dfmessages::trigger_number_t> m_open_trigger_decisions;
   std::mutex m_open_trigger_decisions_mutex;
+
+  std::shared_ptr<LivetimeCounter> m_livetime_counter;
 
   std::string m_connection_name;
   daqdataformats::run_number_t m_run_number;

--- a/unittest/TokenManager_test.cxx
+++ b/unittest/TokenManager_test.cxx
@@ -13,6 +13,7 @@
 #include "networkmanager/nwmgr/Structs.hpp"
 
 #include "trigger/TokenManager.hpp"
+#include "trigger/LivetimeCounter.hpp"
 
 /**
  * @brief Name of this test module
@@ -61,7 +62,8 @@ BOOST_AUTO_TEST_CASE(Basics)
 
   int initial_tokens = 10;
   daqdataformats::run_number_t run_number = 1;
-  trigger::TokenManager tm("foo", initial_tokens, run_number);
+  auto livetime_counter=std::make_shared<trigger::LivetimeCounter>(trigger::LivetimeCounter::State::kPaused);
+  trigger::TokenManager tm("foo", initial_tokens, run_number, livetime_counter);
 
   BOOST_CHECK_EQUAL(tm.get_n_tokens(), initial_tokens);
   BOOST_CHECK_EQUAL(tm.triggers_allowed(), true);


### PR DESCRIPTION
LivetimeCounter: keeps track of time [ms] spend in one of states:
kLive         --live to triggers
kPaused   -- intentionally paused to triggers
kDead       -- dead to triggers due to DFO being busy

Passes counts to opmon.
Writes out summary at run stop.