### PR TITLE
fixes for random and custom TC maker plugins

### DIFF
--- a/plugins/CustomTriggerCandidateMaker.cpp
+++ b/plugins/CustomTriggerCandidateMaker.cpp
@@ -58,7 +58,7 @@ CustomTriggerCandidateMaker::CustomTriggerCandidateMaker(const std::string& name
 void
 CustomTriggerCandidateMaker::init(const nlohmann::json& obj)
 {
-  m_time_sync_source = get_iom_receiver<dfmessages::TimeSync>(appfwk::connection_uid(obj, "time_sync_source"));
+  m_time_sync_source = get_iom_receiver<dfmessages::TimeSync>(".*");
   m_trigger_candidate_sink =
     get_iom_sender<triggeralgs::TriggerCandidate>(appfwk::connection_uid(obj, "trigger_candidate_sink"));
 }

--- a/plugins/RandomTriggerCandidateMaker.cpp
+++ b/plugins/RandomTriggerCandidateMaker.cpp
@@ -50,9 +50,9 @@ RandomTriggerCandidateMaker::RandomTriggerCandidateMaker(const std::string& name
 void
 RandomTriggerCandidateMaker::init(const nlohmann::json& obj)
 {
-  m_time_sync_source = get_iom_receiver<dfmessages::TimeSync>(appfwk::connection_uid(obj, "time_sync_source"));
+  m_time_sync_source = get_iom_receiver<dfmessages::TimeSync>(".*");
   m_trigger_candidate_sink =
-    get_iom_sender<triggeralgs::TriggerCandidate>(appfwk::connection_uid(obj, "trigger_candiate_sink"));
+    get_iom_sender<triggeralgs::TriggerCandidate>(appfwk::connection_uid(obj, "trigger_candidate_sink"));
 }
 
 void
@@ -68,7 +68,7 @@ RandomTriggerCandidateMaker::get_info(opmonlib::InfoCollector& ci, int /*level*/
 void
 RandomTriggerCandidateMaker::do_configure(const nlohmann::json& obj)
 {
-  m_conf = obj.get<randomtriggercandidatemaker::ConfParams>();
+  m_conf = obj.get<randomtriggercandidatemaker::Conf>();
 }
 
 void

--- a/plugins/RandomTriggerCandidateMaker.hpp
+++ b/plugins/RandomTriggerCandidateMaker.hpp
@@ -78,7 +78,7 @@ private:
   std::shared_ptr<iomanager::ReceiverConcept<dfmessages::TimeSync>> m_time_sync_source;
   std::shared_ptr<iomanager::SenderConcept<triggeralgs::TriggerCandidate>> m_trigger_candidate_sink;
 
-  randomtriggercandidatemaker::ConfParams m_conf;
+  randomtriggercandidatemaker::Conf m_conf;
 
   int get_interval(std::mt19937& gen);
 

--- a/schema/trigger/randomtriggercandidatemaker.jsonnet
+++ b/schema/trigger/randomtriggercandidatemaker.jsonnet
@@ -8,7 +8,7 @@ local types = {
   timestamp_estimation: s.enum("timestamp_estimation", ["kTimeSync", "kSystemClock"]),
   distribution_type: s.enum("distribution_type", ["kUniform", "kPoisson"]),
   
-  conf : s.record("ConfParams", [
+  conf : s.record("Conf", [
     s.field("trigger_interval_ticks", self.ticks, 64000000,
       doc="Interval between triggers in 16 ns time ticks (default 1.024 s) "),
 


### PR DESCRIPTION
A fix to make RandomTriggerCandidateMaker functional, including all configuration parameters. 

RTCM is a standalone module that inserts TCs straight into the MLT. 
These TCs can be created at a configurable frequency. 
The are two methods when creating these: a flat distribution (kUniform) and a random Poisson distribution (kPoisson). 
The time estimation can be done either via system clock or using the TimeSync messages. 
More details are available here: [slides](https://indico.fnal.gov/event/61371/contributions/275588/attachments/171005/230370/RTCM.pdf)

Example configuration for testing:
 ```
"trigger": { 

    "use_random_maker": true,
    "rtcm_timestamp_method": "kSystemClock",
    "rtcm_time_distribution": "kUniform",
    "rtcm_trigger_interval_ticks": 32000000

  }
```
  
  Minimal configuration for testing (that uses defaults):
 ```
"trigger": {
    "use_random_maker": true,
...
  }
```