### PR TITLE
Candidate fix in zipper::complete() for Tardy messages at the start of a run

### DIFF
--- a/plugins/zipper.hpp
+++ b/plugins/zipper.hpp
@@ -9,6 +9,8 @@
 #ifndef TRIGGER_PLUGINS_ZIPPER_HPP_
 #define TRIGGER_PLUGINS_ZIPPER_HPP_
 
+#include "logging/Logging.hpp"
+
 #include <chrono>
 #include <queue>
 #include <vector>
@@ -264,8 +266,17 @@ public:
     const size_t target_cardinality = streams.size();
 
     if (target_cardinality < cardinality) { // absent streams
+      //TLOG_DEBUG(18) << "target_cardinality < cardinality: " << target_cardinality << " " << cardinality;
       if (latency == duration_t::zero()) { // unbound latency
         return false;
+      }
+      else if (now != timepoint_t::min()) {
+        auto delta = now - this->top().debut;
+        //TLOG_DEBUG(18) << "delta and latency are " << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()
+        //               << " and " << std::chrono::duration_cast<std::chrono::milliseconds>(latency).count();
+        if (delta < latency) {
+          return false;
+        }
       }
     }
 


### PR DESCRIPTION
The background for this PR is that I noticed when I ran the `dfmodules/integtest/3ru_3df_multirun_test.py` automated integration test using the `dunedaq-v3.2.2` software on teststand computers at Fermilab (e.g. mu2edaq13 and iceberg01), I saw warning messages like the following:

- `Tardy input set from element 13. Set start time 79554162175490000 but last sent time 79554162175800000 DAQModule: zip_1`

Some of those warnings happened before triggers were enabled, and some of them happened during runs.

I believe that the warnings at run start were caused by simple edge effects as the flow of TPs from different DataLinkHandlers started arriving.  This PR is associated with this set of warning messages.

Let's say that the zipper has been told that the cardinality is 2.  At the start of a run, TPs start arriving from one DLH, and a short while later, TPs start arriving from the second DLH.  During the time that the TPs from only one DLH are arriving, the new "if" statement in zipper::complete() [if (target_cardinality < cardinality) } evaluates to true, but the associated "if" statement [`if (latency == duration_t::zero()`] evaluates to false, so the full logic in the complete() method is run.  And, it finds that completeness equals _target_cardinality_, even though completeness does not equal configured cardinality, so it returns true, and the initial TPs from the first DLH are sent downstream.  

When the TPs from the second DLH start arriving (with timestamps that are similar to what the first DLH sent, but they arrived just a little bit later), the zipper doesn't like that.  It discards those TPs and prints out warning messages.

With my candidate change, the TPs from the first DLH are not sent downstream immediately, and that provides some time for the TPs from the second DLH to arrive.  Then, the full logic inside complete() is run, since target_cardinality equals configured cardinality.

I suspect that this new "if" block in the v3.2.2 code is intended to allow for situations in which one of the DLHs never sends TPs.  However, it has the side effect of causing warning messages to be printed out when the TPs start arriving from a 2nd sender, as described above.  So, my thought was to extend the "if" block to allow for the latency time to be taken into account.  That is what the "else" clause is designed to do.  And, I've confirmed that is reliably eliminates the Tardy messages at begin-run time.

One concern that I have with my proposed change is that it will cause a little bit of overhead when the max_latency value is non-zero and a DLH **never** sends any TPs.  Please think about whether that might cause a problem.

I can explain more in a Zoom call, if that would be helpful.

Independent of all of this, I still don't have a good explanation for the Tardy messages that happen during runs.  That seems to be related to occasional lack of synchronization between the DLHs sending TPs, but I haven't been able to determine why that happens sometimes and not others.