### PR TITLE
Allow partial fragments in TCBuffer

### DIFF
--- a/plugins/TCBuffer.cpp
+++ b/plugins/TCBuffer.cpp
@@ -115,7 +115,7 @@ TCBuffer::do_work(std::atomic<bool>& running_flag)
                     << ", dest: " << data_request->data_destination;
       popped_anything = true;
       ++n_requests_received;
-      m_request_handler_impl->issue_request(*data_request, false);
+      m_request_handler_impl->issue_request(*data_request, true);
     }
 
     if (!popped_anything) {


### PR DESCRIPTION
This change causes the underlying Readout code to immediately return whatever is in the TriggerCandidate latency buffer instead of waiting for a timeout, or waiting until additional TriggerCandidates arrive in the buffer.
This is appropriate since, by definition, the TC information in the latency buffer for the current trigger will already include the TC associated with the current trigger.