### PR TITLE
Set `origin` and `seqno` in TPSets emitted by FakeTPCreatorHeartbeatMaker

### DIFF
--- a/plugins/FakeTPCreatorHeartbeatMaker.cpp
+++ b/plugins/FakeTPCreatorHeartbeatMaker.cpp
@@ -96,6 +96,9 @@ FakeTPCreatorHeartbeatMaker::do_work(std::atomic<bool>& running_flag)
     try {
       m_input_queue->pop(tpset, m_queue_timeout);
       m_tpset_received_count++;
+      if (m_geoid.region_id == daqdataformats::GeoID::s_invalid_region_id) {
+        m_geoid = tpset.origin;
+      }
     } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
       // The condition to exit the loop is that we've been stopped and
       // there's nothing left on the input queue
@@ -176,6 +179,7 @@ FakeTPCreatorHeartbeatMaker::get_heartbeat(TPSet& tpset_heartbeat,
   tpset_heartbeat.start_time = current_tpset_start_time;
   tpset_heartbeat.end_time = current_tpset_start_time;
   tpset_heartbeat.run_number = m_run_number;
+  tpset_heartbeat.origin = m_geoid;
 }
 
 } // namespace trigger

--- a/plugins/FakeTPCreatorHeartbeatMaker.cpp
+++ b/plugins/FakeTPCreatorHeartbeatMaker.cpp
@@ -91,6 +91,8 @@ FakeTPCreatorHeartbeatMaker::do_work(std::atomic<bool>& running_flag)
 
   daqdataformats::timestamp_t last_sent_heartbeat_time;
 
+  TPSet::seqno_t sequence_number = 0;
+  
   while (true) {
     TPSet tpset;
     try {
@@ -122,6 +124,8 @@ FakeTPCreatorHeartbeatMaker::do_work(std::atomic<bool>& running_flag)
     if (send_heartbeat) {
       TPSet tpset_heartbeat;
       get_heartbeat(tpset_heartbeat, current_tpset_start_time);
+      tpset_heartbeat.seqno = sequence_number;
+      ++sequence_number;
       while (!successfully_sent_heartbeat) {
         try {
           m_output_queue->push(tpset_heartbeat, m_queue_timeout);
@@ -137,6 +141,10 @@ FakeTPCreatorHeartbeatMaker::do_work(std::atomic<bool>& running_flag)
         }
       }
     }
+    
+    tpset.seqno = sequence_number;
+    ++sequence_number;
+
     while (!successfully_sent_real_tpset) {
       try {
         m_output_queue->push(tpset, m_queue_timeout);

--- a/plugins/FakeTPCreatorHeartbeatMaker.hpp
+++ b/plugins/FakeTPCreatorHeartbeatMaker.hpp
@@ -66,7 +66,11 @@ private:
   triggeralgs::timestamp_t m_heartbeat_interval;
 
   daqdataformats::run_number_t m_run_number{ daqdataformats::TypeDefaults::s_invalid_run_number };
-  
+
+  daqdataformats::GeoID m_geoid{
+    daqdataformats::GeoID::SystemType::kDataSelection,
+    daqdataformats::GeoID::s_invalid_region_id,
+    daqdataformats::GeoID::s_invalid_element_id };
   // Opmon variables
   using metric_counter_type = decltype(faketpcreatorheartbeatmakerinfo::Info::tpset_received_count);
   std::atomic<metric_counter_type> m_tpset_received_count{ 0 };


### PR DESCRIPTION
This PR adds a correct setting of the `origin` and `seqno` fields in the TPSets emitted by `FakeTPCreatorHeartbeatMaker`