### PR TITLE
Mrigansusx/mlt readout map

### DIFF
--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -123,6 +123,7 @@ private:
 
   void add_tc(const triggeralgs::TriggerCandidate& tc);
   void add_td(const PendingTD& pending_td);
+  void add_tc_ignored(const triggeralgs::TriggerCandidate& tc);
   void call_tc_decision(const PendingTD& pending_td, bool override_flag = false);
   bool check_overlap(const triggeralgs::TriggerCandidate& tc, const PendingTD& pending_td);
   bool check_overlap_td(const PendingTD& pending_td);

--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -136,6 +136,11 @@ private:
   int m_earliest_tc_index;
   int get_earliest_tc_index(const PendingTD& pending_td);
 
+  // Readout map config
+  nlohmann::json m_readout_window_map_data;
+  std::map<detdataformats::trigger::TriggerCandidateData::Type, std::pair<triggeralgs::timestamp_t, triggeralgs::timestamp_t>> m_readout_window_map;
+  void parse_readout_map(const nlohmann::json& data);
+
   // Create the next trigger decision
   dfmessages::TriggerDecision create_decision(const PendingTD& pending_td);
   dfmessages::trigger_type_t m_trigger_type_shifted;

--- a/schema/trigger/moduleleveltrigger.jsonnet
+++ b/schema/trigger/moduleleveltrigger.jsonnet
@@ -12,11 +12,82 @@ local types = {
   time_t : s.number("time_t", "i8", doc="Time"),
   tc_type : s.number("tc_type", "i4", doc="TC type"),
   tc_types : s.sequence("tc_types", self.tc_type, doc="List of TC types"),
+  readout_time:    s.number(   "ROTime",        "i8", doc="A readout time in ticks"),
+
+  tc_readout: s.record("tc_readout", [
+    s.field("candidate_type", self.tc_type,        default=0,     doc="The TC type"),
+    s.field("time_before",    self.time_t,    default=10000, doc="Time to readout before TC time [ticks]"),
+    s.field("time_after",     self.time_t,     default=20000, doc="Time to readout after TC time [ticks]"),
+  ]),
 
   sourceid : s.record("SourceID", [
       s.field("element", self.element_id, doc="" ),
       s.field("subsystem", self.subsystem, doc="" )],
       doc="SourceID"),
+
+  c0_readout: s.record("c0_readout", [
+    s.field("candidate_type", self.tc_type,      default=0,     doc="The TC type, 0=Unknown"),
+    s.field("time_before",    self.readout_time, default=10000, doc="Time to readout before TC time [ticks]"),
+    s.field("time_after",     self.readout_time, default=20000, doc="Time to readout after TC time [ticks]"),
+  ]),
+  c1_readout: s.record("c1_readout", [
+    s.field("candidate_type", self.tc_type,      default=1,     doc="The TC type, 1=Timing"),
+    s.field("time_before",    self.readout_time, default=10000, doc="Time to readout before TC time [ticks]"),
+    s.field("time_after",     self.readout_time, default=20000, doc="Time to readout after TC time [ticks]"),
+  ]),
+  c2_readout: s.record("c2_readout", [
+    s.field("candidate_type", self.tc_type,      default=2,     doc="The TC type, 2=TPCLowE"),
+    s.field("time_before",    self.readout_time, default=10000, doc="Time to readout before TC time [ticks]"),
+    s.field("time_after",     self.readout_time, default=20000, doc="Time to readout after TC time [ticks]"),
+  ]),
+  c3_readout: s.record("c3_readout", [
+    s.field("candidate_type", self.tc_type,      default=3,     doc="The TC type, 3=Supernova"),
+    s.field("time_before",    self.readout_time, default=10000, doc="Time to readout before TC time [ticks]"),
+    s.field("time_after",     self.readout_time, default=20000, doc="Time to readout after TC time [ticks]"),
+  ]),
+  c4_readout: s.record("c4_readout", [
+    s.field("candidate_type", self.tc_type,      default=4,     doc="The TC type, 4=Random"),
+    s.field("time_before",    self.readout_time, default=10000, doc="Time to readout before TC time [ticks]"),
+    s.field("time_after",     self.readout_time, default=20000, doc="Time to readout after TC time [ticks]"),
+  ]),
+  c5_readout: s.record("c5_readout", [
+    s.field("candidate_type", self.tc_type,      default=5,     doc="The TC type, 5=Prescale"),
+    s.field("time_before",    self.readout_time, default=10000, doc="Time to readout before TC time [ticks]"),
+    s.field("time_after",     self.readout_time, default=20000, doc="Time to readout after TC time [ticks]"),
+  ]),
+  c6_readout: s.record("c6_readout", [
+    s.field("candidate_type", self.tc_type,      default=6,     doc="The TC type, 6=ADCSimpleWindow"),
+    s.field("time_before",    self.readout_time, default=10000, doc="Time to readout before TC time [ticks]"),
+    s.field("time_after",     self.readout_time, default=20000, doc="Time to readout after TC time [ticks]"),
+  ]),
+  c7_readout: s.record("c7_readout", [
+    s.field("candidate_type", self.tc_type,      default=7,     doc="The TC type, 7=HorizontalMuon"),
+    s.field("time_before",    self.readout_time, default=10000, doc="Time to readout before TC time [ticks]"),
+    s.field("time_after",     self.readout_time, default=20000, doc="Time to readout after TC time [ticks]"),
+  ]),
+  c8_readout: s.record("c8_readout", [
+    s.field("candidate_type", self.tc_type,      default=8,     doc="The TC type, 8=MichelElectron"),
+    s.field("time_before",    self.readout_time, default=10000, doc="Time to readout before TC time [ticks]"),
+    s.field("time_after",     self.readout_time, default=20000, doc="Time to readout after TC time [ticks]"),
+  ]),
+  c9_readout: s.record("c9_readout", [
+    s.field("candidate_type", self.tc_type,      default=9,     doc="The TC type, 9=LowEnergyEvent"),
+    s.field("time_before",    self.readout_time, default=10000, doc="Time to readout before TC time [ticks]"),
+    s.field("time_after",     self.readout_time, default=20000, doc="Time to readout after TC time [ticks]"),
+  ]),
+
+  tc_readout_map: s.record("tc_readout_map", [
+    s.field("c0", self.c0_readout, default=self.c0_readout, doc="TC readout for TC type 0"),
+    s.field("c1", self.c1_readout, default=self.c1_readout, doc="TC readout for TC type 1"),
+    s.field("c2", self.c2_readout, default=self.c2_readout, doc="TC readout for TC type 2"),
+    s.field("c3", self.c3_readout, default=self.c3_readout, doc="TC readout for TC type 3"),
+    s.field("c4", self.c4_readout, default=self.c4_readout, doc="TC readout for TC type 4"),
+    s.field("c5", self.c5_readout, default=self.c5_readout, doc="TC readout for TC type 5"),
+    s.field("c6", self.c6_readout, default=self.c6_readout, doc="TC readout for TC type 6"),
+    s.field("c7", self.c7_readout, default=self.c7_readout, doc="TC readout for TC type 7"),
+    s.field("c8", self.c8_readout, default=self.c8_readout, doc="TC readout for TC type 8"),
+    s.field("c9", self.c9_readout, default=self.c9_readout, doc="TC readout for TC type 9"),
+  ]),
 
   linkvec : s.sequence("link_vec", self.sourceid),
   
@@ -30,6 +101,7 @@ local types = {
       s.field("buffer_timeout", self.time_t, 100, doc="Buffering timeout [ms] for new TCs"),
       s.field("td_readout_limit", self.time_t, 1000, doc="Time limit [ms] for the length of TD readout window"),
       s.field("ignore_tc", self.tc_types, [], doc="List of TC types to be ignored"),
+      s.field("td_readout_map", self.tc_readout_map, self.tc_readout_map, doc="A map holding readout pre/post depending on TC type"),
   ], doc="ModuleLevelTrigger configuration parameters"),
   
 };


### PR DESCRIPTION
Addition of readout map to MLT, allows configurable readout windows per TC type.
Updated logic for ignored TC types in MLT: now added to list of contributing TCs in TD (so can be later used in ROI, coincidences), but does not extend the readout window or expiration.