### PR TITLE
update connections to always have local names

### DIFF
--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -79,8 +79,9 @@ private:
   void dfo_busy_callback(dfmessages::TriggerInhibit& inhibit);
 
   // Queue sources and sinks
-  std::shared_ptr<iomanager::ReceiverConcept<triggeralgs::TriggerCandidate>> m_candidate_source;
-  std::shared_ptr<iomanager::ReceiverConcept<dfmessages::TriggerInhibit>> m_inhibit_receiver;
+  std::shared_ptr<iomanager::ReceiverConcept<triggeralgs::TriggerCandidate>> m_candidate_input;
+  std::shared_ptr<iomanager::ReceiverConcept<dfmessages::TriggerInhibit>> m_inhibit_input;
+  std::string m_td_output_connection;
 
   std::vector<dfmessages::SourceID> m_links;
 
@@ -89,8 +90,6 @@ private:
   // paused state, in which we don't send triggers
   std::atomic<bool> m_paused;
   std::atomic<bool> m_dfo_is_busy;
-  std::string m_trigger_decision_connection;
-  std::string m_inhibit_connection;
   std::atomic<bool> m_hsi_passthrough;
 
   dfmessages::trigger_number_t m_last_trigger_number;

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -71,7 +71,6 @@ TimingTriggerCandidateMaker::do_conf(const nlohmann::json& config)
   m_detid_offsets_map[params.s0.signal_type] = { params.s0.time_before, params.s0.time_after };
   m_detid_offsets_map[params.s1.signal_type] = { params.s1.time_before, params.s1.time_after };
   m_detid_offsets_map[params.s2.signal_type] = { params.s2.time_before, params.s2.time_after };
-  m_hsievent_receive_connection = params.hsievent_connection_name;
   m_hsi_passthrough = params.hsi_trigger_type_passthrough;
   m_hsi_pt_before = params.s0.time_before;
   m_hsi_pt_after = params.s0.time_after;
@@ -82,7 +81,9 @@ void
 TimingTriggerCandidateMaker::init(const nlohmann::json& iniobj)
 {
   try {
-    m_output_queue = get_iom_sender<triggeralgs::TriggerCandidate>(appfwk::connection_uid(iniobj, "output"));
+    auto ci = appfwk::connection_index(iniobj, {"output", "hsi_input"});	   
+    m_output_queue = get_iom_sender<triggeralgs::TriggerCandidate>(ci["output"]);
+    m_hsievent_input = get_iom_receiver<dfmessages::HSIEvent>(ci["hsi_input"]);
   } catch (const ers::Issue& excpt) {
     throw dunedaq::trigger::InvalidQueueFatalError(ERS_HERE, get_name(), "input/output", excpt);
   }
@@ -100,8 +101,7 @@ TimingTriggerCandidateMaker::do_start(const nlohmann::json& startobj)
   auto start_params = startobj.get<rcif::cmd::StartParams>();
   m_run_number.store(start_params.run);
 
-  m_hsievent_receiver = get_iom_receiver<dfmessages::HSIEvent>(m_hsievent_receive_connection);
-  m_hsievent_receiver->add_callback(std::bind(&TimingTriggerCandidateMaker::receive_hsievent, this, std::placeholders::_1));
+  m_hsievent_input->add_callback(std::bind(&TimingTriggerCandidateMaker::receive_hsievent, this, std::placeholders::_1));
   
   TLOG_DEBUG(2) << get_name() + " successfully started.";
 }
@@ -109,7 +109,7 @@ TimingTriggerCandidateMaker::do_start(const nlohmann::json& startobj)
 void
 TimingTriggerCandidateMaker::do_stop(const nlohmann::json&)
 {
-  m_hsievent_receiver->remove_callback();
+  m_hsievent_input->remove_callback();
 
   TLOG() << "Received " << m_tsd_received_count << " HSIEvent messages. Successfully sent " << m_tc_sent_count
          << " TriggerCandidates";

--- a/plugins/TimingTriggerCandidateMaker.hpp
+++ b/plugins/TimingTriggerCandidateMaker.hpp
@@ -61,7 +61,7 @@ private:
 
   using sink_t = dunedaq::iomanager::SenderConcept<triggeralgs::TriggerCandidate>;
   std::shared_ptr<sink_t> m_output_queue;
-  std::shared_ptr<iomanager::ReceiverConcept<dfmessages::HSIEvent>> m_hsievent_receiver;
+  std::shared_ptr<iomanager::ReceiverConcept<dfmessages::HSIEvent>> m_hsievent_input;
 
   std::chrono::milliseconds m_queue_timeout;
 

--- a/schema/trigger/moduleleveltrigger.jsonnet
+++ b/schema/trigger/moduleleveltrigger.jsonnet
@@ -5,7 +5,6 @@ local s = moo.oschema.schema(ns);
 local types = {
   element_id : s.number("element_id_t", "u4"),
   subsystem : s.string("subsystem_t"),
-  connection_name : s.string("connection_name"),
   hsi_tt_pt : s.boolean("hsi_tt_pt"),
   td_out_of_timeout_b : s.boolean("td_out_of_timeout_b"),
   candidate_type_t : s.number("candidate_type_t", "u4", doc="Candidate type"),
@@ -23,8 +22,6 @@ local types = {
   conf : s.record("ConfParams", [
     s.field("links", self.linkvec,
       doc="List of link identifiers that may be included into trigger decision"),
-      s.field("dfo_connection", self.connection_name, doc="Connection name to use for sending TDs to DFO"),
-      s.field("dfo_busy_connection", self.connection_name, doc="Connection name to use for receiving inhibits from DFO"),
       s.field("hsi_trigger_type_passthrough", self.hsi_tt_pt, doc="Option to override the trigger type inside MLT"),
       s.field("td_out_of_timeout", self.td_out_of_timeout_b, doc="Option to drop TD if TC comes out of timeout window"),
       s.field("buffer_timeout", self.time_t, 100, doc="Buffering timeout [ms] for new TCs"),

--- a/schema/trigger/timingtriggercandidatemaker.jsonnet
+++ b/schema/trigger/timingtriggercandidatemaker.jsonnet
@@ -5,7 +5,6 @@ local s = moo.oschema.schema(ns);
 local types = {
 	time_t : s.number("time_t", "i8", doc="Time"),
 	signal_type_t : s.number("signal_type_t", "u4", doc="Signal type"),
-	connection_name : s.string("connection_name"),
 	hsi_tt_pt : s.boolean("hsi_tt_pt"),
 	map_t : s.record("map_t", [
 			s.field("signal_type",
@@ -46,9 +45,6 @@ local types = {
 				time_after: 2000000
 			},
 			doc="Example 2"),
-		s.field("hsievent_connection_name", 
-			self.connection_name, 
-			doc="Connection name to be used to send hsievent to"),
 		s.field("hsi_trigger_type_passthrough", self.hsi_tt_pt, doc="Option to override the trigger type values")
 	], doc="Configuration of the different readout time maps"),
 


### PR DESCRIPTION
change to setup connection endpoint at init, to be more uniform with other modules and the use of the connectivity service.