### PR TITLE
Use DefaultSkipListRequestHandler from readoutlibs

### DIFF
--- a/plugins/TABuffer.hpp
+++ b/plugins/TABuffer.hpp
@@ -12,8 +12,8 @@
 #include "daqdataformats/Fragment.hpp"
 #include "iomanager/Receiver.hpp"
 #include "readoutlibs/FrameErrorRegistry.hpp"
-#include "readoutlibs/models/DefaultRequestHandlerModel.hpp"
-#include "readoutlibs/models/BinarySearchQueueModel.hpp"
+#include "readoutlibs/models/DefaultSkipListRequestHandler.hpp"
+#include "readoutlibs/models/SkipListLatencyBufferModel.hpp"
 #include "triggeralgs/TriggerObjectOverlay.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
 #include "utilities/WorkerThread.hpp"
@@ -126,9 +126,9 @@ private:
   std::chrono::milliseconds m_queue_timeout;
 
   using buffer_object_t = TAWrapper;
-  using latency_buffer_t = readoutlibs::BinarySearchQueueModel<buffer_object_t>;
+  using latency_buffer_t = readoutlibs::SkipListLatencyBufferModel<buffer_object_t>;
   std::unique_ptr<latency_buffer_t> m_latency_buffer_impl{nullptr};
-  using request_handler_t = readoutlibs::DefaultRequestHandlerModel<buffer_object_t, latency_buffer_t>;
+  using request_handler_t = readoutlibs::DefaultSkipListRequestHandler<buffer_object_t>;
   std::unique_ptr<request_handler_t> m_request_handler_impl{nullptr};
 
   // Don't actually use this, but it's currently needed as arg to request handler ctor

--- a/plugins/TCBuffer.hpp
+++ b/plugins/TCBuffer.hpp
@@ -15,7 +15,8 @@
 
 #include "readoutlibs/FrameErrorRegistry.hpp"
 #include "readoutlibs/models/DefaultRequestHandlerModel.hpp"
-#include "readoutlibs/models/BinarySearchQueueModel.hpp"
+#include "readoutlibs/models/SkipListLatencyBufferModel.hpp"
+#include "readoutlibs/models/DefaultSkipListRequestHandler.hpp"
 #include "triggeralgs/TriggerActivity.hpp"
 #include "triggeralgs/TriggerObjectOverlay.hpp"
 #include "utilities/WorkerThread.hpp"
@@ -122,9 +123,9 @@ private:
   std::chrono::milliseconds m_queue_timeout;
 
   using buffer_object_t = TCWrapper;
-  using latency_buffer_t = readoutlibs::BinarySearchQueueModel<buffer_object_t>;
+  using latency_buffer_t = readoutlibs::SkipListLatencyBufferModel<buffer_object_t>;
   std::unique_ptr<latency_buffer_t> m_latency_buffer_impl{nullptr};
-  using request_handler_t = readoutlibs::DefaultRequestHandlerModel<buffer_object_t, latency_buffer_t>;
+  using request_handler_t = readoutlibs::DefaultSkipListRequestHandler<buffer_object_t>;
   std::unique_ptr<request_handler_t> m_request_handler_impl{nullptr};
 
   // Don't actually use this, but it's currently needed as arg to request handler ctor

--- a/plugins/TPBuffer.hpp
+++ b/plugins/TPBuffer.hpp
@@ -11,8 +11,8 @@
 
 #include "iomanager/Receiver.hpp"
 #include "readoutlibs/FrameErrorRegistry.hpp"
-#include "readoutlibs/models/DefaultRequestHandlerModel.hpp"
-#include "readoutlibs/models/BinarySearchQueueModel.hpp"
+#include "readoutlibs/models/DefaultSkipListRequestHandler.hpp"
+#include "readoutlibs/models/SkipListLatencyBufferModel.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
 #include "utilities/WorkerThread.hpp"
 
@@ -115,9 +115,9 @@ private:
   std::chrono::milliseconds m_queue_timeout;
 
   using buffer_object_t = TPWrapper;
-  using latency_buffer_t = readoutlibs::BinarySearchQueueModel<buffer_object_t>;
+  using latency_buffer_t = readoutlibs::SkipListLatencyBufferModel<buffer_object_t>;
   std::unique_ptr<latency_buffer_t> m_latency_buffer_impl{nullptr};
-  using request_handler_t = readoutlibs::DefaultRequestHandlerModel<buffer_object_t, latency_buffer_t>;
+  using request_handler_t = readoutlibs::DefaultSkipListRequestHandler<buffer_object_t>;
   std::unique_ptr<request_handler_t> m_request_handler_impl{nullptr};
 
   // Don't actually use this, but it's currently needed as arg to request handler ctor


### PR DESCRIPTION
This is needed to handle out-of-time-order objects in the latency buffer. Requires https://github.com/DUNE-DAQ/readoutlibs/pull/24 .

This fixes errors like:

```GeoID[type: DataSelection, region: 20000, element: 0] Trigger Matching result with empty fragment: TS match result on link 0: Trigger number=1 Oldest stored TS=79554162196262608 Start of window TS=79554162089472543 End of window TS=79554162089472893 Estimated newest stored TS=79554162089472543 Requestor=fragments_to_dataflow1```

which occur when TCs arrive out-of-order.