### PR TITLE
Adding small readout window to TCs from RTCM and CTCM

### DIFF
--- a/plugins/CustomTriggerCandidateMaker.cpp
+++ b/plugins/CustomTriggerCandidateMaker.cpp
@@ -143,8 +143,8 @@ triggeralgs::TriggerCandidate
 CustomTriggerCandidateMaker::create_candidate(dfmessages::timestamp_t timestamp, int tc_type)
 {
   triggeralgs::TriggerCandidate candidate;
-  candidate.time_start = timestamp;
-  candidate.time_end = timestamp;
+  candidate.time_start = (timestamp - 1000);
+  candidate.time_end = (timestamp + 1000);
   candidate.time_candidate = timestamp;
   candidate.detid = { 0 };
   candidate.type = static_cast<dunedaq::trgdataformats::TriggerCandidateData::Type>(tc_type);

--- a/plugins/RandomTriggerCandidateMaker.cpp
+++ b/plugins/RandomTriggerCandidateMaker.cpp
@@ -117,8 +117,8 @@ triggeralgs::TriggerCandidate
 RandomTriggerCandidateMaker::create_candidate(dfmessages::timestamp_t timestamp)
 {
   triggeralgs::TriggerCandidate candidate;
-  candidate.time_start = timestamp;
-  candidate.time_end = timestamp;
+  candidate.time_start = (timestamp - 1000);
+  candidate.time_end = (timestamp + 1000);
   candidate.time_candidate = timestamp;
   candidate.detid = { 0 };
   candidate.type = triggeralgs::TriggerCandidate::Type::kRandom;


### PR DESCRIPTION
This PR adds little (hardcoded) offsets to the readout windows of TC objects produced by both Random TCM and Custom TCM.
This is to avoid 0 length readout windows (as was the case previously), until a more permanent (and/or elegant) solution is designed. 

For testing I've looked at the output of the trigger log and used the HDF5LIBS_TestDumpRecord.
Results from tests of RTCM:
```
2024-Jan-18 18:13:33,010 DEBUG_1 [void dunedaq::trigger::ModuleLevelTrigger::send_trigger_decisions() at /nfs/home/mrigan/dune-daq/dev/sourcecode/trigger/plugins/ModuleLevelTrigger.cpp:342] Got TC of type 4, timestamp 106599875812500000, start/end 106599875812499000/106599875812501000
2024-Jan-18 18:13:34,006 DEBUG_1 [void dunedaq::trigger::ModuleLevelTrigger::send_trigger_decisions() at /nfs/home/mrigan/dune-daq/dev/sourcecode/trigger/plugins/ModuleLevelTrigger.cpp:342] Got TC of type 4, timestamp 106599875875000000, start/end 106599875874999000/106599875875001000
2024-Jan-18 18:13:35,002 DEBUG_1 [void dunedaq::trigger::ModuleLevelTrigger::send_trigger_decisions() at /nfs/home/mrigan/dune-daq/dev/sourcecode/trigger/plugins/ModuleLevelTrigger.cpp:342] Got TC of type 4, timestamp 106599875937500000, start/end 106599875937499000/106599875937501000
2024-Jan-18 18:13:36,009 DEBUG_1 [void dunedaq::trigger::ModuleLevelTrigger::send_trigger_decisions() at /nfs/home/mrigan/dune-daq/dev/sourcecode/trigger/plugins/ModuleLevelTrigger.cpp:342] Got TC of type 4, timestamp 106599876000000000, start/end 106599875999999000/106599876000001000
```
```
        WIBEth fragment with SourceID Detector_Readout_0x00000065 from subdetector HD_TPC has size = 72
                It may contain data from the following detector components:
                        subdetector HD_TPC, crate 1, slot 0, link 1
                Readout window before = 1000, after = 1000
        Hardware_Signal fragment with SourceID HW_Signals_Interface_0x00000000 from subdetector DAQ has size = 72
                Readout window before = 1000, after = 1000
        Trigger_Candidate fragment with SourceID Trigger_0x00000000 from subdetector DAQ has size = 128
                TC type = kRandom (4), TC algorithm = 2, number of TAs = 0
                Start time = 106599875874999000, end time = 106599875875001000, and candidate time = 106599875875000000
                Readout window before = 1000, after = 1000
```
Results from tests of CTCM:
```
2024-Jan-18 18:29:05,289 DEBUG_1 [void dunedaq::trigger::ModuleLevelTrigger::send_trigger_decisions() at /nfs/home/mrigan/dune-daq/dev/sourcecode/trigger/plugins/ModuleLevelTrigger.cpp:342] Got TC of type 1, timestamp 106599934080000000, start/end 106599934079999000/106599934080001000
2024-Jan-18 18:29:05,289 DEBUG_1 [void dunedaq::trigger::ModuleLevelTrigger::send_trigger_decisions() at /nfs/home/mrigan/dune-daq/dev/sourcecode/trigger/plugins/ModuleLevelTrigger.cpp:342] Got TC of type 3, timestamp 106599934080000000, start/end 106599934079999000/106599934080001000
2024-Jan-18 18:29:05,289 DEBUG_1 [void dunedaq::trigger::ModuleLevelTrigger::send_trigger_decisions() at /nfs/home/mrigan/dune-daq/dev/sourcecode/trigger/plugins/ModuleLevelTrigger.cpp:342] Got TC of type 2, timestamp 106599934080000000, start/end 106599934079999000/106599934080001000
2024-Jan-18 18:29:05,601 DEBUG_1 [void dunedaq::trigger::ModuleLevelTrigger::send_trigger_decisions() at /nfs/home/mrigan/dune-daq/dev/sourcecode/trigger/plugins/ModuleLevelTrigger.cpp:342] Got TC of type 1, timestamp 106599934100000000, start/end 106599934099999000/106599934100001000
2024-Jan-18 18:29:05,601 DEBUG_1 [void dunedaq::trigger::ModuleLevelTrigger::send_trigger_decisions() at /nfs/home/mrigan/dune-daq/dev/sourcecode/trigger/plugins/ModuleLevelTrigger.cpp:342] Got TC of type 4, timestamp 106599934100000000, start/end 106599934099999000/106599934100001000
```
```
2024-Jan-18 18:32:04,479 LOG [main(...) at /nfs/home/mrigan/dune-daq/dev/sourcecode/hdf5libs/test/apps/HDF5LIBS_TestDumpRecord.cpp:103]
        TriggerRecordHeader: check_word: 33334444, version: 3, trigger_number: 5, run_number: 2, trigger_timestamp: 106599932180000000, trigger_type: 1, error_bits: 0, num_requested_components: 4, sequence_number: 0, max_sequence_number: 0, element_id: { subsystem: TR_Builder id: 0 }
        WIBEth fragment with SourceID Detector_Readout_0x00000064 from subdetector HD_TPC has size = 72
                It may contain data from the following detector components:
                        subdetector HD_TPC, crate 1, slot 0, link 0
                Readout window before = 1000, after = 1000
        WIBEth fragment with SourceID Detector_Readout_0x00000065 from subdetector HD_TPC has size = 72
                It may contain data from the following detector components:
                        subdetector HD_TPC, crate 1, slot 0, link 1
                Readout window before = 1000, after = 1000
        Hardware_Signal fragment with SourceID HW_Signals_Interface_0x00000000 from subdetector DAQ has size = 72
                Readout window before = 1000, after = 1000
        Trigger_Candidate fragment with SourceID Trigger_0x00000000 from subdetector DAQ has size = 128
                TC type = kTiming (1), TC algorithm = 8, number of TAs = 0
                Start time = 106599932179999000, end time = 106599932180001000, and candidate time = 106599932180000000
                Readout window before = 1000, after = 1000
2024-Jan-18 18:32:04,481 LOG [main(...) at /nfs/home/mrigan/dune-daq/dev/sourcecode/hdf5libs/test/apps/HDF5LIBS_TestDumpRecord.cpp:103]
        TriggerRecordHeader: check_word: 33334444, version: 3, trigger_number: 6, run_number: 2, trigger_timestamp: 106599932190000000, trigger_type: 1, error_bits: 0, num_requested_components: 4, sequence_number: 0, max_sequence_number: 0, element_id: { subsystem: TR_Builder id: 0 }
        WIBEth fragment with SourceID Detector_Readout_0x00000064 from subdetector HD_TPC has size = 72
                It may contain data from the following detector components:
                        subdetector HD_TPC, crate 1, slot 0, link 0
                Readout window before = 1000, after = 1000
        WIBEth fragment with SourceID Detector_Readout_0x00000065 from subdetector HD_TPC has size = 72
                It may contain data from the following detector components:
                        subdetector HD_TPC, crate 1, slot 0, link 1
                Readout window before = 1000, after = 1000
        Hardware_Signal fragment with SourceID HW_Signals_Interface_0x00000000 from subdetector DAQ has size = 72
                Readout window before = 1000, after = 1000
        Trigger_Candidate fragment with SourceID Trigger_0x00000000 from subdetector DAQ has size = 128
                TC type = kTPCLowE (2), TC algorithm = 8, number of TAs = 0
                Start time = 106599932189999000, end time = 106599932190001000, and candidate time = 106599932190000000
                Readout window before = 1000, after = 1000
```
I've also run minimal integration tests but these generally do not use these makers.