### PR TITLE
Possible readout window change in MLT when use_roi_readout is true 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(trigger VERSION 1.6.0)
+project(trigger VERSION 1.6.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -962,7 +962,8 @@ ModuleLevelTrigger::roi_readout_make_requests(dfmessages::TriggerDecision& decis
 
     // Once the components are prepared, create requests and append them to decision
     std::vector<dfmessages::ComponentRequest> requests =
-      create_all_decision_requests(links, this_group.time_window, this_group.time_window);
+      create_all_decision_requests(links, decision.trigger_timestamp - this_group.time_window,
+                                   decision.trigger_timestamp + this_group.time_window);
     add_requests_to_decision(decision, requests);
     links.clear();
   }


### PR DESCRIPTION
In ModuleLevelTrigger::roi_readout_make_requests(), this change bases the readout window on trigger time plus/minus the configured time window...

Not sure if this change is reasonable, but without it, we get no data fragments from the DataLinkHandlers in the Readout Apps or TPBuffers in the Trigger App.  To be discussed at the next Release Coordination meeting...