### PR TITLE
Asztuc/tcmaking oks fix

### DIFF
--- a/plugins/DataSubscriber.cpp
+++ b/plugins/DataSubscriber.cpp
@@ -13,6 +13,7 @@
 #include "readoutlibs/models/DataSubscriberModel.hpp"
 #include "trigger/HSISourceModel.hpp"
 #include "trigger/TPSetSourceModel.hpp"
+#include "trigger/TriggerSourceModel.hpp"
 
 #include "appdal/DataSubscriber.hpp"
 
@@ -93,14 +94,14 @@ DataSubscriber::create_data_subscriber(const coredal::DaqModule* cfg)
   if (raw_dt == "TriggerActivity") {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating trigger activities subscriber";
     auto source_model =
-      std::make_unique<readoutlibs::DataSubscriberModel<triggeralgs::TriggerActivity, trigger::TAWrapper>>();
+      std::make_unique<trigger::TriggerSourceModel<triggeralgs::TriggerActivity, trigger::TAWrapper>>();
     return source_model;
   }
 
   if (raw_dt == "TriggerCandidate") {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating trigger candidates subscriber";
     auto source_model =
-      std::make_unique<readoutlibs::DataSubscriberModel<triggeralgs::TriggerCandidate, trigger::TCWrapper>>();
+      std::make_unique<trigger::TriggerSourceModel<triggeralgs::TriggerCandidate, trigger::TCWrapper>>();
     return source_model;
   }
 

--- a/src/trigger/TriggerSourceModel.hpp
+++ b/src/trigger/TriggerSourceModel.hpp
@@ -1,0 +1,105 @@
+/**
+ * @file TriggerSourceModel.hpp
+ *
+ * This is part of the DUNE DAQ , copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef TRIGGER_SRC_TRIGGER_TRIGGERSOURCEMODEL_HPP_
+#define TRIGGER_SRC_TRIGGER_TRIGGERSOURCEMODEL_HPP_
+
+#include <functional>
+#include "readoutlibs/concepts/SourceConcept.hpp"
+#include "detdataformats/DetID.hpp"
+#include "dfmessages/HSIEvent.hpp"
+#include "triggeralgs/TriggerCandidate.hpp"
+#include "trigger/TCWrapper.hpp"
+
+
+#include "iomanager/IOManager.hpp"
+#include "iomanager/Sender.hpp"
+#include "iomanager/Receiver.hpp"
+#include "logging/Logging.hpp"
+#include "coredal/DaqModule.hpp"
+#include "appdal/DataSubscriber.hpp"
+#include "trigger/TAWrapper.hpp"
+#include "trigger/TCWrapper.hpp"
+
+//#include "appdal/HSI2TCTranslatorConf.hpp" 
+//#include "appdal/HSISignalWindow.hpp" 
+
+namespace dunedaq::trigger {
+
+
+template<class TriggerXObject, class TXWrapper>
+class TriggerSourceModel : public readoutlibs::SourceConcept
+{
+public: 
+  using inherited = readoutlibs::SourceConcept;
+
+  /**
+   * @brief SourceModel Constructor
+   * @param name Instance name for this SourceModel instance
+   */
+  
+  TriggerSourceModel(): readoutlibs::SourceConcept() {}
+  ~TriggerSourceModel() {}
+
+  void init(const coredal::DaqModule* cfg) override {
+    if (cfg->get_outputs().size() != 1) {
+      throw readoutlibs::InitializationError(ERS_HERE, "Only 1 output supported for subscribers");
+    }
+    m_data_sender = get_iom_sender<TXWrapper>(cfg->get_outputs()[0]->UID());
+
+    if (cfg->get_inputs().size() != 1) {
+      throw readoutlibs::InitializationError(ERS_HERE, "Only 1 input supported for subscribers");
+    }
+    m_data_receiver = get_iom_receiver<TriggerXObject>(cfg->get_inputs()[0]->UID());
+/*
+    auto data_reader = cfg->cast<appdal::DataSubscriber>();
+    if (data_reader == nullptr) {
+       throw readoutlibs::InitializationError(ERS_HERE, "DAQ module is not a DataReader");
+    }
+    auto hsi_conf = data_reader->get_configuration()->cast<appdal::HSI2TCTranslatorConf>();
+    if (hsi_conf == nullptr) {
+	throw readoutlibs::InitializationError(ERS_HERE, "Missing HSI2TCTranslatorConf");
+    }
+    for (auto win : hsi_conf->get_signals()) {
+	   m_signals[win->get_signal_type()] = std::pair<uint32_t, uint32_t>(win->get_time_before(), win->get_time_after());
+    }
+    */
+  }
+
+  void start() {
+    m_data_receiver->add_callback(std::bind(&TriggerSourceModel::handle_payload, this, std::placeholders::_1));
+  }  
+
+  void stop() {
+    m_data_receiver->remove_callback();
+  }
+
+  void get_info(opmonlib::InfoCollector& /*ci*/, int /*level*/) {}
+
+  bool handle_payload(TriggerXObject& data) // NOLINT(build/unsigned)
+  {
+    TXWrapper tx(data);
+    if (!m_data_sender->try_send(std::move(tx), iomanager::Sender::s_no_block)) {
+      ++m_dropped_packets;
+    }
+    return true;
+  }
+
+private:
+  using source_t = dunedaq::iomanager::ReceiverConcept<TriggerXObject>;
+  std::shared_ptr<source_t> m_data_receiver;
+
+  using sink_t = dunedaq::iomanager::SenderConcept<TXWrapper>;
+  std::shared_ptr<sink_t> m_data_sender;
+
+  //Stats
+  std::atomic<uint64_t> m_dropped_packets{0};
+};
+
+} // namespace dunedaq::trigger
+
+#endif // TRIGGER_SRC_TRIGGER_TRIGGERSOURCEMODEL_HPP_


### PR DESCRIPTION
Adding new subscriber model that does `TriggerDatatype` -> `TDatatypeWrapper` conversion correctly, via 
`TDatatypeWrapper tdata(TriggerDatatype)` rather than with casts (the `TXWrapper(TriggerX _)` constructor must be called to fill the buffers correctly).

It feels a bit annoying to make whole new class with everything copy-pasted, maybe basing this class off `readoutlibs::DataSubscriberModel` and overloading `DataSubscriberModel::handle_payload` would be better here? That's why it's a draft PR for now, in case @glehmannmiotto has a better idea.