### PR TITLE
Implement Brett's zipper fix for VDCB runs

### DIFF
--- a/plugins/TriggerZipper.hpp
+++ b/plugins/TriggerZipper.hpp
@@ -121,6 +121,8 @@ public:
     m_cfg = cfgobj.get<cfg_t>();
     m_zm.set_max_latency(std::chrono::milliseconds(m_cfg.max_latency_ms));
     m_zm.set_cardinality(m_cfg.cardinality);
+    m_zm.set_tolerance(m_cfg.completeness_tolerance);
+    m_zm.set_tolerate_incompleteness(m_cfg.tolerate_incompleteness);
   }
 
   void do_scrap(const nlohmann::json& /*stopobj*/)

--- a/plugins/zipper.hpp
+++ b/plugins/zipper.hpp
@@ -258,11 +258,19 @@ public:
       return false;
     }
 
+    const size_t target_cardinality = streams.size();
+
+    if (target_cardinality < cardinality) { // absent streams
+      if (latency == duration_t::zero()) { // unbound latency
+        return false;
+      }
+    }
+
     size_t completeness = 0;
 
     const auto top_ident = this->top().identity;
 
-    // check each stream to see if it is "represented"
+    // check each known stream to see if it is "represented"
     for (const auto& sit : streams) {
       const auto& ident = sit.first;
       auto have = sit.second.occupancy;
@@ -276,9 +284,7 @@ public:
         continue; // stream is represented
       }
 
-      // check last ditch check where latency
-      // bounding allows us to ignore stale streams.
-
+      // unbound latency, wait as long as needed
       if (latency == duration_t::zero()) {
         // std::cerr << "no latency " << ident << std::endl;
         return false;
@@ -314,7 +320,7 @@ public:
     // reduce the cardinality condition to see if this resolves FW TPG
     // runs, and then if it does, rethink the cardinality/completeness
     // logic.
-    return completeness >= cardinality;
+    return completeness >= target_cardinality;
   }
 
 private:

--- a/schema/trigger/triggerzipper.jsonnet
+++ b/schema/trigger/triggerzipper.jsonnet
@@ -9,6 +9,8 @@ local hier = {
     //               doc="Maximum time in milliseconds to wait to send output"),
     card: s.number("Count", dtype='u8'),
     delay: s.number("Delay", dtype='u8'),
+    tolerance: s.number("Tolerance", dtype='u8'),
+    bool: s.boolean("Boolean"),
 
     // fixme: this should be factored, not copy-pasted
     element_id : s.number("ElementId", "u4"),
@@ -20,6 +22,10 @@ local hier = {
                 doc="Max bound on latency, zero for unbound but lossless"),
         s.field("element_id", hier.element_id,
                 doc="The element of output"),
+        s.field("tolerate_incompleteness", hier.bool, false,
+                doc="Bool to configure whether or not we will tolerate incompleteness of active TSET queues."),    
+        s.field("completeness_tolerance", hier.tolerance, 1,
+                doc="Maximum number of inactive TSET queues we are willing to tolerate."),
     ], doc="TriggerZipper configuration"),
 
   


### PR DESCRIPTION
The max tolerance mode was not being observed at EHN1 VDCB runs, and Brett has created a fix to ensure this is now working as expected. That fix is also implemented here where we can test in the upcoming VDCB runs.