### PR TITLE
Rename resume/pause to enable/disable_triggers

### DIFF
--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -44,8 +44,8 @@ ModuleLevelTrigger::ModuleLevelTrigger(const std::string& name)
   register_command("conf",   &ModuleLevelTrigger::do_configure);
   register_command("start",  &ModuleLevelTrigger::do_start);
   register_command("stop",   &ModuleLevelTrigger::do_stop);
-  register_command("pause",  &ModuleLevelTrigger::do_pause);
-  register_command("resume", &ModuleLevelTrigger::do_resume);
+  register_command("disable_triggers",  &ModuleLevelTrigger::do_pause);
+  register_command("enable_triggers", &ModuleLevelTrigger::do_resume);
   register_command("scrap",  &ModuleLevelTrigger::do_scrap);
   // clang-format on
 }


### PR DESCRIPTION
... To comply with the new FSM.
This is related to: https://github.com/DUNE-DAQ/daqconf/pull/120 and https://github.com/DUNE-DAQ/nanorc/pull/103