### PR TITLE
Changed kTPCDefault to kSimpleThreshold in several test/unittest files

### DIFF
--- a/test/apps/set_serialization_speed.cxx
+++ b/test/apps/set_serialization_speed.cxx
@@ -52,7 +52,7 @@ time_serialization(int tps_per_set)
       tp.adc_peak = uniform(generator);
       tp.detid = 1;
       tp.type = triggeralgs::TriggerPrimitive::Type::kUnknown;
-      tp.algorithm = triggeralgs::TriggerPrimitive::Algorithm::kTPCDefault;
+      tp.algorithm = triggeralgs::TriggerPrimitive::Algorithm::kSimpleThreshold;
       tp.flag = 1;
 
       set.objects.push_back(tp);

--- a/unittest/AlgorithmPlugins_test.cxx
+++ b/unittest/AlgorithmPlugins_test.cxx
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(TAFactory)
 
   for (int idx = 0; idx < 10; idx++) {
     tp.type = triggeralgs::TriggerPrimitive::Type::kTPC;
-    tp.algorithm = triggeralgs::TriggerPrimitive::Algorithm::kTPCDefault;
+    tp.algorithm = triggeralgs::TriggerPrimitive::Algorithm::kSimpleThreshold;
     tp.time_start = idx;
     tp.time_peak = 1+idx;
     tp.time_over_threshold = 2;

--- a/unittest/TriggerObjectOverlay_test.cxx
+++ b/unittest/TriggerObjectOverlay_test.cxx
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(TriggerActivityOverlay_in_out) {
     primitive.adc_peak = i+5;     // NOLINT(build/unsigned)
     primitive.detid = i+65;
     primitive.type = TriggerPrimitive::Type::kPDS;
-    primitive.algorithm = TriggerPrimitive::Algorithm::kTPCDefault;
+    primitive.algorithm = TriggerPrimitive::Algorithm::kSimpleThreshold;
     primitive.flag = 1;
 
     activity.inputs.push_back(primitive);


### PR DESCRIPTION
One of several additional changes needed to react to [the change from a single TP Algorithm name to several of them with more descriptive names](https://github.com/DUNE-DAQ/trgdataformats/pull/10/files).