### PR TITLE
Update `replay_tp_to_chain`

### DIFF
--- a/plugins/TriggerPrimitiveMaker.cpp
+++ b/plugins/TriggerPrimitiveMaker.cpp
@@ -257,8 +257,8 @@ TriggerPrimitiveMaker::do_work(std::atomic<bool>& running_flag,
       ++generated_count;
       generated_tp_count += tpset.objects.size();
       try {
-          TPSet tpset_copy(tpset);
-        tpset_sink->send(std::move(tpset_copy), m_queue_timeout);
+        TPSet tpset_copy(tpset);
+        tpset_sink->send(std::move(tpset_copy), m_queue_timeout, "TPSets");
       } catch (const dunedaq::iomanager::TimeoutExpired& e) {
         ers::warning(e);
         ++push_failed_count;

--- a/plugins/TriggerPrimitiveMaker.cpp
+++ b/plugins/TriggerPrimitiveMaker.cpp
@@ -36,7 +36,7 @@ TriggerPrimitiveMaker::TriggerPrimitiveMaker(const std::string& name)
   // clang-format off
   register_command("conf",  &TriggerPrimitiveMaker::do_configure);
   register_command("start", &TriggerPrimitiveMaker::do_start);
-  register_command("stop",  &TriggerPrimitiveMaker::do_stop);
+  register_command("stop_trigger_sources",  &TriggerPrimitiveMaker::do_stop);
   register_command("scrap", &TriggerPrimitiveMaker::do_scrap);
   // clang-format on
 }

--- a/python/trigger/replay_tp_to_chain/__main__.py
+++ b/python/trigger/replay_tp_to_chain/__main__.py
@@ -1,10 +1,6 @@
-import json
-import os
-import rich.traceback
 from rich.console import Console
 
-from appfwk.system import System
-from appfwk.conf_utils import AppConnection
+from daqconf.core.system import System
 
 # Add -h as default help option
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -15,11 +11,6 @@ console = Console()
 from dunedaq.env import get_moo_model_path
 import moo.io
 moo.io.default_load_path = get_moo_model_path()
-
-# Load configuration types
-import moo.otypes
-moo.otypes.load_types('networkmanager/nwmgr.jsonnet')
-import dunedaq.networkmanager.nwmgr as nwmgr
 
 import click
 
@@ -36,111 +27,91 @@ def cli(slowdown_factor, input_file, trigger_activity_plugin, trigger_activity_c
       JSON_DIR: Json file output folder
     """
 
-    partition_name="replay_tp_partition"
-    the_system = System(partition_name)
+    the_system = System()
     
     console.log("Loading faketp config generator")
     from .replay_tp_app import get_replay_app
     from daqconf.apps.dataflow_gen import get_dataflow_app
     from daqconf.apps.trigger_gen import get_trigger_app
     from daqconf.apps.dfo_gen import get_dfo_app
+    
     console.log(f"Generating configs")
 
     ru_configs=[{"host": "localhost",
                  "card_id": 0,
-                 "region_id": 0,
+                 "region_id": i,
                  "start_channel": 0,
-                 "channel_count": len(input_file)}]
+                 "channel_count": 1} for i in range(len(input_file))]
     
     the_system.apps["replay"] = get_replay_app(
         INPUT_FILES = input_file,
         SLOWDOWN_FACTOR = slowdown_factor
     )
 
-    the_system.apps['trigger'] = get_trigger_app(
-        PARTITION = partition_name,
-        SOFTWARE_TPG_ENABLED = True,
-        ACTIVITY_PLUGIN = trigger_activity_plugin,
-        ACTIVITY_CONFIG = eval(trigger_activity_config),
-        CANDIDATE_PLUGIN = trigger_candidate_plugin,
-        CANDIDATE_CONFIG = eval(trigger_candidate_config),
-        RU_CONFIG = ru_configs,
-        HOST="localhost"
+    the_system.apps["dataflow0"] = get_dataflow_app(
+        HOSTIDX = 0,
+        OUTPUT_PATH = ".",
+        # OPERATIONAL_ENVIRONMENT = op_env,
+        # TPC_REGION_NAME_PREFIX = tpc_region_name_prefix,
+        # MAX_FILE_SIZE = max_file_size,
+        # MAX_TRIGGER_RECORD_WINDOW = max_trigger_record_window,
+        # MAX_EXPECTED_TR_SEQUENCES = max_expected_tr_sequences,
+        # TOKEN_COUNT = trigemu_token_count,
+        # TRB_TIMEOUT = trigger_record_building_timeout,
+        HOST="localhost",
+        # HAS_DQM=enable_dqm,
+        # DEBUG=debug
     )
 
     the_system.apps['dfo'] = get_dfo_app(
         DF_COUNT = 1,
-        TOKEN_COUNT = 10,
-        PARTITION=partition_name,
-        HOST="localhost"
+        # TOKEN_COUNT = trigemu_token_count,
+        # STOP_TIMEOUT = dfo_stop_timeout,
+        HOST="localhost",
+        # DEBUG=debug
     )
 
-    the_system.apps["dataflow0"] = get_dataflow_app(
-        HOSTIDX = 0,
-        OUTPUT_PATH = ".",
-        PARTITION=partition_name,
-        HOST="localhost"
+    the_system.apps['trigger'] = get_trigger_app(
+        SOFTWARE_TPG_ENABLED = True,
+        FIRMWARE_TPG_ENABLED = False,
+        DATA_RATE_SLOWDOWN_FACTOR = slowdown_factor,
+        CLOCK_SPEED_HZ = 50_000_000,
+        RU_CONFIG = ru_configs,
+        ACTIVITY_PLUGIN = trigger_activity_plugin,
+        ACTIVITY_CONFIG = eval(trigger_activity_config),
+        CANDIDATE_PLUGIN = trigger_candidate_plugin,
+        CANDIDATE_CONFIG = eval(trigger_candidate_config),
+        USE_HSI_INPUT = False,
+        # SYSTEM_TYPE = system_type,
+        # TTCM_S1=ttcm_s1,
+        # TTCM_S2=ttcm_s2,
+        # TRIGGER_WINDOW_BEFORE_TICKS = trigger_window_before_ticks,
+        # TRIGGER_WINDOW_AFTER_TICKS = trigger_window_after_ticks,
+        # HSI_TRIGGER_TYPE_PASSTHROUGH = hsi_trigger_type_passthrough,
+        # CHANNEL_MAP_NAME = tpg_channel_map,
+        # DATA_REQUEST_TIMEOUT=trigger_data_request_timeout,
+        HOST="localhost",
+        # DEBUG=debug
     )
 
-    ru_config = ru_configs[0]
-    apa_idx = ru_config['region_id']
-    for link in range(ru_config["channel_count"]):
-        # PL 2022-02-02: global_link is needed here to have non-overlapping app connections if len(ru)>1 with the same region_id
-        # Adding the ru number here too, in case we have many region_ids
-        global_link = link+ru_config["start_channel"]
-        the_system.app_connections.update(
-                    {
-                        f"replay.tp_output{global_link}":
-                        AppConnection(nwmgr_connection=f"{partition_name}.tpsets_apa{apa_idx}_link{global_link}",
-                                      msg_type="dunedaq::trigger::TPSet",
-                                      msg_module_name="TPSetNQ",
-                                      topics=["TPSets"],
-                                      receivers=([f"trigger.tpsets_into_buffer_ru0_link{link}",
-                                                  f"trigger.tpsets_into_chain_ru0_link{link}"]))
-                    })
-
-    the_system.app_connections[f"dfo.trigger_decisions0"] = AppConnection(nwmgr_connection=f"{partition_name}.trigdec_0",
-                                                                          msg_type="dunedaq::dfmessages::TriggerDecision",
-                                                                          msg_module_name="TriggerDecisionNQ",
-                                                                          topics=[],
-                                                                          receivers=[f"dataflow0.trigger_decisions"])
-
-    the_system.app_connections["trigger.td_to_dfo"] = AppConnection(nwmgr_connection=f"{partition_name}.td_mlt_to_dfo",
-                                                                    topics=[],
-                                                                    use_nwqa=False,
-                                                                    receivers=["dfo.td_to_dfo"])
-
-    the_system.app_connections["dfo.df_busy_signal"] = AppConnection(nwmgr_connection=f"{partition_name}.df_busy_signal",
-                                                                     topics=[],
-                                                                     use_nwqa=False,
-                                                                     receivers=["trigger.df_busy_signal"])
-
-    the_system.network_endpoints.append(nwmgr.Connection(name=f"{the_system.partition_name}.triginh",
-                                                         topics=[],
-                                                         address=f"tcp://{{host_dfo}}:{the_system.next_unassigned_port()}"))
-    the_system.network_endpoints.append(nwmgr.Connection(name=f"{the_system.partition_name}.trmon_dqm2df_0", topics=[], address=f"tcp://{{host_dataflow0}}:{the_system.next_unassigned_port()}"))
-    the_system.network_endpoints.append(nwmgr.Connection(name=f"{the_system.partition_name}.hsievents", topics=[], address=f"tcp://{{host_dataflow0}}:{the_system.next_unassigned_port()}"))
-    
-    from appfwk.conf_utils import add_network, make_app_command_data
-    from daqconf.core.fragment_producers import  connect_all_fragment_producers, set_mlt_links, remove_mlt_link
+    from daqconf.core.fragment_producers import connect_all_fragment_producers, set_mlt_links
 
     connect_all_fragment_producers(the_system)
     set_mlt_links(the_system, "trigger")
-
-    add_network("trigger", the_system)
-    add_network("dfo", the_system)
-    add_network("replay", the_system)
-    add_network("dataflow0", the_system)
-
-    from appfwk.conf_utils import make_app_command_data, make_system_command_datas, generate_boot, write_json_files
-    # Arrange per-app command data into the format used by util.write_json_files()
+    
+    from daqconf.core.conf_utils import make_app_command_data, make_system_command_datas, write_json_files
+    from daqconf.core.metadata import write_metadata_file
+    
     app_command_datas = {
-        name : make_app_command_data(the_system, app)
+        name : make_app_command_data(the_system, app, name)
         for name,app in the_system.apps.items()
     }
+
     system_command_datas = make_system_command_datas(the_system)
-    boot = generate_boot(the_system.apps)
+
     write_json_files(app_command_datas, system_command_datas, json_dir)
+
+    write_metadata_file(json_dir, "replay_tp_to_chain")
 
 if __name__ == '__main__':
 

--- a/python/trigger/replay_tp_to_chain/__main__.py
+++ b/python/trigger/replay_tp_to_chain/__main__.py
@@ -90,6 +90,7 @@ def cli(slowdown_factor, input_file, trigger_activity_plugin, trigger_activity_c
         # TRIGGER_WINDOW_BEFORE_TICKS = trigger_window_before_ticks,
         # TRIGGER_WINDOW_AFTER_TICKS = trigger_window_after_ticks,
         # HSI_TRIGGER_TYPE_PASSTHROUGH = hsi_trigger_type_passthrough,
+        USE_CHANNEL_FILTER = False,
         # CHANNEL_MAP_NAME = tpg_channel_map,
         # DATA_REQUEST_TIMEOUT=trigger_data_request_timeout,
         HOST="localhost",

--- a/python/trigger/replay_tp_to_chain/__main__.py
+++ b/python/trigger/replay_tp_to_chain/__main__.py
@@ -21,8 +21,9 @@ import click
 @click.option('--trigger-activity-config', default='dict(prescale=100)', help="Trigger activity algorithm config (string containing python dictionary)")
 @click.option('--trigger-candidate-plugin', default='TriggerCandidateMakerPrescalePlugin', help="Trigger candidate algorithm plugin")
 @click.option('--trigger-candidate-config', default='dict(prescale=100)', help="Trigger candidate algorithm config (string containing python dictionary)")
+@click.option('-l', '--number-of-loops', default='-1', help="Number of times to loop over the input files (-1 for infinite)")
 @click.argument('json_dir', type=click.Path())
-def cli(slowdown_factor, input_file, trigger_activity_plugin, trigger_activity_config, trigger_candidate_plugin, trigger_candidate_config, json_dir):
+def cli(slowdown_factor, input_file, trigger_activity_plugin, trigger_activity_config, trigger_candidate_plugin, trigger_candidate_config, number_of_loops, json_dir):
     """
       JSON_DIR: Json file output folder
     """
@@ -45,7 +46,8 @@ def cli(slowdown_factor, input_file, trigger_activity_plugin, trigger_activity_c
     
     the_system.apps["replay"] = get_replay_app(
         INPUT_FILES = input_file,
-        SLOWDOWN_FACTOR = slowdown_factor
+        SLOWDOWN_FACTOR = slowdown_factor,
+        NUMBER_OF_LOOPS = number_of_loops
     )
 
     the_system.apps["dataflow0"] = get_dataflow_app(

--- a/python/trigger/replay_tp_to_chain/replay_tp_app.py
+++ b/python/trigger/replay_tp_to_chain/replay_tp_app.py
@@ -4,7 +4,6 @@ import moo.io
 moo.io.default_load_path = get_moo_model_path()
 
 from pprint import pprint
-pprint(moo.io.default_load_path)
 # Load configuration types
 import moo.otypes
 
@@ -18,7 +17,8 @@ from daqconf.core.daqmodule import DAQModule
 from daqconf.core.conf_utils import Direction
 
 def get_replay_app(INPUT_FILES: [str],
-                   SLOWDOWN_FACTOR: float):
+                   SLOWDOWN_FACTOR: float,
+                   NUMBER_OF_LOOPS: int):
 
     clock_frequency_hz = 50_000_000 / SLOWDOWN_FACTOR
     modules = []
@@ -36,7 +36,7 @@ def get_replay_app(INPUT_FILES: [str],
     modules.append(DAQModule(name = "tpm",
                              plugin = "TriggerPrimitiveMaker",
                              conf = tpm.ConfParams(tp_streams = tp_streams,
-                                                   number_of_loops=-1, # Infinite
+                                                   number_of_loops=NUMBER_OF_LOOPS,
                                                    tpset_time_offset=0,
                                                    tpset_time_width=10000,
                                                    clock_frequency_hz=clock_frequency_hz,

--- a/python/trigger/replay_tp_to_chain/replay_tp_app.py
+++ b/python/trigger/replay_tp_to_chain/replay_tp_app.py
@@ -13,9 +13,9 @@ moo.otypes.load_types('trigger/triggerprimitivemaker.jsonnet')
 # Import new types
 import dunedaq.trigger.triggerprimitivemaker as tpm
 
-from appfwk.app import App, ModuleGraph
-from appfwk.daqmodule import DAQModule
-from appfwk.conf_utils import Direction, Connection
+from daqconf.core.app import App, ModuleGraph
+from daqconf.core.daqmodule import DAQModule
+from daqconf.core.conf_utils import Direction
 
 def get_replay_app(INPUT_FILES: [str],
                    SLOWDOWN_FACTOR: float):
@@ -40,12 +40,11 @@ def get_replay_app(INPUT_FILES: [str],
                                                    tpset_time_offset=0,
                                                    tpset_time_width=10000,
                                                    clock_frequency_hz=clock_frequency_hz,
-                                                   maximum_wait_time_us=1000,),
-                             connections = {}))
+                                                   maximum_wait_time_us=1000,)))
 
     mgraph = ModuleGraph(modules)
     for istream in range(n_streams):
-        mgraph.add_endpoint(f"tp_output{istream}", f"tpm.output{istream}", Direction.OUT)
+        mgraph.add_endpoint(f"tpsets_ru{istream}_link0", f"tpm.output{istream}", Direction.OUT, topic=["TPSets"])
 
     return App(modulegraph=mgraph, host="localhost", name="ReplayApp")
 


### PR DESCRIPTION
This PR updates the `replay_tp_to_chain` application that reads TPs from text file and replays them through the trigger system, so that it works with the latest trigger app from daqconf, and the latest daqconf style for connections etc. Requires https://github.com/DUNE-DAQ/daqconf/pull/153