### PR TITLE
Revert changes to TPChannelFilter

### DIFF
--- a/plugins/TPChannelFilter.cpp
+++ b/plugins/TPChannelFilter.cpp
@@ -78,7 +78,7 @@ TPChannelFilter::channel_should_be_removed(int channel) const
   uint plane = m_channel_map->get_plane_from_offline_channel(channel);
   // Check for collection
   if (plane == 0 || plane == 1) {
-    return false;
+    return !m_conf.keep_induction;
   }
   // Check for induction
   if (plane == 2) {

--- a/plugins/zipper.hpp
+++ b/plugins/zipper.hpp
@@ -254,7 +254,7 @@ public:
    */
   bool complete(const timepoint_t& now = timepoint_t::min()) const
   {
-    if (this->empty()) {
+    if (this->empty()) { 
       return false;
     }
 
@@ -309,6 +309,11 @@ public:
       ++completeness;
     }
 
+    // Currently, the cardinality is set to 2 even when there is
+    // only 1 (active) input stream during FW TP Generation. We'll temporarily
+    // reduce the cardinality condition to see if this resolves FW TPG
+    // runs, and then if it does, rethink the cardinality/completeness
+    // logic.
     return completeness >= cardinality;
   }
 


### PR DESCRIPTION
Some changes were made to the file `TPChannelFilter.cpp` during a SW TPG run of the integration week. These should not have made their way through to the `patch/v3.2.x` branch of trigger. This is to revert that change and provides a test fix to the over-production of TRs in the SW TPG integration tests.