### PR TITLE
fix for the stop command logic in TP Channel Filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(trigger VERSION 1.5.7)
+project(trigger VERSION 1.5.8)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/trigger/Tee.hxx
+++ b/include/trigger/Tee.hxx
@@ -79,7 +79,7 @@ Tee<T>::do_work(std::atomic<bool>& running_flag)
 {
   size_t n_objects = 0;
   
-  while (true) {
+  while (running_flag.load()) {
     T object;
     try {
       object = m_input_queue->receive(std::chrono::milliseconds(100));
@@ -108,7 +108,6 @@ Tee<T>::do_work(std::atomic<bool>& running_flag)
       ers::warning(dunedaq::iomanager::TimeoutExpired(ERS_HERE, get_name(), "push to output queue 2", timeout_ms));
     }
   }
-
   TLOG() << get_name() << ": Exiting do_work() method after receiving " << n_objects << " objects";
 }
 

--- a/plugins/TPChannelFilter.hpp
+++ b/plugins/TPChannelFilter.hpp
@@ -47,7 +47,7 @@ private:
   void do_start(const nlohmann::json& obj);
   void do_stop(const nlohmann::json& obj);
   void do_scrap(const nlohmann::json& obj);
-  void do_work(std::atomic<bool>&);
+  void do_work();
 
   bool channel_should_be_removed(int channel) const;
   dunedaq::utilities::WorkerThread m_thread;
@@ -55,7 +55,6 @@ private:
   using metric_counter_type = decltype(tpchannelfilterinfo::Info::received_count);
   std::atomic<metric_counter_type> m_received_count;
   std::atomic<metric_counter_type> m_sent_count;
-
 
   using source_t = dunedaq::iomanager::ReceiverConcept<TPSet>;
   std::shared_ptr<source_t> m_input_queue;
@@ -66,6 +65,9 @@ private:
   std::shared_ptr<detchannelmaps::TPCChannelMap> m_channel_map;
 
   dunedaq::trigger::tpchannelfilter::Conf m_conf;
+
+  // Are we in the RUNNING state?
+  std::atomic<bool> m_running_flag{ false };
 };
 } // namespace trigger
 } // namespace dunedaq

--- a/plugins/TriggerZipper.hpp
+++ b/plugins/TriggerZipper.hpp
@@ -177,7 +177,7 @@ public:
   // thread worker
   void worker()
   {
-    while (true) {
+    while (m_running.load()) {
       // Once we've received a stop command, keep reading the input
       // queue until there's nothing left on it
       if (!proc_one() && !m_running.load()) {


### PR DESCRIPTION
An issue was discovered where the trigger app would not stop in time - especially reproducible when running with multiple readouts. The issue was tracked back to the TPChannelFilter. The logic for checking the stop command was updated and did fix the issue for a particular test. (more testing needed)