### PR TITLE
Update usages in unit test to account for new parameter to IOManager::configure

### DIFF
--- a/unittest/TokenManager_test.cxx
+++ b/unittest/TokenManager_test.cxx
@@ -41,7 +41,7 @@ struct IOManagerTestFixture
     dunedaq::iomanager::ConnectionId cid{ "foo", "TriggerDecisionToken" };
     connections.emplace_back(
       dunedaq::iomanager::Connection{ cid, "inproc://foo", dunedaq::iomanager::ConnectionType::kSendRecv });
-    get_iomanager()->configure({}, connections, false); // Not using ConfigClient
+    get_iomanager()->configure({}, connections, false, 0ms); // Not using ConfigClient
   }
   ~IOManagerTestFixture()
   {

--- a/unittest/TriggerZipper_test.cxx
+++ b/unittest/TriggerZipper_test.cxx
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(ZipperScenario1)
   iomanager::Queues_t queues;
   queues.emplace_back(iomanager::QueueConfig{ { "zipper_input", "TPSet" }, iomanager::QueueType::kStdDeQueue, 10 });
   queues.emplace_back(iomanager::QueueConfig{ { "zipper_output", "TPSet" }, iomanager::QueueType::kStdDeQueue, 10 });
-  iomanager::IOManager::get()->configure(queues, {});
+  iomanager::IOManager::get()->configure(queues, {}, false, 0ms); // Not using Connectivity Service
 
   auto in = dunedaq::get_iom_sender<trigger::TPSet>("zipper_input");
   auto out = dunedaq::get_iom_receiver<trigger::TPSet>("zipper_output");


### PR DESCRIPTION
Follows https://github.com/DUNE-DAQ/iomanager/pull/35