### PR TITLE
Option to provide TC types to be ignored in the MLT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(trigger VERSION 1.5.2)
+project(trigger VERSION 1.5.3)
 
 find_package(daq-cmake REQUIRED)
 

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -64,6 +64,7 @@ ModuleLevelTrigger::get_info(opmonlib::InfoCollector& ci, int /*level*/)
   moduleleveltriggerinfo::Info i;
 
   i.tc_received_count = m_tc_received_count.load();
+  i.tc_ignored_count = m_tc_ignored_count.load();
 
   i.td_sent_count = m_td_sent_count.load();
   i.td_sent_tc_count = m_td_sent_tc_count.load();
@@ -112,11 +113,10 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
   TLOG_DEBUG(3) << "TD readout limit: " << m_td_readout_limit;
   TLOG_DEBUG(3) << "Ignoring TC types: " << m_ignoring_tc_types;
   TLOG_DEBUG(3) << "TC types to ignore: ";
-  for (std::vector<int>::iterator it = m_ignored_tc_types.begin(); it != m_ignored_tc_types.end();){
-    TLOG_DEBUG(3) << *it; 
-    ++it; 
+  for (std::vector<int>::iterator it = m_ignored_tc_types.begin(); it != m_ignored_tc_types.end();) {
+    TLOG_DEBUG(3) << *it;
+    ++it;
   }
-
 }
 
 void
@@ -245,6 +245,7 @@ ModuleLevelTrigger::send_trigger_decisions()
 
   // OpMon.
   m_tc_received_count.store(0);
+  m_tc_ignored_count.store(0);
   m_td_sent_count.store(0);
   m_td_sent_tc_count.store(0);
   m_td_inhibited_count.store(0);
@@ -267,13 +268,14 @@ ModuleLevelTrigger::send_trigger_decisions()
       TLOG_DEBUG(1) << "Got TC of type " << static_cast<int>(tc->type) << ", timestamp " << tc->time_candidate
                     << ", start/end " << tc->time_start << "/" << tc->time_end;
       ++m_tc_received_count;
-   
+
       // Option to ignore TC types (if given by config)
-      if (m_ignoring_tc_types == true){
+      if (m_ignoring_tc_types == true) {
         TLOG_DEBUG(3) << "TC type: " << static_cast<int>(tc->type);
-        if (check_trigger_type_ignore(static_cast<int>(tc->type)) == true) { 
-          TLOG_DEBUG(3) << "ignoring...";  
-          continue; 
+        if (check_trigger_type_ignore(static_cast<int>(tc->type)) == true) {
+          TLOG_DEBUG(3) << "ignoring...";
+          m_tc_ignored_count++;
+          continue;
         }
       }
 
@@ -328,6 +330,9 @@ ModuleLevelTrigger::send_trigger_decisions()
          << m_td_inhibited_tc_count.load() << " TCs) were inhibited. " << m_td_dropped_count.load() << " TDs ("
          << m_td_dropped_tc_count.load() << " TCs) were dropped. " << m_td_cleared_count.load() << " TDs ("
          << m_td_cleared_tc_count.load() << " TCs) were cleared.";
+  if (m_ignoring_tc_types == true) {
+    TLOG() << "Ignored " << m_tc_ignored_count.load() << " TCs.";
+  }
 
   m_lc_kLive_count = m_livetime_counter->get_time(LivetimeCounter::State::kLive);
   m_lc_kPaused_count = m_livetime_counter->get_time(LivetimeCounter::State::kPaused);
@@ -542,8 +547,8 @@ bool
 ModuleLevelTrigger::check_trigger_type_ignore(int tc_type)
 {
   bool ignore = false;
-  for (std::vector<int>::iterator it = m_ignored_tc_types.begin(); it != m_ignored_tc_types.end();){
-    if (tc_type == *it){
+  for (std::vector<int>::iterator it = m_ignored_tc_types.begin(); it != m_ignored_tc_types.end();) {
+    if (tc_type == *it) {
       ignore = true;
       break;
     }

--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -14,15 +14,15 @@
 #ifndef TRIGGER_PLUGINS_MODULELEVELTRIGGER_HPP_
 #define TRIGGER_PLUGINS_MODULELEVELTRIGGER_HPP_
 
+#include "trigger/Issues.hpp"
 #include "trigger/LivetimeCounter.hpp"
 #include "trigger/TokenManager.hpp"
 #include "trigger/moduleleveltriggerinfo/InfoNljs.hpp"
-#include "trigger/Issues.hpp"
 
 #include "appfwk/DAQModule.hpp"
-#include "detdataformats/trigger/Types.hpp"
-#include "detdataformats/trigger/TriggerCandidateData.hpp"
 #include "daqdataformats/SourceID.hpp"
+#include "detdataformats/trigger/TriggerCandidateData.hpp"
+#include "detdataformats/trigger/Types.hpp"
 #include "dfmessages/TimeSync.hpp"
 #include "dfmessages/TriggerDecision.hpp"
 #include "dfmessages/TriggerDecisionToken.hpp"
@@ -32,11 +32,11 @@
 #include "timinglibs/TimestampEstimator.hpp"
 #include "triggeralgs/TriggerCandidate.hpp"
 
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
 #include <vector>
-#include <map>
 
 namespace dunedaq {
 
@@ -110,25 +110,26 @@ private:
   LivetimeCounter::state_time_t m_lc_deadtime;
 
   // New buffering
-  struct PendingTD {
-    std::vector <triggeralgs::TriggerCandidate> contributing_tcs;
+  struct PendingTD
+  {
+    std::vector<triggeralgs::TriggerCandidate> contributing_tcs;
     triggeralgs::timestamp_t readout_start;
     triggeralgs::timestamp_t readout_end;
     int64_t walltime_expiration;
   };
-  std::vector <PendingTD> m_pending_tds;
-  std::vector <PendingTD> m_sent_tds;
+  std::vector<PendingTD> m_pending_tds;
+  std::vector<PendingTD> m_sent_tds;
   std::mutex m_td_vector_mutex;
-  
+
   void add_tc(const triggeralgs::TriggerCandidate& tc);
   void add_td(const PendingTD& pending_td);
-  void call_tc_decision(const PendingTD& pending_td, bool override_flag=false);
+  void call_tc_decision(const PendingTD& pending_td, bool override_flag = false);
   bool check_overlap(const triggeralgs::TriggerCandidate& tc, const PendingTD& pending_td);
   bool check_overlap_td(const PendingTD& pending_td);
   bool check_td_readout_length(const PendingTD&);
   void clear_td_vectors();
   void flush_td_vectors();
-  std::vector <PendingTD> get_ready_tds(std::vector <PendingTD>& pending_tds);
+  std::vector<PendingTD> get_ready_tds(std::vector<PendingTD>& pending_tds);
   int64_t m_buffer_timeout;
   int64_t m_td_readout_limit;
   std::atomic<bool> m_send_timed_out_tds;
@@ -147,6 +148,7 @@ private:
   // Opmon variables
   using metric_counter_type = decltype(moduleleveltriggerinfo::Info::tc_received_count);
   std::atomic<metric_counter_type> m_tc_received_count{ 0 };
+  std::atomic<metric_counter_type> m_tc_ignored_count{ 0 };
   std::atomic<metric_counter_type> m_td_sent_count{ 0 };
   std::atomic<metric_counter_type> m_td_sent_tc_count{ 0 };
   std::atomic<metric_counter_type> m_td_inhibited_count{ 0 };

--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -139,6 +139,11 @@ private:
   dfmessages::TriggerDecision create_decision(const PendingTD& pending_td);
   dfmessages::trigger_type_t m_trigger_type_shifted;
 
+  // Optional list of TC types to ignore
+  std::vector<int> m_ignored_tc_types;
+  bool m_ignoring_tc_types;
+  bool check_trigger_type_ignore(int tc_type);
+
   // Opmon variables
   using metric_counter_type = decltype(moduleleveltriggerinfo::Info::tc_received_count);
   std::atomic<metric_counter_type> m_tc_received_count{ 0 };

--- a/plugins/TPBuffer.hpp
+++ b/plugins/TPBuffer.hpp
@@ -93,7 +93,7 @@ private:
 
     //static const constexpr size_t fixed_payload_size = 5568;
     static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kTrigger;
-    static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kSW_TriggerPrimitive;
+    static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTriggerPrimitive;
     // No idea what this should really be set to
     static const constexpr uint64_t expected_tick_difference = 16; // NOLINT(build/unsigned)
 };

--- a/plugins/TPChannelFilter.cpp
+++ b/plugins/TPChannelFilter.cpp
@@ -78,7 +78,7 @@ TPChannelFilter::channel_should_be_removed(int channel) const
   uint plane = m_channel_map->get_plane_from_offline_channel(channel);
   // Check for collection
   if (plane == 0 || plane == 1) {
-    return !m_conf.keep_induction;
+    return false;
   }
   // Check for induction
   if (plane == 2) {

--- a/plugins/TPSetBufferCreator.cpp
+++ b/plugins/TPSetBufferCreator.cpp
@@ -168,7 +168,7 @@ TPSetBufferCreator::convert_to_fragment(std::vector<TPSet>& tpsets, dfmessages::
   frag_h.window_end = input_data_request.request_information.window_end;
   frag_h.run_number = input_data_request.run_number;
   frag_h.element_id = sourceid;
-  frag_h.fragment_type = (daqdataformats::fragment_type_t)daqdataformats::FragmentType::kSW_TriggerPrimitive;
+  frag_h.fragment_type = (daqdataformats::fragment_type_t)daqdataformats::FragmentType::kTriggerPrimitive;
   frag_h.sequence_number = input_data_request.sequence_number;
   frag_h.detector_id = static_cast<uint16_t>(detdataformats::DetID::Subdetector::kDAQ); // NOLINT(build/unsigned)
 

--- a/schema/trigger/moduleleveltrigger.jsonnet
+++ b/schema/trigger/moduleleveltrigger.jsonnet
@@ -10,6 +10,8 @@ local types = {
   td_out_of_timeout_b : s.boolean("td_out_of_timeout_b"),
   candidate_type_t : s.number("candidate_type_t", "u4", doc="Candidate type"),
   time_t : s.number("time_t", "i8", doc="Time"),
+  tc_type : s.number("tc_type", "i4", doc="TC type"),
+  tc_types : s.sequence("tc_types", self.tc_type, doc="List of TC types"),
 
   sourceid : s.record("SourceID", [
       s.field("element", self.element_id, doc="" ),
@@ -27,6 +29,7 @@ local types = {
       s.field("td_out_of_timeout", self.td_out_of_timeout_b, doc="Option to drop TD if TC comes out of timeout window"),
       s.field("buffer_timeout", self.time_t, 100, doc="Buffering timeout [ms] for new TCs"),
       s.field("td_readout_limit", self.time_t, 1000, doc="Time limit [ms] for the length of TD readout window"),
+      s.field("ignore_tc", self.tc_types, [], doc="List of TC types to be ignored"),
   ], doc="ModuleLevelTrigger configuration parameters"),
   
 };

--- a/schema/trigger/moduleleveltriggerinfo.jsonnet
+++ b/schema/trigger/moduleleveltriggerinfo.jsonnet
@@ -10,7 +10,8 @@ local info = {
                      doc="An unsigned of 8 bytes"),
 
    info: s.record("Info", [
-       s.field("tc_received_count",                     self.uint8, 0, doc="Number of trigger candidates received."), 
+       s.field("tc_received_count",                     self.uint8, 0, doc="Number of trigger candidates received."),
+       s.field("tc_ignored_count",                      self.uint8, 0, doc="Number of trigger candidates ignored."), 
        s.field("td_sent_count",                         self.uint8, 0, doc="Number of trigger decisions added to queue."),
        s.field("td_sent_tc_count",                      self.uint8, 0, doc="Number of contributing trigger candidates associated with decisions added to queue."), 
        s.field("td_queue_timeout_expired_err_count",    self.uint8, 0, doc="Number of trigger decisions failed to be added to queue due to timeout."),

--- a/test/apps/print_ds_fragments.cxx
+++ b/test/apps/print_ds_fragments.cxx
@@ -142,7 +142,7 @@ main(int argc, char** argv)
       hdf5file.get_fragment_dataset_paths(record_id, dunedaq::daqdataformats::SourceID::Subsystem::kTrigger);
     for (auto const& frag_path : frag_paths) {
       auto frag_ptr = hdf5file.get_frag_ptr(frag_path);
-      if (frag_ptr->get_fragment_type() == dunedaq::daqdataformats::FragmentType::kSW_TriggerPrimitive) {
+      if (frag_ptr->get_fragment_type() == dunedaq::daqdataformats::FragmentType::kTriggerPrimitive) {
         print_tps(std::move(frag_ptr));
       }
       if (frag_ptr->get_fragment_type() == dunedaq::daqdataformats::FragmentType::kTriggerActivity) {


### PR DESCRIPTION
passed via the daqcong config json
loaded in MLT
incoming TC type check against the vector
if to be ignored: skips the buffering logic and does not contribute to TD decision making

also added to opmon and run summary in MLT