### PR TITLE
Modified one of the drain() methods in TriggerGenericMaker to try to …

### DIFF
--- a/src/trigger/TriggerGenericMaker.hpp
+++ b/src/trigger/TriggerGenericMaker.hpp
@@ -543,8 +543,10 @@ public: // NOLINT
             ers::error(AlgorithmFailedToSend(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
             // out.back() is dropped
           }
-          out_vec.pop_back();
         }
+        // 11-Jul-2023, KAB et al: moved the pop_back() call outside the 'if (!drop)' block so that
+        // this code doesn't loop forever.
+        out_vec.pop_back();
       }
     }
   }


### PR DESCRIPTION
…avoid looping forever.

Our sense is that the `out_vec.pop_back()` call should have always been outside the "`if (!drop)`" block.

As part of this, our current feeling is that "drop" means "don't send downstream".  I don't believe that "drop" means "remove the data from internal buffers" because I think that the data *always* needs to be removed from the internal buffers.  If this interpretation is correct, then a different name for the "drop" argument might be better...  (later)

This change has been confirmed to avoid the Stop transition timeout that Wes Ketchum reported when running with DUNE-WIBs and TPG on APA2 at NP04 using fd-dunedaq-v4.1.0 release-candidate-3.