### PR TITLE
Added mutex to MLT code to protect against a race condition in which a TD is sent to the DFO after triggers are disabled

### DIFF
--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -181,7 +181,7 @@ ModuleLevelTrigger::do_start(const nlohmann::json& startobj)
 
   m_inhibit_input->add_callback(std::bind(&ModuleLevelTrigger::dfo_busy_callback, this, std::placeholders::_1));
 
-  m_bitword_check = false;  // this needs to be before the send thread is started, or it needs to be removed; why is it a class datat member anyway?
+  m_bitword_check = false;  // this needs to be before the send thread is started, or it needs to be removed; why is it a class data member anyway?
   m_send_trigger_decisions_thread = std::thread(&ModuleLevelTrigger::send_trigger_decisions, this);
   pthread_setname_np(m_send_trigger_decisions_thread.native_handle(), "mlt-trig-dec");
 

--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -153,6 +153,7 @@ private:
   std::vector<PendingTD> m_pending_tds;
   std::vector<PendingTD> m_sent_tds;
   std::mutex m_td_vector_mutex;
+  std::mutex m_pause_resume_mutex;
 
   void add_tc(const triggeralgs::TriggerCandidate& tc);
   void add_td(const PendingTD& pending_td);


### PR DESCRIPTION
When running automated integration tests in fddaq-v4.2.0 and later systems, I occasionally see complaints from the DFO that it received a TriggerDecision message with the wrong run number.  This always happens at the beginning of a 2nd or 3rd run in a single DAQ session.  

I believe that the problem is that the MLT has sent a TD after triggers have been disabled.  This should not happen, but I believe that a bug is allowing it to happen.  

I believe that the sequence goes something like this:

- run control sends a 'disable_triggers' command to the MLT, and the MLT replies that it has done so.  However, there is a bug/race condition in the MLT code that allows it to send another TD even after is says that it has disabled triggers.
- run control sends 'stop' commands to the MLT, DFO, and every other process and module in the system.  
- the stop command arrives at the DFO very quickly, before it has a chance to read in the new TD message from the MLT
- when the next run is started, the DFO finds the stale TD in its connection to the MLT, and it issues the warning message

The main change to the code that I made is to protect the whole block of code in the call_tc_decisio() method that depends on the m_paused variable from changes to that variable from a different thread.  With this change, the m_paused variable can probable be made a simple boolean variable instead of an atomic one, but I haven't made that change yet.  (we can talk about that or leave it as it is)

There was also a change to the initialization of the m_bitword_check variable.  I'm not sure why this isn't just a local variable in the call_tc_decision() method, but if it does need to be a class data member, then it should be initialized before the thread that makes use of it is started.

I've tried to confirm that these changes effectively prevent the complaints from the DFO about stale TD messaes, but the problem happens so rarely, I don't yet have statistics like "it happens once in every N test runs before the change, and it happens zero times in 2N runs after the change".  But, I wanted to go ahead and file the PR so that others are aware of this problem and possible solution.