### PR TITLE
Revert changes to TPChannelFilter for integration week tests.

### DIFF
--- a/plugins/TPChannelFilter.cpp
+++ b/plugins/TPChannelFilter.cpp
@@ -78,7 +78,7 @@ TPChannelFilter::channel_should_be_removed(int channel) const
   uint plane = m_channel_map->get_plane_from_offline_channel(channel);
   // Check for collection
   if (plane == 0 || plane == 1) {
-    return false;
+    return !m_conf.keep_induction;
   }
   // Check for induction
   if (plane == 2) {


### PR DESCRIPTION
A temporary change in the code made its way to `develop` accidentally during integration week. This one liner fix reverts that change and has been shown to produce good integration test results for the SW TPG issues @bieryAtFnal raised.