### PR TITLE
Mrigansusx/mlt readout map fix

### DIFF
--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -116,9 +116,11 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
   m_td_readout_limit = params.td_readout_limit;
   m_ignored_tc_types = params.ignore_tc;
   m_ignoring_tc_types = (m_ignored_tc_types.size() > 0) ? true : false;
+  m_use_readout_map = params.use_readout_map;
   TLOG_DEBUG(3) << "Buffer timeout: " << m_buffer_timeout;
   TLOG_DEBUG(3) << "Should send timed out TDs: " << m_send_timed_out_tds;
   TLOG_DEBUG(3) << "TD readout limit: " << m_td_readout_limit;
+  TLOG_DEBUG(3) << "Use readout map: " << m_use_readout_map;
   TLOG_DEBUG(3) << "Ignoring TC types: " << m_ignoring_tc_types;
   TLOG_DEBUG(3) << "TC types to ignore: ";
   for (std::vector<int>::iterator it = m_ignored_tc_types.begin(); it != m_ignored_tc_types.end();) {
@@ -126,9 +128,11 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
     ++it;
   }
 
-  m_readout_window_map_data = params.td_readout_map;
-  parse_readout_map(m_readout_window_map_data);
-  print_readout_map(m_readout_window_map);
+  if (m_use_readout_map){
+    m_readout_window_map_data = params.td_readout_map;
+    parse_readout_map(m_readout_window_map_data);
+    print_readout_map(m_readout_window_map);
+  }
 }
 
 void
@@ -280,9 +284,14 @@ ModuleLevelTrigger::send_trigger_decisions()
   while (m_running_flag) {
     std::optional<triggeralgs::TriggerCandidate> tc = m_candidate_input->try_receive(std::chrono::milliseconds(10));
     if (tc.has_value()) {
-      TLOG_DEBUG(1) << "Got TC of type " << static_cast<int>(tc->type) << ", timestamp " << tc->time_candidate
-                    << ", start/end " << tc->time_start << "/" << tc->time_end
-                    << ", readout start/end " << tc->time_candidate-m_readout_window_map[tc->type].first << "/" << tc->time_candidate+m_readout_window_map[tc->type].second;
+      if (m_use_readout_map){
+        TLOG_DEBUG(1) << "Got TC of type " << static_cast<int>(tc->type) << ", timestamp " << tc->time_candidate
+                      << ", start/end " << tc->time_start << "/" << tc->time_end
+                      << ", readout start/end " << tc->time_candidate-m_readout_window_map[tc->type].first << "/" << tc->time_candidate+m_readout_window_map[tc->type].second;
+      } else {
+        TLOG_DEBUG(1) << "Got TC of type " << static_cast<int>(tc->type) << ", timestamp " << tc->time_candidate
+                      << ", start/end " << tc->time_start << "/" << tc->time_end;
+      }
       ++m_tc_received_count;
 
       // Option to ignore TC types (if given by config)
@@ -423,15 +432,27 @@ ModuleLevelTrigger::add_tc(const triggeralgs::TriggerCandidate& tc)
 
   for (std::vector<PendingTD>::iterator it = m_pending_tds.begin(); it != m_pending_tds.end();) {
     if (check_overlap(tc, *it)) {
-      TLOG_DEBUG(3) << "TC with start/end times " << tc.time_candidate-m_readout_window_map[tc.type].first << "/" << tc.time_candidate+m_readout_window_map[tc.type].second
-                    << " overlaps with pending TD with start/end times " << it->readout_start << "/" << it->readout_end;
-      it->contributing_tcs.push_back(tc);
-      it->readout_start = ((tc.time_candidate - m_readout_window_map[tc.type].first) >= it->readout_start)
-                            ? it->readout_start
-                            : (tc.time_candidate - m_readout_window_map[tc.type].first);
-      it->readout_end = ((tc.time_candidate + m_readout_window_map[tc.type].second) >= it->readout_end)
-                          ? (tc.time_candidate + m_readout_window_map[tc.type].second)
-                          : it->readout_end;
+      if (m_use_readout_map){
+        TLOG_DEBUG(3) << "TC with start/end times " << tc.time_candidate-m_readout_window_map[tc.type].first << "/" << tc.time_candidate+m_readout_window_map[tc.type].second
+                      << " overlaps with pending TD with start/end times " << it->readout_start << "/" << it->readout_end;
+        it->contributing_tcs.push_back(tc);
+        it->readout_start = ((tc.time_candidate - m_readout_window_map[tc.type].first) >= it->readout_start)
+                              ? it->readout_start
+                              : (tc.time_candidate - m_readout_window_map[tc.type].first);
+        it->readout_end = ((tc.time_candidate + m_readout_window_map[tc.type].second) >= it->readout_end)
+                            ? (tc.time_candidate + m_readout_window_map[tc.type].second)
+                            : it->readout_end;
+      } else {
+        TLOG_DEBUG(3) << "TC with start/end times " << tc.time_start << "/" << tc.time_end
+                      << " overlaps with pending TD with start/end times " << it->readout_start << "/" << it->readout_end;
+        it->contributing_tcs.push_back(tc);
+        it->readout_start = (tc.time_start >= it->readout_start)
+                             ? it->readout_start
+                             : tc.time_start;
+        it->readout_end = (tc.time_end >= it->readout_end)
+                           ? tc.time_end
+                           : it->readout_end;
+      }
       it->walltime_expiration = tc_wallclock_arrived + m_buffer_timeout;
       added_to_existing = true;
       break;
@@ -442,8 +463,13 @@ ModuleLevelTrigger::add_tc(const triggeralgs::TriggerCandidate& tc)
   if (!added_to_existing) {
     PendingTD td_candidate;
     td_candidate.contributing_tcs.push_back(tc);
-    td_candidate.readout_start = tc.time_candidate - m_readout_window_map[tc.type].first;
-    td_candidate.readout_end = tc.time_candidate + m_readout_window_map[tc.type].second;
+    if (m_use_readout_map){
+      td_candidate.readout_start = tc.time_candidate - m_readout_window_map[tc.type].first;
+      td_candidate.readout_end = tc.time_candidate + m_readout_window_map[tc.type].second;
+    } else {
+      td_candidate.readout_start = tc.time_start;
+      td_candidate.readout_end = tc.time_end;
+    }
     td_candidate.walltime_expiration = tc_wallclock_arrived + m_buffer_timeout;
     m_pending_tds.push_back(td_candidate);
   }
@@ -455,8 +481,13 @@ ModuleLevelTrigger::add_tc_ignored(const triggeralgs::TriggerCandidate& tc)
 {
   for (std::vector<PendingTD>::iterator it = m_pending_tds.begin(); it != m_pending_tds.end();) {
     if (check_overlap(tc, *it)) {
-      TLOG_DEBUG(3) << "!Ignored! TC with start/end times " << tc.time_candidate-m_readout_window_map[tc.type].first << "/" << tc.time_candidate+m_readout_window_map[tc.type].second
-                    << " overlaps with pending TD with start/end times " << it->readout_start << "/" << it->readout_end;
+      if (m_use_readout_map){
+        TLOG_DEBUG(3) << "!Ignored! TC with start/end times " << tc.time_candidate-m_readout_window_map[tc.type].first << "/" << tc.time_candidate+m_readout_window_map[tc.type].second
+                      << " overlaps with pending TD with start/end times " << it->readout_start << "/" << it->readout_end;
+      } else {
+        TLOG_DEBUG(3) << "!Ignored! TC with start/end times " << tc.time_start << "/" << tc.time_end
+                      << " overlaps with pending TD with start/end times " << it->readout_start << "/" << it->readout_end;
+      }
       it->contributing_tcs.push_back(tc);
       break;
     }
@@ -468,8 +499,13 @@ ModuleLevelTrigger::add_tc_ignored(const triggeralgs::TriggerCandidate& tc)
 bool
 ModuleLevelTrigger::check_overlap(const triggeralgs::TriggerCandidate& tc, const PendingTD& pending_td)
 {
-  return !(((tc.time_candidate + m_readout_window_map[tc.type].second) < pending_td.readout_start) ||
-           ((tc.time_candidate - m_readout_window_map[tc.type].first > pending_td.readout_end)));
+  if (m_use_readout_map){
+    return !(((tc.time_candidate + m_readout_window_map[tc.type].second) < pending_td.readout_start) ||
+             ((tc.time_candidate - m_readout_window_map[tc.type].first > pending_td.readout_end)));
+  } else {
+    return !((tc.time_end < pending_td.readout_start) ||
+             (tc.time_start > pending_td.readout_end));
+  }
 }
 
 bool

--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -137,6 +137,7 @@ private:
   int get_earliest_tc_index(const PendingTD& pending_td);
 
   // Readout map config
+  bool m_use_readout_map;
   nlohmann::json m_readout_window_map_data;
   std::map<detdataformats::trigger::TriggerCandidateData::Type,
            std::pair<triggeralgs::timestamp_t, triggeralgs::timestamp_t>>

--- a/schema/trigger/moduleleveltrigger.jsonnet
+++ b/schema/trigger/moduleleveltrigger.jsonnet
@@ -11,6 +11,7 @@ local types = {
   time_t : s.number("time_t", "i8", doc="Time"),
   tc_type : s.number("tc_type", "i4", doc="TC type"),
   tc_types : s.sequence("tc_types", self.tc_type, doc="List of TC types"),
+  use_ro_map : s.boolean("use_ro_map", doc="Flaf to use custom readout map"),
   readout_time:    s.number(   "ROTime",        "i8", doc="A readout time in ticks"),
 
   tc_readout: s.record("tc_readout", [
@@ -98,6 +99,7 @@ local types = {
       s.field("buffer_timeout", self.time_t, 100, doc="Buffering timeout [ms] for new TCs"),
       s.field("td_readout_limit", self.time_t, 1000, doc="Time limit [ms] for the length of TD readout window"),
       s.field("ignore_tc", self.tc_types, [], doc="List of TC types to be ignored"),
+      s.field("use_readout_map", self.use_ro_map, default=false, doc="Option to use defalt readout windows (tc.time_start and tc.time_end) or a custom readout map from daqconf"),
       s.field("td_readout_map", self.tc_readout_map, self.tc_readout_map, doc="A map holding readout pre/post depending on TC type"),
   ], doc="ModuleLevelTrigger configuration parameters"),
   


### PR DESCRIPTION
A fix for the MLT readout map.
It makes the readout map optional, and it is false by default. 
If the map is to be used, the readout windows are passed from daqconf configuration.
If the map is not to be used, MLT uses TC.time_start and TC.time_end, as was the case before the use of the map.