### PR TITLE
Added the checking of the run number in HSIEvents in TimingTriggerCandidateMaker

### DIFF
--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -157,6 +157,15 @@ ERS_DECLARE_ISSUE_BASE(trigger,
                        ((std::string)name),
                        ((std::bitset<16>)trigger_type))
 
+ERS_DECLARE_ISSUE_BASE(trigger,
+                       InvalidHSIEventRunNumber,
+                       appfwk::GeneralDAQModuleIssue,
+                       "An invalid run number was received in an HSIEvent, "
+                         << "received=" << received << ", expected=" << expected << ", timestamp=" << ts
+                         << ", sequence_count=" << seq,
+                       ((std::string)name),
+                       ((size_t)received)((size_t)expected)((size_t)ts)((size_t)seq))
+
 } // namespace dunedaq
 
 #endif // TRIGGER_INCLUDE_TRIGGER_ISSUES_HPP_

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -11,6 +11,7 @@
 #include "appfwk/DAQModuleHelper.hpp"
 #include "detdataformats/trigger/Types.hpp"
 #include "iomanager/IOManager.hpp"
+#include "rcif/cmd/Nljs.hpp"
 
 #include <regex>
 #include <string>
@@ -87,13 +88,16 @@ TimingTriggerCandidateMaker::init(const nlohmann::json& iniobj)
 }
 
 void
-TimingTriggerCandidateMaker::do_start(const nlohmann::json&)
+TimingTriggerCandidateMaker::do_start(const nlohmann::json& startobj)
 {
   // OpMon.
   m_tsd_received_count.store(0);
   m_tc_sent_count.store(0);
   m_tc_sig_type_err_count.store(0);
   m_tc_total_count.store(0);
+
+  auto start_params = startobj.get<rcif::cmd::StartParams>();
+  m_run_number.store(start_params.run);
 
   m_hsievent_receiver = get_iom_receiver<dfmessages::HSIEvent>(m_hsievent_receive_connection);
   m_hsievent_receiver->add_callback(std::bind(&TimingTriggerCandidateMaker::receive_hsievent, this, std::placeholders::_1));
@@ -114,7 +118,15 @@ TimingTriggerCandidateMaker::do_stop(const nlohmann::json&)
 void
 TimingTriggerCandidateMaker::receive_hsievent(dfmessages::HSIEvent& data)
 {
-  TLOG_DEBUG(3) << "Activity received.";
+  TLOG_DEBUG(3) << "Activity received with timestamp " << data.timestamp << ", sequence_counter " << data.sequence_counter
+                << ", and run_number " << data.run_number;
+
+  if (data.run_number != m_run_number) {
+    ers::error(dunedaq::trigger::InvalidHSIEventRunNumber(ERS_HERE, get_name(), data.run_number, m_run_number,
+                                                          data.timestamp, data.sequence_counter));
+    return;
+  }
+
   ++m_tsd_received_count;
   
   if (m_hsi_passthrough == true){

--- a/plugins/TimingTriggerCandidateMaker.hpp
+++ b/plugins/TimingTriggerCandidateMaker.hpp
@@ -14,6 +14,7 @@
 #include "trigger/timingtriggercandidatemakerinfo/InfoNljs.hpp"
 
 #include "appfwk/DAQModule.hpp"
+#include "daqdataformats/Types.hpp"
 #include "dfmessages/HSIEvent.hpp"
 #include "iomanager/Receiver.hpp"
 #include "iomanager/Sender.hpp"
@@ -73,6 +74,8 @@ private:
   std::atomic<metric_counter_type> m_tc_sent_count{ 0 };
   std::atomic<metric_counter_type> m_tc_sig_type_err_count{ 0 };
   std::atomic<metric_counter_type> m_tc_total_count{ 0 };
+
+  std::atomic<daqdataformats::run_number_t> m_run_number;
 };
 } // namespace trigger
 } // namespace dunedaq


### PR DESCRIPTION
In the unlikely event that HSIEvents are received in the wrong run, this new code will generate error messages.

These changes depend on related changes in the dfmessages and timinglibs repos.  These changes should be merged to develop *after* both of those sets of changes.