### PR TITLE
Drop `TriggerGenericMaker` outputs at stop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(trigger VERSION 1.4.2)
+project(trigger VERSION 1.4.3)
 
 find_package(daq-cmake REQUIRED)
 


### PR DESCRIPTION
Between the time when data stops flowing (because the readout unit upstream has stopped sending), and when `TriggerGenericMaker` receives the stop command, significant time may have passed. In this time, the data in the `TriggerGenericWorker`'s output buffer becomes old and stale, so if we send it out, we get tardy warnings from the downstream zipper. This commit changes the behaviour to just drop the stale outputs at stop.