### PR TITLE
Logging system rework

### DIFF
--- a/include/trigger/Logging.hpp
+++ b/include/trigger/Logging.hpp
@@ -1,0 +1,34 @@
+/**
+ * @file Logging.hpp Common logging declarations in triggeralgs
+ *
+ * This is part of the DUNE DAQ , copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef TRIGGER_INCLUDE_LOGGING_HPP_
+#define TRIGGER_INCLUDE_LOGGING_HPP_
+
+namespace dunedaq {
+namespace trigger {
+namespace logging {
+
+/**
+* @brief Common name used by TRACE TLOG calls from this package
+*/
+enum
+{
+  TLVL_VERY_IMPORTANT = 1,
+  TLVL_IMPORTANT      = 2,
+  TLVL_GENERAL        = 3,
+  TLVL_DEBUG_INFO     = 4,
+  TLVL_DEBUG_LOW      = 5,
+  TLVL_DEBUG_MEDIUM   = 10,
+  TLVL_DEBUG_HIGH     = 15,
+  TLVL_DEBUG_ALL      = 20
+};
+
+} // namespace logging
+} // namespace trigger
+} // namespace dunedaq
+
+#endif // TRIGGER_INCLUDE_LOGGING_HPP_

--- a/include/trigger/Tee.hxx
+++ b/include/trigger/Tee.hxx
@@ -15,7 +15,7 @@
 
 #include <string>
 
-using dunedaq::trigger::logging::TLVL_IMPORTANT;
+using dunedaq::trigger::logging::TLVL_GENERAL;
 
 namespace dunedaq {
 namespace trigger {
@@ -52,7 +52,7 @@ template<class T>
 void
 Tee<T>::do_conf(const nlohmann::json&)
 {
-  TLOG_DEBUG(TLVL_IMPORTANT) << "[Tee] " << get_name() + " configured.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[Tee] " << get_name() + " configured.";
 }
 
 template<class T>
@@ -60,7 +60,7 @@ void
 Tee<T>::do_start(const nlohmann::json&)
 {
   m_thread.start_working_thread("tee");
-  TLOG_DEBUG(TLVL_IMPORTANT) << "[Tee] " << get_name() + " successfully started.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[Tee] " << get_name() + " successfully started.";
 }
 
 template<class T>
@@ -68,7 +68,7 @@ void
 Tee<T>::do_stop(const nlohmann::json&)
 {
   m_thread.stop_working_thread();
-  TLOG_DEBUG(TLVL_IMPORTANT) << "[Tee] " << get_name() + " successfully stopped.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[Tee] " << get_name() + " successfully stopped.";
 }
 
 template<class T>
@@ -111,7 +111,7 @@ Tee<T>::do_work(std::atomic<bool>& running_flag)
       ers::warning(dunedaq::iomanager::TimeoutExpired(ERS_HERE, get_name(), "push to output queue 2", timeout_ms));
     }
   }
-  TLOG() << get_name() << ": Exiting do_work() method after receiving " << n_objects << " objects";
+  TLOG(1) << get_name() << ": Exiting do_work() method after receiving " << n_objects << " objects";
 }
 
 } // namespace trigger

--- a/include/trigger/Tee.hxx
+++ b/include/trigger/Tee.hxx
@@ -11,8 +11,11 @@
 #include "iomanager/IOManager.hpp"
 #include "rcif/cmd/Nljs.hpp"
 #include "trigger/Issues.hpp"
+#include "trigger/Logging.hpp"
 
 #include <string>
+
+using dunedaq::trigger::logging::TLVL_IMPORTANT;
 
 namespace dunedaq {
 namespace trigger {
@@ -49,7 +52,7 @@ template<class T>
 void
 Tee<T>::do_conf(const nlohmann::json&)
 {
-  TLOG_DEBUG(2) << get_name() + " configured.";
+  TLOG_DEBUG(TLVL_IMPORTANT) << "[Tee] " << get_name() + " configured.";
 }
 
 template<class T>
@@ -57,7 +60,7 @@ void
 Tee<T>::do_start(const nlohmann::json&)
 {
   m_thread.start_working_thread("tee");
-  TLOG_DEBUG(2) << get_name() + " successfully started.";
+  TLOG_DEBUG(TLVL_IMPORTANT) << "[Tee] " << get_name() + " successfully started.";
 }
 
 template<class T>
@@ -65,7 +68,7 @@ void
 Tee<T>::do_stop(const nlohmann::json&)
 {
   m_thread.stop_working_thread();
-  TLOG_DEBUG(2) << get_name() + " successfully stopped.";
+  TLOG_DEBUG(TLVL_IMPORTANT) << "[Tee] " << get_name() + " successfully stopped.";
 }
 
 template<class T>

--- a/include/trigger/Tee.hxx
+++ b/include/trigger/Tee.hxx
@@ -111,7 +111,7 @@ Tee<T>::do_work(std::atomic<bool>& running_flag)
       ers::warning(dunedaq::iomanager::TimeoutExpired(ERS_HERE, get_name(), "push to output queue 2", timeout_ms));
     }
   }
-  TLOG(1) << get_name() << ": Exiting do_work() method after receiving " << n_objects << " objects";
+  TLOG() << get_name() << ": Exiting do_work() method after receiving " << n_objects << " objects";
 }
 
 } // namespace trigger

--- a/plugins/CustomTriggerCandidateMaker.cpp
+++ b/plugins/CustomTriggerCandidateMaker.cpp
@@ -307,9 +307,9 @@ CustomTriggerCandidateMaker::print_timestamps_vector(std::vector<std::pair<int, 
 void
 CustomTriggerCandidateMaker::print_final_tc_counts(std::map<int, int> counts)
 {
-  TLOG(1) << "[CTCM] Final counts:";
+  TLOG() << "[CTCM] Final counts:";
   for (auto it = m_tc_settings.begin(); it != m_tc_settings.end(); it++) {
-    TLOG(1) << "[CTCM] TC type: " << it->first << ", interval: " << it->second << ", count: " << counts[it->first];
+    TLOG() << "[CTCM] TC type: " << it->first << ", interval: " << it->second << ", count: " << counts[it->first];
   }
   return;
 }

--- a/plugins/CustomTriggerCandidateMaker.cpp
+++ b/plugins/CustomTriggerCandidateMaker.cpp
@@ -43,7 +43,6 @@ sortbysec(const std::pair<int, dunedaq::dfmessages::timestamp_t>& a,
 }
 
 using dunedaq::trigger::logging::TLVL_GENERAL;
-using dunedaq::trigger::logging::TLVL_DEBUG_INFO;
 using dunedaq::trigger::logging::TLVL_DEBUG_LOW;
 using dunedaq::trigger::logging::TLVL_DEBUG_MEDIUM;
 using dunedaq::trigger::logging::TLVL_DEBUG_HIGH;
@@ -308,9 +307,9 @@ CustomTriggerCandidateMaker::print_timestamps_vector(std::vector<std::pair<int, 
 void
 CustomTriggerCandidateMaker::print_final_tc_counts(std::map<int, int> counts)
 {
-  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[CTCM] Final counts:";
+  TLOG(1) << "[CTCM] Final counts:";
   for (auto it = m_tc_settings.begin(); it != m_tc_settings.end(); it++) {
-    TLOG_DEBUG(TLVL_DEBUG_INFO) << "[CTCM] TC type: " << it->first << ", interval: " << it->second << ", count: " << counts[it->first];
+    TLOG(1) << "[CTCM] TC type: " << it->first << ", interval: " << it->second << ", count: " << counts[it->first];
   }
   return;
 }

--- a/plugins/FakeTPCreatorHeartbeatMaker.cpp
+++ b/plugins/FakeTPCreatorHeartbeatMaker.cpp
@@ -7,12 +7,16 @@
  */
 
 #include "FakeTPCreatorHeartbeatMaker.hpp"
+#include "trigger/Logging.hpp"
 
 #include "appfwk/DAQModuleHelper.hpp"
 #include "iomanager/IOManager.hpp"
 #include "rcif/cmd/Nljs.hpp"
 
 #include <string>
+
+using dunedaq::trigger::logging::TLVL_GENERAL;
+using dunedaq::trigger::logging::TLVL_DEBUG_HIGH;
 
 namespace dunedaq {
 namespace trigger {
@@ -57,7 +61,7 @@ void
 FakeTPCreatorHeartbeatMaker::do_conf(const nlohmann::json& conf)
 {
   m_heartbeat_interval = conf.get<dunedaq::trigger::faketpcreatorheartbeatmaker::Conf>().heartbeat_interval;
-  TLOG_DEBUG(2) << get_name() + " configured.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[FHM] " << get_name() + " configured.";
 }
 
 void
@@ -67,14 +71,14 @@ FakeTPCreatorHeartbeatMaker::do_start(const nlohmann::json& args)
   m_run_number = start_params.run;
 
   m_thread.start_working_thread("heartbeater");
-  TLOG_DEBUG(2) << get_name() + " successfully started.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[FHM] " << get_name() + " successfully started.";
 }
 
 void
 FakeTPCreatorHeartbeatMaker::do_stop(const nlohmann::json&)
 {
   m_thread.stop_working_thread();
-  TLOG_DEBUG(2) << get_name() + " successfully stopped.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[FHM] " << get_name() + " successfully stopped.";
 }
 
 void
@@ -112,7 +116,7 @@ FakeTPCreatorHeartbeatMaker::do_work(std::atomic<bool>& running_flag)
     if (m_sourceid.id == daqdataformats::SourceID::s_invalid_id) {
       m_sourceid = tpset->origin;
     }
-    TLOG_DEBUG(3) << "Activity received.";
+    TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[FHM] Activity received.";
 
     daqdataformats::timestamp_t current_tpset_start_time = tpset->start_time;
 
@@ -159,9 +163,9 @@ FakeTPCreatorHeartbeatMaker::do_work(std::atomic<bool>& running_flag)
     }
   }
 
-  TLOG() << "Received " << m_tpset_received_count << " and sent " << m_tpset_sent_count << " real TPSets. Sent "
+  TLOG(1) << "[FHM] Received " << m_tpset_received_count << " and sent " << m_tpset_sent_count << " real TPSets. Sent "
          << m_heartbeats_sent << " fake heartbeats." << std::endl;
-  TLOG_DEBUG(2) << "Exiting do_work() method";
+  TLOG_DEBUG(TLVL_GENERAL) << "[FHM] Exiting do_work() method";
 }
 
 bool

--- a/plugins/FakeTPCreatorHeartbeatMaker.cpp
+++ b/plugins/FakeTPCreatorHeartbeatMaker.cpp
@@ -163,7 +163,7 @@ FakeTPCreatorHeartbeatMaker::do_work(std::atomic<bool>& running_flag)
     }
   }
 
-  TLOG(1) << "[FHM] Received " << m_tpset_received_count << " and sent " << m_tpset_sent_count << " real TPSets. Sent "
+  TLOG() << "[FHM] Received " << m_tpset_received_count << " and sent " << m_tpset_sent_count << " real TPSets. Sent "
          << m_heartbeats_sent << " fake heartbeats." << std::endl;
   TLOG_DEBUG(TLVL_GENERAL) << "[FHM] Exiting do_work() method";
 }

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -852,6 +852,7 @@ ModuleLevelTrigger::create_request_for_link(dfmessages::SourceID link,
   request.window_begin = start;
   request.window_end = end;
 
+  TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] link: " << link;
   TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] setting request start: " << request.window_begin;
   TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] setting request end: " << request.window_end;
 

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -10,6 +10,7 @@
 #include "ModuleLevelTrigger.hpp"
 
 #include "trigger/Issues.hpp"
+#include "trigger/Logging.hpp"
 #include "trigger/LivetimeCounter.hpp"
 #include "trigger/moduleleveltrigger/Nljs.hpp"
 
@@ -30,6 +31,13 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+
+using dunedaq::trigger::logging::TLVL_IMPORTANT;
+using dunedaq::trigger::logging::TLVL_DEBUG_INFO;
+using dunedaq::trigger::logging::TLVL_DEBUG_LOW;
+using dunedaq::trigger::logging::TLVL_DEBUG_MEDIUM;
+using dunedaq::trigger::logging::TLVL_DEBUG_HIGH;
+using dunedaq::trigger::logging::TLVL_DEBUG_ALL;
 
 namespace dunedaq {
 namespace trigger {
@@ -110,7 +118,7 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
   parse_group_links(m_group_links_data);
   print_group_links();
   m_total_group_links = m_group_links.size();
-  TLOG_DEBUG(3) << "Total group links: " << m_total_group_links;
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Total group links: " << m_total_group_links;
 
   // m_trigger_decision_connection = params.dfo_connection;
   // m_inhibit_connection = params.dfo_busy_connection;
@@ -127,11 +135,11 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
   m_use_readout_map = params.use_readout_map;
   m_use_roi_readout = params.use_roi_readout;
   m_use_bitwords = params.use_bitwords;
-  TLOG_DEBUG(3) << "Allow merging: " << m_tc_merging;
-  TLOG_DEBUG(3) << "Buffer timeout: " << m_buffer_timeout;
-  TLOG_DEBUG(3) << "Should send timed out TDs: " << m_send_timed_out_tds;
-  TLOG_DEBUG(3) << "TD readout limit: " << m_td_readout_limit;
-  TLOG_DEBUG(3) << "Use ROI readout?: " << m_use_roi_readout;
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Allow merging: " << m_tc_merging;
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Buffer timeout: " << m_buffer_timeout;
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Should send timed out TDs: " << m_send_timed_out_tds;
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] TD readout limit: " << m_td_readout_limit;
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Use ROI readout?: " << m_use_roi_readout;
 
   // ROI map
   if (m_use_roi_readout) {
@@ -141,7 +149,7 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
   }
 
   // Custom readout map
-  TLOG_DEBUG(3) << "Use readout map: " << m_use_readout_map;
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Use readout map: " << m_use_readout_map;
   if (m_use_readout_map) {
     m_readout_window_map_data = params.td_readout_map;
     parse_readout_map(m_readout_window_map_data);
@@ -149,17 +157,17 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
   }
 
   // Ignoring TC types
-  TLOG_DEBUG(3) << "Ignoring TC types: " << m_ignoring_tc_types;
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Ignoring TC types: " << m_ignoring_tc_types;
   if (m_ignoring_tc_types) {
-    TLOG_DEBUG(3) << "TC types to ignore: ";
+    TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] TC types to ignore: ";
     for (std::vector<int>::iterator it = m_ignored_tc_types.begin(); it != m_ignored_tc_types.end();) {
-      TLOG_DEBUG(3) << *it;
+      TLOG_DEBUG(TLVL_DEBUG_INFO) << *it;
       ++it;
     }
   }
 
   // Trigger bitwords
-  TLOG_DEBUG(3) << "Use bitwords: " << m_use_bitwords;
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Use bitwords: " << m_use_bitwords;
   if (m_use_bitwords) {
     m_trigger_bitwords_json = params.trigger_bitwords;
     print_bitword_flags(m_trigger_bitwords_json);
@@ -202,7 +210,7 @@ ModuleLevelTrigger::do_stop(const nlohmann::json& /*stopobj*/)
 
   m_lc_deadtime = m_livetime_counter->get_time(LivetimeCounter::State::kDead) +
                   m_livetime_counter->get_time(LivetimeCounter::State::kPaused);
-  TLOG(3) << "LivetimeCounter - total deadtime+paused: " << m_lc_deadtime << std::endl;
+  TLOG_DEBUG(TLVL_IMPORTANT) << "[MLT] LivetimeCounter - total deadtime+paused: " << m_lc_deadtime << std::endl;
   m_livetime_counter.reset(); // Calls LivetimeCounter dtor?
 
   m_inhibit_input->remove_callback();
@@ -220,9 +228,9 @@ ModuleLevelTrigger::do_pause(const nlohmann::json& /*pauseobj*/)
 
   m_paused.store(true);
   m_livetime_counter->set_state(LivetimeCounter::State::kPaused);
-  TLOG() << "******* Triggers PAUSED! in run " << m_run_number << " *********";
+  TLOG(0) << "[MLT] ******* Triggers PAUSED! in run " << m_run_number << " *********";
   ers::info(TriggerPaused(ERS_HERE));
-  TLOG_DEBUG(5) << "TS End: "
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] TS End: "
                 << std::chrono::duration_cast<std::chrono::microseconds>(
                      std::chrono::system_clock::now().time_since_epoch())
                      .count();
@@ -232,10 +240,10 @@ void
 ModuleLevelTrigger::do_resume(const nlohmann::json& /*resumeobj*/)
 {
   ers::info(TriggerActive(ERS_HERE));
-  TLOG() << "******* Triggers RESUMED! in run " << m_run_number << " *********";
+  TLOG(0) << "[MLT] ******* Triggers RESUMED! in run " << m_run_number << " *********";
   m_livetime_counter->set_state(LivetimeCounter::State::kLive);
   m_paused.store(false);
-  TLOG_DEBUG(5) << "TS Start: "
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] TS Start: "
                 << std::chrono::duration_cast<std::chrono::microseconds>(
                      std::chrono::system_clock::now().time_since_epoch())
                      .count();
@@ -253,10 +261,10 @@ dfmessages::TriggerDecision
 ModuleLevelTrigger::create_decision(const ModuleLevelTrigger::PendingTD& pending_td)
 {
   m_earliest_tc_index = get_earliest_tc_index(pending_td);
-  TLOG_DEBUG(5) << "earliest TC index: " << m_earliest_tc_index;
+  TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] earliest TC index: " << m_earliest_tc_index;
 
   if (pending_td.contributing_tcs.size() > 1) {
-    TLOG_DEBUG(5) << "!!! TD created from " << pending_td.contributing_tcs.size() << " TCs !!!";
+    TLOG_DEBUG(TLVL_DEBUG_LOW) << "[MLT] TD created from " << pending_td.contributing_tcs.size() << " TCs !";
   }
 
   dfmessages::TriggerDecision decision;
@@ -276,7 +284,7 @@ ModuleLevelTrigger::create_decision(const ModuleLevelTrigger::PendingTD& pending
     decision.trigger_type = static_cast<dfmessages::trigger_type_t>(m_TD_bitword.to_ulong()); // m_trigger_type;
   }
 
-  TLOG_DEBUG(3) << "HSI passthrough: " << m_hsi_passthrough
+  TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[MLT] HSI passthrough: " << m_hsi_passthrough
                 << ", TC detid: " << pending_td.contributing_tcs[m_earliest_tc_index].detid
                 << ", TC type: " << static_cast<int>(pending_td.contributing_tcs[m_earliest_tc_index].type)
                 << ", TC cont number: " << pending_td.contributing_tcs.size()
@@ -334,21 +342,21 @@ ModuleLevelTrigger::send_trigger_decisions()
     std::optional<triggeralgs::TriggerCandidate> tc = m_candidate_input->try_receive(std::chrono::milliseconds(10));
     if (tc.has_value()) {
       if ( (m_use_readout_map) && (m_readout_window_map.count(tc->type)) ) {
-        TLOG_DEBUG(1) << "Got TC of type " << static_cast<int>(tc->type) << ", timestamp " << tc->time_candidate
+        TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] Got TC of type " << static_cast<int>(tc->type) << ", timestamp " << tc->time_candidate
                       << ", start/end " << tc->time_start << "/" << tc->time_end << ", readout start/end "
                       << tc->time_candidate - m_readout_window_map[tc->type].first << "/"
                       << tc->time_candidate + m_readout_window_map[tc->type].second;
       } else {
-        TLOG_DEBUG(1) << "Got TC of type " << static_cast<int>(tc->type) << ", timestamp " << tc->time_candidate
+        TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] Got TC of type " << static_cast<int>(tc->type) << ", timestamp " << tc->time_candidate
                       << ", start/end " << tc->time_start << "/" << tc->time_end;
       }
       ++m_tc_received_count;
 
       // Option to ignore TC types (if given by config)
       if (m_ignoring_tc_types == true) {
-        TLOG_DEBUG(3) << "TC type: " << static_cast<int>(tc->type);
+        TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] TC type: " << static_cast<int>(tc->type);
         if (check_trigger_type_ignore(static_cast<int>(tc->type)) == true) {
-          TLOG_DEBUG(3) << "ignoring...";
+          TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] ignoring...";
           m_tc_ignored_count++;
 
           if (m_tc_merging) {
@@ -363,7 +371,7 @@ ModuleLevelTrigger::send_trigger_decisions()
 
       std::lock_guard<std::mutex> lock(m_td_vector_mutex);
       add_tc(*tc);
-      TLOG_DEBUG(10) << "pending tds size: " << m_pending_tds.size();
+      TLOG_DEBUG(TLVL_DEBUG_ALL) << "[MLT] pending tds size: " << m_pending_tds.size();
     } else {
       // The condition to exit the loop is that we've been stopped and
       // there's nothing left on the input queue
@@ -374,7 +382,7 @@ ModuleLevelTrigger::send_trigger_decisions()
 
     std::lock_guard<std::mutex> lock(m_td_vector_mutex);
     auto ready_tds = get_ready_tds(m_pending_tds);
-    TLOG_DEBUG(10) << "ready tds: " << ready_tds.size() << ", updated pending tds: " << m_pending_tds.size()
+    TLOG_DEBUG(TLVL_DEBUG_ALL) << "[MLT] ready tds: " << ready_tds.size() << ", updated pending tds: " << m_pending_tds.size()
                    << ", sent tds: " << m_sent_tds.size();
 
     for (std::vector<PendingTD>::iterator it = ready_tds.begin(); it != ready_tds.end();) {
@@ -392,7 +400,7 @@ ModuleLevelTrigger::send_trigger_decisions()
             ++m_td_dropped_count;
             m_td_dropped_tc_count += it->contributing_tcs.size();
             it = ready_tds.erase(it);
-            TLOG_DEBUG(5) << "overlapping previous TD, dropping!";
+            TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[MLT] TD overlapping previous TD, dropping!";
           } else { // overlap, but set to sent overlapping TD
             call_tc_decision(*it);
             ++it;
@@ -407,10 +415,10 @@ ModuleLevelTrigger::send_trigger_decisions()
       }
     }
 
-    TLOG_DEBUG(10) << "updated sent tds: " << m_sent_tds.size();
+    TLOG_DEBUG(TLVL_DEBUG_ALL) << "[MLT] updated sent tds: " << m_sent_tds.size();
   }
 
-  TLOG() << "Run " << m_run_number << ": "
+  TLOG(0) << "[MLT] Run " << m_run_number << ": "
          << "Received " << m_tc_received_count << " TCs. Sent " << m_td_sent_count.load() << " TDs consisting of "
          << m_td_sent_tc_count.load() << " TCs. " << m_td_paused_count.load() << " TDs (" << m_td_paused_tc_count.load()
          << " TCs) were created during pause, and " << m_td_inhibited_count.load() << " TDs ("
@@ -418,10 +426,10 @@ ModuleLevelTrigger::send_trigger_decisions()
          << m_td_dropped_tc_count.load() << " TCs) were dropped. " << m_td_cleared_count.load() << " TDs ("
          << m_td_cleared_tc_count.load() << " TCs) were cleared.";
   if (m_ignoring_tc_types) {
-    TLOG() << "Ignored " << m_tc_ignored_count.load() << " TCs.";
+    TLOG(0) << "Ignored " << m_tc_ignored_count.load() << " TCs.";
   }
   if (m_use_bitwords) {
-    TLOG() << "Not triggered (failed bitword check) on " << m_td_not_triggered_count.load() << " TDs consisting of "
+    TLOG(0) << "Not triggered (failed bitword check) on " << m_td_not_triggered_count.load() << " TDs consisting of "
            << m_td_not_triggered_tc_count.load() << " TCs.";
   }
 
@@ -441,7 +449,7 @@ ModuleLevelTrigger::call_tc_decision(const ModuleLevelTrigger::PendingTD& pendin
 {
 
   m_TD_bitword = get_TD_bitword(pending_td);
-  TLOG_DEBUG(5) << "[MLT] TD has bitword: " << m_TD_bitword << " " << static_cast<dfmessages::trigger_type_t>(m_TD_bitword.to_ulong());
+  TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[MLT] TD has bitword: " << m_TD_bitword << " " << static_cast<dfmessages::trigger_type_t>(m_TD_bitword.to_ulong());
   if (m_use_bitwords) {
     // Check trigger bitwords
     m_bitword_check = check_trigger_bitwords();
@@ -453,7 +461,7 @@ ModuleLevelTrigger::call_tc_decision(const ModuleLevelTrigger::PendingTD& pendin
 
     if ((!m_paused.load() && !m_dfo_is_busy.load())) {
 
-      TLOG_DEBUG(3) << "Sending a decision with triggernumber " << decision.trigger_number << " timestamp "
+      TLOG_DEBUG(TLVL_DEBUG_LOW) << "[MLT] Sending a decision with triggernumber " << decision.trigger_number << " timestamp "
              << decision.trigger_timestamp << " start " << decision.components.front().window_begin << " end " << decision.components.front().window_end
  	     << " number of links " << decision.components.size()
              << " based on TC of type "
@@ -472,7 +480,7 @@ ModuleLevelTrigger::call_tc_decision(const ModuleLevelTrigger::PendingTD& pendin
         add_td(pending_td);
       } catch (const ers::Issue& e) {
         ers::error(e);
-        TLOG_DEBUG(1) << "The network is misbehaving: it accepted TD but the send failed for "
+        TLOG_DEBUG(TLVL_IMPORTANT) << "[MLT] The network is misbehaving: it accepted TD but the send failed for "
                       << pending_td.contributing_tcs[m_earliest_tc_index].time_candidate;
         m_td_queue_timeout_expired_err_count++;
         m_td_queue_timeout_expired_err_tc_count += pending_td.contributing_tcs.size();
@@ -481,11 +489,11 @@ ModuleLevelTrigger::call_tc_decision(const ModuleLevelTrigger::PendingTD& pendin
     } else if (m_paused.load()) {
       ++m_td_paused_count;
       m_td_paused_tc_count += pending_td.contributing_tcs.size();
-      TLOG_DEBUG(1) << "Triggers are paused. Not sending a TriggerDecision for pending TD with start/end times "
+      TLOG_DEBUG(TLVL_IMPORTANT) << "[MLT] Triggers are paused. Not sending a TriggerDecision for pending TD with start/end times "
                     << pending_td.readout_start << "/" << pending_td.readout_end;
     } else {
       ers::warning(TriggerInhibited(ERS_HERE, m_run_number));
-      TLOG_DEBUG(1) << "The DFO is busy. Not sending a TriggerDecision for candidate timestamp "
+      TLOG_DEBUG(TLVL_IMPORTANT) << "[MLT] The DFO is busy. Not sending a TriggerDecision for candidate timestamp "
                     << pending_td.contributing_tcs[m_earliest_tc_index].time_candidate;
       m_td_inhibited_count++;
       m_new_td_inhibited_count++;
@@ -512,7 +520,7 @@ ModuleLevelTrigger::add_tc(const triggeralgs::TriggerCandidate& tc)
       if (check_overlap(tc, *it)) {
 	it->contributing_tcs.push_back(tc);
         if ( (m_use_readout_map) && (m_readout_window_map.count(tc.type)) ){
-          TLOG_DEBUG(3) << "TC with start/end times " << tc.time_candidate - m_readout_window_map[tc.type].first << "/"
+          TLOG_DEBUG(TLVL_DEBUG_LOW) << "[MLT] TC with start/end times " << tc.time_candidate - m_readout_window_map[tc.type].first << "/"
                         << tc.time_candidate + m_readout_window_map[tc.type].second
                         << " overlaps with pending TD with start/end times " << it->readout_start << "/"
                         << it->readout_end;
@@ -523,7 +531,7 @@ ModuleLevelTrigger::add_tc(const triggeralgs::TriggerCandidate& tc)
                               ? (tc.time_candidate + m_readout_window_map[tc.type].second)
                               : it->readout_end;
         } else {
-          TLOG_DEBUG(3) << "TC with start/end times " << tc.time_start << "/" << tc.time_end
+          TLOG_DEBUG(TLVL_DEBUG_LOW) << "[MLT] TC with start/end times " << tc.time_start << "/" << tc.time_end
                         << " overlaps with pending TD with start/end times " << it->readout_start << "/"
                         << it->readout_end;
           it->readout_start = (tc.time_start >= it->readout_start) ? it->readout_start : tc.time_start;
@@ -559,12 +567,12 @@ ModuleLevelTrigger::add_tc_ignored(const triggeralgs::TriggerCandidate& tc)
   for (std::vector<PendingTD>::iterator it = m_pending_tds.begin(); it != m_pending_tds.end();) {
     if (check_overlap(tc, *it)) {
       if ( (m_use_readout_map) && (m_readout_window_map.count(tc.type)) ) {
-        TLOG_DEBUG(3) << "!Ignored! TC with start/end times " << tc.time_candidate - m_readout_window_map[tc.type].first
+        TLOG_DEBUG(TLVL_DEBUG_LOW) << "[MLT] !Ignored! TC with start/end times " << tc.time_candidate - m_readout_window_map[tc.type].first
                       << "/" << tc.time_candidate + m_readout_window_map[tc.type].second
                       << " overlaps with pending TD with start/end times " << it->readout_start << "/"
                       << it->readout_end;
       } else {
-        TLOG_DEBUG(3) << "!Ignored! TC with start/end times " << tc.time_start << "/" << tc.time_end
+        TLOG_DEBUG(TLVL_DEBUG_LOW) << "[MLT] !Ignored! TC with start/end times " << tc.time_start << "/" << tc.time_end
                       << " overlaps with pending TD with start/end times " << it->readout_start << "/"
                       << it->readout_end;
       }
@@ -597,7 +605,7 @@ ModuleLevelTrigger::check_overlap_td(const PendingTD& pending_td)
       overlap = false;
     } else {
       overlap = true;
-      TLOG_DEBUG(3) << "Pending TD with start/end " << pending_td.readout_start << "/" << pending_td.readout_end
+      TLOG_DEBUG(TLVL_DEBUG_LOW) << "[MLT] Pending TD with start/end " << pending_td.readout_start << "/" << pending_td.readout_end
                     << " overlaps with sent TD with start/end " << sent_td.readout_start << "/" << sent_td.readout_end;
       break;
     }
@@ -660,7 +668,7 @@ ModuleLevelTrigger::check_td_readout_length(const PendingTD& pending_td)
   bool td_too_long = false;
   if (static_cast<int64_t>(pending_td.readout_end - pending_td.readout_start) >= m_td_readout_limit) {
     td_too_long = true;
-    TLOG_DEBUG(3) << "Too long readout window: " << (pending_td.readout_end - pending_td.readout_start)
+    TLOG_DEBUG(TLVL_DEBUG_LOW) << "[MLT] Too long readout window: " << (pending_td.readout_end - pending_td.readout_start)
                   << ", sending immediate TD!";
   }
   return td_too_long;
@@ -669,7 +677,7 @@ ModuleLevelTrigger::check_td_readout_length(const PendingTD& pending_td)
 void
 ModuleLevelTrigger::flush_td_vectors()
 {
-  TLOG_DEBUG(3) << "Flushing TDs. Size: " << m_pending_tds.size();
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Flushing TDs. Size: " << m_pending_tds.size();
   std::lock_guard<std::mutex> lock(m_td_vector_mutex);
   for (PendingTD pending_td : m_pending_tds) {
     call_tc_decision(pending_td);
@@ -680,7 +688,7 @@ void
 ModuleLevelTrigger::clear_td_vectors()
 {
   std::lock_guard<std::mutex> lock(m_td_vector_mutex);
-  TLOG_DEBUG(1) << "clear_td_vectors() clearing " << m_pending_tds.size() << " pending TDs and " << m_sent_tds.size()
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] clear_td_vectors() clearing " << m_pending_tds.size() << " pending TDs and " << m_sent_tds.size()
                 << " sent TDs";
   m_td_cleared_count += m_pending_tds.size();
   for (PendingTD pending_td : m_pending_tds) {
@@ -693,10 +701,10 @@ ModuleLevelTrigger::clear_td_vectors()
 void
 ModuleLevelTrigger::dfo_busy_callback(dfmessages::TriggerInhibit& inhibit)
 {
-  TLOG_DEBUG(17) << "Received inhibit message with busy status " << inhibit.busy << " and run number "
+  TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] Received inhibit message with busy status " << inhibit.busy << " and run number "
                  << inhibit.run_number;
   if (inhibit.run_number == m_run_number) {
-    TLOG_DEBUG(18) << "Changing our flag for the DFO busy state from " << m_dfo_is_busy.load() << " to "
+    TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] Changing our flag for the DFO busy state from " << m_dfo_is_busy.load() << " to "
                    << inhibit.busy;
     m_dfo_is_busy = inhibit.busy;
     m_livetime_counter->set_state(LivetimeCounter::State::kDead);
@@ -738,9 +746,9 @@ ModuleLevelTrigger::get_TD_bitword(const PendingTD& ready_td)
 void
 ModuleLevelTrigger::print_trigger_bitwords(std::vector<std::bitset<16>> trigger_bitwords)
 {
-  TLOG_DEBUG(3) << "Configured trigger words:";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Configured trigger words:";
   for (auto bitword : trigger_bitwords) {
-    TLOG_DEBUG(3) << bitword;
+    TLOG_DEBUG(TLVL_DEBUG_INFO) << bitword;
   }
   return;
 }
@@ -748,9 +756,9 @@ ModuleLevelTrigger::print_trigger_bitwords(std::vector<std::bitset<16>> trigger_
 void
 ModuleLevelTrigger::print_bitword_flags(nlohmann::json m_trigger_bitwords_json)
 {
-  TLOG_DEBUG(3) << "Configured trigger flags:";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Configured trigger flags:";
   for (auto bitflag : m_trigger_bitwords_json) {
-    TLOG_DEBUG(3) << bitflag;
+    TLOG_DEBUG(TLVL_DEBUG_INFO) << bitflag;
   }
   return;
 }
@@ -760,10 +768,10 @@ ModuleLevelTrigger::check_trigger_bitwords()
 {
   bool trigger_check = false;
   for (auto bitword : m_trigger_bitwords) {
-    TLOG(15) << "TD word: " << m_TD_bitword << ", bitword: " << bitword;
+    TLOG(TLVL_DEBUG_ALL) << "[MLT] TD word: " << m_TD_bitword << ", bitword: " << bitword;
     trigger_check = ((m_TD_bitword & bitword) == bitword);
-    TLOG(15) << "&: " << (m_TD_bitword & bitword);
-    TLOG(15) << "trigger?: " << trigger_check;
+    TLOG(TLVL_DEBUG_ALL) << "[MLT] &: " << (m_TD_bitword & bitword);
+    TLOG(TLVL_DEBUG_ALL) << "[MLT] trigger?: " << trigger_check;
     if (trigger_check == true)
       break;
   }
@@ -798,9 +806,9 @@ void
 ModuleLevelTrigger::print_readout_map(std::map<trgdataformats::TriggerCandidateData::Type,
                                                std::pair<triggeralgs::timestamp_t, triggeralgs::timestamp_t>> map)
 {
-  TLOG_DEBUG(3) << "MLT TD Readout map:";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] TD Readout map:";
   for (auto const& [key, val] : map) {
-    TLOG_DEBUG(3) << "Type: " << static_cast<int>(key) << ", before: " << val.first << ", after: " << val.second;
+    TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Type: " << static_cast<int>(key) << ", before: " << val.first << ", after: " << val.second;
   }
   return;
 }
@@ -823,14 +831,14 @@ ModuleLevelTrigger::parse_group_links(const nlohmann::json& data)
 void
 ModuleLevelTrigger::print_group_links()
 {
-  TLOG_DEBUG(3) << "MLT Group Links:";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] Group Links:";
   for (auto const& [key, val] : m_group_links) {
-    TLOG_DEBUG(3) << "Group: " << key;
+    TLOG_DEBUG(TLVL_DEBUG_INFO) << "Group: " << key;
     for (auto const& link : val) {
-      TLOG_DEBUG(3) << link;
+      TLOG_DEBUG(TLVL_DEBUG_INFO) << link;
     }
   }
-  TLOG_DEBUG(3) << " ";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << " ";
   return;
 }
 
@@ -844,8 +852,8 @@ ModuleLevelTrigger::create_request_for_link(dfmessages::SourceID link,
   request.window_begin = start;
   request.window_end = end;
 
-  TLOG_DEBUG(10) << "setting request start: " << request.window_begin;
-  TLOG_DEBUG(10) << "setting request end: " << request.window_end;
+  TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] setting request start: " << request.window_begin;
+  TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] setting request end: " << request.window_end;
 
   return request;
 }
@@ -895,15 +903,15 @@ ModuleLevelTrigger::parse_roi_conf(const nlohmann::json& data)
 void
 ModuleLevelTrigger::print_roi_conf(std::map<int, roi_group> roi_conf)
 {
-  TLOG_DEBUG(3) << "ROI CONF";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] ROI CONF";
   for (const auto& [key, value] : roi_conf) {
-    TLOG_DEBUG(3) << "ID: " << key;
-    TLOG_DEBUG(3) << "n links: " << value.n_links;
-    TLOG_DEBUG(3) << "prob: " << value.prob;
-    TLOG_DEBUG(3) << "time: " << value.time_window;
-    TLOG_DEBUG(3) << "mode: " << value.mode;
+    TLOG_DEBUG(TLVL_DEBUG_INFO) << "ID: " << key;
+    TLOG_DEBUG(TLVL_DEBUG_INFO) << "n links: " << value.n_links;
+    TLOG_DEBUG(TLVL_DEBUG_INFO) << "prob: " << value.prob;
+    TLOG_DEBUG(TLVL_DEBUG_INFO) << "time: " << value.time_window;
+    TLOG_DEBUG(TLVL_DEBUG_INFO) << "mode: " << value.mode;
   }
-  TLOG_DEBUG(3) << " ";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << " ";
   return;
 }
 
@@ -945,7 +953,7 @@ ModuleLevelTrigger::roi_readout_make_requests(dfmessages::TriggerDecision& decis
 
     // If mode is random, pick groups to request at random
     if (this_group.mode == "kRandom") {
-      TLOG_DEBUG(10) << "RAND";
+      TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] RAND";
       std::set<int> groups;
       while (static_cast<int>(groups.size()) < this_group.n_links) {
         groups.insert(get_random_num_int());
@@ -955,7 +963,7 @@ ModuleLevelTrigger::roi_readout_make_requests(dfmessages::TriggerDecision& decis
       }
       // Otherwise, read sequntially by IDs, starting at 0
     } else {
-      TLOG_DEBUG(10) << "SEQ";
+      TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] SEQ";
       int r_id = 0;
       while (r_id < this_group.n_links) {
         links.insert(links.end(), m_group_links[r_id].begin(), m_group_links[r_id].end());
@@ -963,8 +971,8 @@ ModuleLevelTrigger::roi_readout_make_requests(dfmessages::TriggerDecision& decis
       }
     }
 
-    TLOG_DEBUG(10) << "TD timestamp: " << decision.trigger_timestamp;
-    TLOG_DEBUG(10) << "group window: " << this_group.time_window;
+    TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] TD timestamp: " << decision.trigger_timestamp;
+    TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[MLT] group window: " << this_group.time_window;
 
     // Once the components are prepared, create requests and append them to decision
     std::vector<dfmessages::ComponentRequest> requests =

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -228,7 +228,7 @@ ModuleLevelTrigger::do_pause(const nlohmann::json& /*pauseobj*/)
 
   m_paused.store(true);
   m_livetime_counter->set_state(LivetimeCounter::State::kPaused);
-  TLOG(0) << "[MLT] ******* Triggers PAUSED! in run " << m_run_number << " *********";
+  TLOG() << "[MLT] ******* Triggers PAUSED! in run " << m_run_number << " *********";
   ers::info(TriggerPaused(ERS_HERE));
   TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] TS End: "
                 << std::chrono::duration_cast<std::chrono::microseconds>(
@@ -240,7 +240,7 @@ void
 ModuleLevelTrigger::do_resume(const nlohmann::json& /*resumeobj*/)
 {
   ers::info(TriggerActive(ERS_HERE));
-  TLOG(0) << "[MLT] ******* Triggers RESUMED! in run " << m_run_number << " *********";
+  TLOG() << "[MLT] ******* Triggers RESUMED! in run " << m_run_number << " *********";
   m_livetime_counter->set_state(LivetimeCounter::State::kLive);
   m_paused.store(false);
   TLOG_DEBUG(TLVL_DEBUG_INFO) << "[MLT] TS Start: "
@@ -418,7 +418,7 @@ ModuleLevelTrigger::send_trigger_decisions()
     TLOG_DEBUG(TLVL_DEBUG_ALL) << "[MLT] updated sent tds: " << m_sent_tds.size();
   }
 
-  TLOG(0) << "[MLT] Run " << m_run_number << ": "
+  TLOG() << "[MLT] Run " << m_run_number << ": "
          << "Received " << m_tc_received_count << " TCs. Sent " << m_td_sent_count.load() << " TDs consisting of "
          << m_td_sent_tc_count.load() << " TCs. " << m_td_paused_count.load() << " TDs (" << m_td_paused_tc_count.load()
          << " TCs) were created during pause, and " << m_td_inhibited_count.load() << " TDs ("
@@ -426,10 +426,10 @@ ModuleLevelTrigger::send_trigger_decisions()
          << m_td_dropped_tc_count.load() << " TCs) were dropped. " << m_td_cleared_count.load() << " TDs ("
          << m_td_cleared_tc_count.load() << " TCs) were cleared.";
   if (m_ignoring_tc_types) {
-    TLOG(0) << "Ignored " << m_tc_ignored_count.load() << " TCs.";
+    TLOG() << "Ignored " << m_tc_ignored_count.load() << " TCs.";
   }
   if (m_use_bitwords) {
-    TLOG(0) << "Not triggered (failed bitword check) on " << m_td_not_triggered_count.load() << " TDs consisting of "
+    TLOG() << "Not triggered (failed bitword check) on " << m_td_not_triggered_count.load() << " TDs consisting of "
            << m_td_not_triggered_tc_count.load() << " TCs.";
   }
 
@@ -768,10 +768,10 @@ ModuleLevelTrigger::check_trigger_bitwords()
 {
   bool trigger_check = false;
   for (auto bitword : m_trigger_bitwords) {
-    TLOG(TLVL_DEBUG_ALL) << "[MLT] TD word: " << m_TD_bitword << ", bitword: " << bitword;
+    TLOG_DEBUG(TLVL_DEBUG_ALL) << "[MLT] TD word: " << m_TD_bitword << ", bitword: " << bitword;
     trigger_check = ((m_TD_bitword & bitword) == bitword);
-    TLOG(TLVL_DEBUG_ALL) << "[MLT] &: " << (m_TD_bitword & bitword);
-    TLOG(TLVL_DEBUG_ALL) << "[MLT] trigger?: " << trigger_check;
+    TLOG_DEBUG(TLVL_DEBUG_ALL) << "[MLT] &: " << (m_TD_bitword & bitword);
+    TLOG_DEBUG(TLVL_DEBUG_ALL) << "[MLT] trigger?: " << trigger_check;
     if (trigger_check == true)
       break;
   }

--- a/plugins/RandomTriggerCandidateMaker.cpp
+++ b/plugins/RandomTriggerCandidateMaker.cpp
@@ -36,7 +36,7 @@
 using dunedaq::trigger::logging::TLVL_GENERAL;
 using dunedaq::trigger::logging::TLVL_DEBUG_INFO;
 using dunedaq::trigger::logging::TLVL_DEBUG_LOW;
-using dunedaq::trigger::logging::TLVL_DEBUG_HIGH;
+using dunedaq::trigger::logging::TLVL_DEBUG_MEDIUM;
 
 namespace dunedaq {
 namespace trigger {
@@ -176,7 +176,7 @@ RandomTriggerCandidateMaker::send_trigger_candidates()
 
     triggeralgs::TriggerCandidate candidate = create_candidate(next_trigger_timestamp);
 
-    TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[RTCM] " << get_name() << " at timestamp " << m_timestamp_estimator->get_timestamp_estimate()
+    TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[RTCM] " << get_name() << " at timestamp " << m_timestamp_estimator->get_timestamp_estimate()
                   << ", pushing a candidate with timestamp " << candidate.time_candidate;
     m_trigger_candidate_sink->send(std::move(candidate), std::chrono::milliseconds(10));
     m_tc_sent_count++;

--- a/plugins/TABuffer.cpp
+++ b/plugins/TABuffer.cpp
@@ -127,7 +127,7 @@ TABuffer::do_work(std::atomic<bool>& running_flag)
     }
   } // while (running_flag.load())
 
-  TLOG(1) << "[TAB] " << get_name() << " exiting do_work() method. Received " << n_tas_received << " TAs " << " and " << n_requests_received << " data requests";
+  TLOG() << "[TAB] " << get_name() << " exiting do_work() method. Received " << n_tas_received << " TAs " << " and " << n_requests_received << " data requests";
 }
 
 } // namespace trigger

--- a/plugins/TABuffer.cpp
+++ b/plugins/TABuffer.cpp
@@ -7,11 +7,15 @@
  */
 
 #include "TABuffer.hpp"
+#include "trigger/Logging.hpp"
 
 #include "appfwk/DAQModuleHelper.hpp"
 #include "daqdataformats/SourceID.hpp"
 
 #include <string>
+
+using dunedaq::trigger::logging::TLVL_GENERAL;
+using dunedaq::trigger::logging::TLVL_DEBUG_ALL;
 
 namespace dunedaq {
 namespace trigger {
@@ -58,7 +62,7 @@ TABuffer::do_conf(const nlohmann::json& args)
   m_latency_buffer_impl->conf(args);
   m_request_handler_impl->conf(args);
 
-  TLOG_DEBUG(2) << get_name() + " configured.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TAB] " << get_name() + " configured.";
 }
 
 void
@@ -66,7 +70,7 @@ TABuffer::do_start(const nlohmann::json& args)
 {
   m_request_handler_impl->start(args);
   m_thread.start_working_thread("tabuffer");
-  TLOG_DEBUG(2) << get_name() + " successfully started.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TAB] "  << get_name() + " successfully started.";
 }
 
 void
@@ -75,7 +79,7 @@ TABuffer::do_stop(const nlohmann::json& args)
   m_thread.stop_working_thread();
   m_request_handler_impl->stop(args);
   m_latency_buffer_impl->flush();
-  TLOG_DEBUG(2) << get_name() + " successfully stopped.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TAB] " << get_name() + " successfully stopped.";
 }
 
 void
@@ -100,22 +104,22 @@ TABuffer::do_work(std::atomic<bool>& running_flag)
       popped_anything = true;
       for (auto const& ta: taset->objects) {
         //uint64_t ta_rec_sys_time  = duration_cast<nanoseconds>(system_clock::now().time_since_epoch()).count();
-        //TLOG() << "Got TA at the TABuffer, it's datatime is: " << ta.time_start << " and system time is: " << ta_rec_sys_time << " and occupancy is: " << m_latency_buffer_impl->occupancy(); 
+        //TLOG_DEBUG(TLVL_DEBUG_ALL) << "[TAB] Got TA at the TABuffer, it's datatime is: " << ta.time_start << " and system time is: " << ta_rec_sys_time << " and occupancy is: " << m_latency_buffer_impl->occupancy(); 
         m_latency_buffer_impl->write(TAWrapper(ta));
         ++n_tas_received;
-        //TLOG() << "Written TA to the TABuffer, it's datatime is: " << ta.time_start << " and system time is: " << ta_rec_sys_time << " and occupancy is: " << m_latency_buffer_impl->occupancy();
+        //TLOG_DEBUG(TLVL_DEBUG_ALL) << "[TAB] Written TA to the TABuffer, it's datatime is: " << ta.time_start << " and system time is: " << ta_rec_sys_time << " and occupancy is: " << m_latency_buffer_impl->occupancy();
       }
     }
     
     std::optional<dfmessages::DataRequest> data_request = m_input_queue_dr->try_receive(std::chrono::milliseconds(0));
     if (data_request.has_value()) {
-      //TLOG() << "Received a data request, occupancy is: " << m_latency_buffer_impl->occupancy();
+      //TLOG_DEBUG(TLVL_DEBUG_ALL) << "[TAB] Received a data request, occupancy is: " << m_latency_buffer_impl->occupancy();
       popped_anything = true;
       //uint64_t dr_rec_sys_time  = duration_cast<nanoseconds>(system_clock::now().time_since_epoch()).count();
-      //TLOG() << "Got TA data request, with window request datatime starting: " << data_request->trigger_timestamp << " and system time is: " << dr_rec_sys_time;
+      //TLOG_DEBUG(TLVL_DEBUG_ALL) << "[TAB] Got TA data request, with window request datatime starting: " << data_request->trigger_timestamp << " and system time is: " << dr_rec_sys_time;
       ++n_requests_received;
       m_request_handler_impl->issue_request(*data_request, false);
-      //TLOG() << "Handled data request, occupancy is: " << m_latency_buffer_impl->occupancy();
+      //TLOG_DEBUG(TLVL_DEBUG_ALL) << "[TAB] Handled data request, occupancy is: " << m_latency_buffer_impl->occupancy();
     }
 
     if (!popped_anything) {
@@ -123,7 +127,7 @@ TABuffer::do_work(std::atomic<bool>& running_flag)
     }
   } // while (running_flag.load())
 
-  TLOG() << get_name() << " exiting do_work() method. Received " << n_tas_received << " TAs " << " and " << n_requests_received << " data requests";
+  TLOG(1) << "[TAB] " << get_name() << " exiting do_work() method. Received " << n_tas_received << " TAs " << " and " << n_requests_received << " data requests";
 }
 
 } // namespace trigger

--- a/plugins/TCBuffer.cpp
+++ b/plugins/TCBuffer.cpp
@@ -130,7 +130,7 @@ TCBuffer::do_work(std::atomic<bool>& running_flag)
     }
   } // while (running_flag.load())
 
-  TLOG(1) << "[TCB] " << get_name() << " exiting do_work() method. Received " << n_tcs_received << " TCs " << " and " << n_requests_received << " data requests";
+  TLOG() << "[TCB] " << get_name() << " exiting do_work() method. Received " << n_tcs_received << " TCs " << " and " << n_requests_received << " data requests";
 }
 } // namespace trigger
 } // namespace dunedaq

--- a/plugins/TCBuffer.cpp
+++ b/plugins/TCBuffer.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "TCBuffer.hpp"
+#include "trigger/Logging.hpp"
 
 #include "appfwk/DAQModuleHelper.hpp"
 #include "dfmessages/DataRequest.hpp"
@@ -15,6 +16,9 @@
 
 #include <chrono>
 #include <string>
+
+using dunedaq::trigger::logging::TLVL_GENERAL;
+using dunedaq::trigger::logging::TLVL_DEBUG_HIGH;
 
 namespace dunedaq {
 namespace trigger {
@@ -62,7 +66,7 @@ TCBuffer::do_conf(const nlohmann::json& args)
   m_latency_buffer_impl->conf(args);
   m_request_handler_impl->conf(args);
 
-  TLOG_DEBUG(2) << get_name() + " configured.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TCB] " << get_name() + " configured.";
 }
 
 void
@@ -70,7 +74,7 @@ TCBuffer::do_start(const nlohmann::json& args)
 {
   m_request_handler_impl->start(args);
   m_thread.start_working_thread("tcbuffer");
-  TLOG_DEBUG(2) << get_name() + " successfully started.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TCB] " << get_name() + " successfully started.";
 }
 
 void
@@ -79,7 +83,7 @@ TCBuffer::do_stop(const nlohmann::json& args)
   m_thread.stop_working_thread();
   m_request_handler_impl->stop(args);
   m_latency_buffer_impl->flush();
-  TLOG_DEBUG(2) << get_name() + " successfully stopped.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TCB] " << get_name() + " successfully stopped.";
 }
 
 void
@@ -101,7 +105,7 @@ TCBuffer::do_work(std::atomic<bool>& running_flag)
     
     std::optional<triggeralgs::TriggerCandidate> tc = m_input_queue_tcs->try_receive(std::chrono::milliseconds(0));
     if (tc.has_value()) {  
-      TLOG_DEBUG(2) << "Got TC with start time " << tc->time_start;
+      TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TCB] Got TC with start time " << tc->time_start;
       popped_anything = true;
       m_latency_buffer_impl->write(TCWrapper(*tc));
       ++n_tcs_received;
@@ -110,7 +114,7 @@ TCBuffer::do_work(std::atomic<bool>& running_flag)
     std::optional<dfmessages::DataRequest> data_request = m_input_queue_dr->try_receive(std::chrono::milliseconds(0));
     if (data_request.has_value()) {
       auto& info = data_request->request_information;
-      TLOG_DEBUG(2) << "Got data request with component " << info.component << ", window_begin " << info.window_begin
+      TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TCB] Got data request with component " << info.component << ", window_begin " << info.window_begin
                     << ", window_end " << info.window_end << ", trig/seq_number "
                     << data_request->trigger_number << "." << data_request->sequence_number
                     << ", runno " << data_request->run_number
@@ -126,7 +130,7 @@ TCBuffer::do_work(std::atomic<bool>& running_flag)
     }
   } // while (running_flag.load())
 
-  TLOG() << get_name() << " exiting do_work() method. Received " << n_tcs_received << " TCs " << " and " << n_requests_received << " data requests";
+  TLOG(1) << "[TCB] " << get_name() << " exiting do_work() method. Received " << n_tcs_received << " TCs " << " and " << n_requests_received << " data requests";
 }
 } // namespace trigger
 } // namespace dunedaq

--- a/plugins/TPBuffer.cpp
+++ b/plugins/TPBuffer.cpp
@@ -7,11 +7,14 @@
  */
 
 #include "TPBuffer.hpp"
+#include "trigger/Logging.hpp"
 
 #include "appfwk/DAQModuleHelper.hpp"
 #include "daqdataformats/SourceID.hpp"
 
 #include <string>
+
+using dunedaq::trigger::logging::TLVL_GENERAL;
 
 namespace dunedaq {
 namespace trigger {
@@ -58,7 +61,7 @@ TPBuffer::do_conf(const nlohmann::json& args)
   m_latency_buffer_impl->conf(args);
   m_request_handler_impl->conf(args);
 
-  TLOG_DEBUG(2) << get_name() + " configured.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TPB] " << get_name() + " configured.";
 }
 
 void
@@ -66,7 +69,7 @@ TPBuffer::do_start(const nlohmann::json& args)
 {
   m_request_handler_impl->start(args);
   m_thread.start_working_thread("tpbuffer");
-  TLOG_DEBUG(2) << get_name() + " successfully started.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TPB] " << get_name() + " successfully started.";
 }
 
 void
@@ -75,7 +78,7 @@ TPBuffer::do_stop(const nlohmann::json& args)
   m_thread.stop_working_thread();
   m_request_handler_impl->stop(args);
   m_latency_buffer_impl->flush();
-  TLOG_DEBUG(2) << get_name() + " successfully stopped.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TPB] " << get_name() + " successfully stopped.";
 }
 
 void
@@ -116,7 +119,7 @@ TPBuffer::do_work(std::atomic<bool>& running_flag)
     }
   } // while (running_flag.load())
 
-  TLOG() << get_name() << " exiting do_work() method. Received " << n_tps_received << " TPs " << " and " << n_requests_received << " data requests";
+  TLOG(1) << "[TPB] " << get_name() << " exiting do_work() method. Received " << n_tps_received << " TPs " << " and " << n_requests_received << " data requests";
 }
 
 } // namespace trigger

--- a/plugins/TPBuffer.cpp
+++ b/plugins/TPBuffer.cpp
@@ -119,7 +119,7 @@ TPBuffer::do_work(std::atomic<bool>& running_flag)
     }
   } // while (running_flag.load())
 
-  TLOG(1) << "[TPB] " << get_name() << " exiting do_work() method. Received " << n_tps_received << " TPs " << " and " << n_requests_received << " data requests";
+  TLOG() << "[TPB] " << get_name() << " exiting do_work() method. Received " << n_tps_received << " TPs " << " and " << n_requests_received << " data requests";
 }
 
 } // namespace trigger

--- a/plugins/TPSetBufferCreator.cpp
+++ b/plugins/TPSetBufferCreator.cpp
@@ -130,7 +130,7 @@ TPSetBufferCreator::do_stop(const nlohmann::json& /*args*/)
 
   m_tps_buffer->clear_buffer(); // emptying buffer
 
-  TLOG_DEBUG(TLVL_GENERAL) << "[TPSetBufferCreator] " << get_name() << ": Exiting do_stop() method : sent " << sentCount << " incomplete fragments";
+  TLOG(1) << "[TPSetBufferCreator] " << get_name() << ": Exiting do_stop() method : sent " << sentCount << " incomplete fragments";
 }
 
 void
@@ -196,7 +196,7 @@ TPSetBufferCreator::send_out_fragment(std::unique_ptr<daqdataformats::Fragment> 
   // everything we generate, even if running_flag is changed
   // to false between the top of the main loop and here
   do {
-    TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TPSetBufferCreator] " << get_name() << ": Pushing the requested TPSet onto queue " << thisQueueName;
+    TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TPSetBufferCreator] " << get_name() << ": Pushing the requested TPSet onto queue " << thisQueueName;
     try {
       auto the_pair = std::make_pair(std::move(frag_out), data_destination);
       m_output_queue_frag->send(std::move(the_pair), m_queueTimeout);
@@ -324,7 +324,7 @@ TPSetBufferCreator::do_work(std::atomic<bool>& running_flag)
 
       switch (requested_tpset.ds_outcome) {
         case TPSetBuffer::kEmpty:
-          TLOG_DEBUG(TLVL_DEBUG_ALL) << "[TPSetBufferCreator] " << get_name() << ": Requested data (" << input_data_request.request_information.window_begin << ", "
+          TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TPSetBufferCreator] " << get_name() << ": Requested data (" << input_data_request.request_information.window_begin << ", "
                  << input_data_request.request_information.window_end << ") not in buffer, which contains "
                  << m_tps_buffer->get_stored_size() << " TPSets between (" << m_tps_buffer->get_earliest_start_time()
                  << ", " << m_tps_buffer->get_latest_end_time() << "). Returning empty fragment.";
@@ -332,14 +332,14 @@ TPSetBufferCreator::do_work(std::atomic<bool>& running_flag)
           send_out_fragment(std::move(frag_out), input_data_request.data_destination, sentCount, running_flag);
           break;
         case TPSetBuffer::kLate:
-          TLOG_DEBUG(TLVL_DEBUG_ALL) << "[TPSetBufferCreator] " << get_name() << ": Requested data (" << input_data_request.request_information.window_begin << ", "
+          TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TPSetBufferCreator] " << get_name() << ": Requested data (" << input_data_request.request_information.window_begin << ", "
                  << input_data_request.request_information.window_end << ") has not arrived in buffer, which contains "
                  << m_tps_buffer->get_stored_size() << " TPSets between (" << m_tps_buffer->get_earliest_start_time()
                  << ", " << m_tps_buffer->get_latest_end_time() << "). Holding request until more data arrives.";
           m_dr_on_hold.insert(std::make_pair(input_data_request, requested_tpset.txsets_in_window));
           break; // don't send anything yet. Wait for more data to arrived.
         case TPSetBuffer::kSuccess:
-          TLOG_DEBUG(TLVL_DEBUG_ALL) << "[TPSetBufferCreator] " << get_name() << ": Sending requested data (" << input_data_request.request_information.window_begin
+          TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TPSetBufferCreator] " << get_name() << ": Sending requested data (" << input_data_request.request_information.window_begin
                  << ", " << input_data_request.request_information.window_end << "), containing "
                  << requested_tpset.txsets_in_window.size() << " TPSets.";
 
@@ -355,7 +355,7 @@ TPSetBufferCreator::do_work(std::atomic<bool>& running_flag)
     }
   } // end while(running_flag.load())
 
-  TLOG_DEBUG(TLVL_GENERAL) << "[TPSetBufferCreator] " << get_name() << ": Exiting the do_work() method: received " << addedCount << " Sets and " << requestedCount
+  TLOG(1) << "[TPSetBufferCreator] " << get_name() << ": Exiting the do_work() method: received " << addedCount << " Sets and " << requestedCount
          << " data requests. " << addFailedCount << " Sets failed to add. Sent " << sentCount << " fragments";
 
 } // NOLINT Function length

--- a/plugins/TPSetBufferCreator.cpp
+++ b/plugins/TPSetBufferCreator.cpp
@@ -106,13 +106,13 @@ TPSetBufferCreator::do_stop(const nlohmann::json& /*args*/)
   size_t sentCount = 0;
   TPSetBuffer::DataRequestOutput requested_tpset;
   if (m_dr_on_hold.size()) { // check if there are still data request on hold
-    TLOG(TLVL_DEBUG_LOW) << "[TPSetBufferCreator] " << get_name() << ": On hold DRs: " << m_dr_on_hold.size();
+    TLOG_DEBUG(TLVL_DEBUG_LOW) << "[TPSetBufferCreator] " << get_name() << ": On hold DRs: " << m_dr_on_hold.size();
     std::map<dfmessages::DataRequest, std::vector<trigger::TPSet>>::iterator it = m_dr_on_hold.begin();
     while (it != m_dr_on_hold.end()) {
 
       requested_tpset.txsets_in_window = it->second;
       std::unique_ptr<daqdataformats::Fragment> frag_out = convert_to_fragment(requested_tpset.txsets_in_window, it->first);
-      TLOG(TLVL_DEBUG_MEDIUM) << "[TPSetBufferCreator] " << get_name() << ": Sending late requested data (" << (it->first).request_information.window_begin << ", "
+      TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TPSetBufferCreator] " << get_name() << ": Sending late requested data (" << (it->first).request_information.window_begin << ", "
              << (it->first).request_information.window_end << "), containing "
              << requested_tpset.txsets_in_window.size() << " TPSets.";
 
@@ -130,7 +130,7 @@ TPSetBufferCreator::do_stop(const nlohmann::json& /*args*/)
 
   m_tps_buffer->clear_buffer(); // emptying buffer
 
-  TLOG(1) << "[TPSetBufferCreator] " << get_name() << ": Exiting do_stop() method : sent " << sentCount << " incomplete fragments";
+  TLOG() << "[TPSetBufferCreator] " << get_name() << ": Exiting do_stop() method : sent " << sentCount << " incomplete fragments";
 }
 
 void
@@ -355,7 +355,7 @@ TPSetBufferCreator::do_work(std::atomic<bool>& running_flag)
     }
   } // end while(running_flag.load())
 
-  TLOG(1) << "[TPSetBufferCreator] " << get_name() << ": Exiting the do_work() method: received " << addedCount << " Sets and " << requestedCount
+  TLOG() << "[TPSetBufferCreator] " << get_name() << ": Exiting the do_work() method: received " << addedCount << " Sets and " << requestedCount
          << " data requests. " << addFailedCount << " Sets failed to add. Sent " << sentCount << " fragments";
 
 } // NOLINT Function length

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -83,7 +83,7 @@ TimingTriggerCandidateMaker::do_conf(const nlohmann::json& config)
   m_prescale_flag = (m_prescale > 1) ? true : false;
   TLOG_DEBUG(TLVL_GENERAL) << "[TTCM] " << get_name() + " configured.";
   if (m_prescale_flag){
-    TLOG(TLVL_VERY_IMPORTANT) << "[TTCM] Running with prescale at: " << m_prescale;
+    TLOG_DEBUG(TLVL_VERY_IMPORTANT) << "[TTCM] Running with prescale at: " << m_prescale;
   }
 }
 
@@ -121,7 +121,7 @@ TimingTriggerCandidateMaker::do_stop(const nlohmann::json&)
 {
   m_hsievent_input->remove_callback();
 
-  TLOG(1) << "[TTCM] Received " << m_tsd_received_count << " HSIEvent messages. Successfully sent " << m_tc_sent_count
+  TLOG() << "[TTCM] Received " << m_tsd_received_count << " HSIEvent messages. Successfully sent " << m_tc_sent_count
          << " TriggerCandidates";
   TLOG_DEBUG(TLVL_GENERAL) << "[TTCM] " << get_name() + " successfully stopped.";
 }

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "TimingTriggerCandidateMaker.hpp"
+#include "trigger/Logging.hpp"
 
 #include "appfwk/DAQModuleHelper.hpp"
 #include "trgdataformats/Types.hpp"
@@ -16,6 +17,12 @@
 
 #include <regex>
 #include <string>
+
+using dunedaq::trigger::logging::TLVL_VERY_IMPORTANT;
+using dunedaq::trigger::logging::TLVL_IMPORTANT;
+using dunedaq::trigger::logging::TLVL_GENERAL;
+using dunedaq::trigger::logging::TLVL_DEBUG_HIGH;
+using dunedaq::trigger::logging::TLVL_DEBUG_MEDIUM;
 
 namespace dunedaq {
 namespace trigger {
@@ -39,7 +46,7 @@ TimingTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEve
   // TODO Trigger Team <dune-daq@github.com> Nov-18-2021: the signal field ia now a signal bit map, rather than unique
   // value -> change logic of below?
   if (m_hsi_passthrough == true) {
-    TLOG_DEBUG(3) << "HSI passthrough applied, modified readout window is set";
+    TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TTCM] HSI passthrough applied, modified readout window is set";
     candidate.time_start = data.timestamp - m_hsi_pt_before;
     candidate.time_end = data.timestamp + m_hsi_pt_after;
   } else {
@@ -76,9 +83,9 @@ TimingTriggerCandidateMaker::do_conf(const nlohmann::json& config)
   m_hsi_pt_after = params.s0.time_after;
   m_prescale = params.prescale;
   m_prescale_flag = (m_prescale > 1) ? true : false;
-  TLOG_DEBUG(2) << get_name() + " configured.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TTCM] " << get_name() + " configured.";
   if (m_prescale_flag){
-    TLOG(2) << "Running with prescale at: " << m_prescale;
+    TLOG(TLVL_VERY_IMPORTANT) << "[TTCM] Running with prescale at: " << m_prescale;
   }
 }
 
@@ -108,7 +115,7 @@ TimingTriggerCandidateMaker::do_start(const nlohmann::json& startobj)
 
   m_hsievent_input->add_callback(std::bind(&TimingTriggerCandidateMaker::receive_hsievent, this, std::placeholders::_1));
   
-  TLOG_DEBUG(2) << get_name() + " successfully started.";
+  TLOG_DEBUG(TLVL_IMPORTANT) << "[TTCM] " << get_name() + " successfully started.";
 }
 
 void
@@ -116,15 +123,15 @@ TimingTriggerCandidateMaker::do_stop(const nlohmann::json&)
 {
   m_hsievent_input->remove_callback();
 
-  TLOG() << "Received " << m_tsd_received_count << " HSIEvent messages. Successfully sent " << m_tc_sent_count
+  TLOG_DEBUG(TLVL_VERY_IMPORTANT) << "[TTCM] Received " << m_tsd_received_count << " HSIEvent messages. Successfully sent " << m_tc_sent_count
          << " TriggerCandidates";
-  TLOG_DEBUG(2) << get_name() + " successfully stopped.";
+  TLOG_DEBUG(TLVL_IMPORTANT) << "[TTCM] " << get_name() + " successfully stopped.";
 }
 
 void
 TimingTriggerCandidateMaker::receive_hsievent(dfmessages::HSIEvent& data)
 {
-  TLOG_DEBUG(3) << "Activity received with timestamp " << data.timestamp << ", sequence_counter " << data.sequence_counter
+  TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TTCM] Activity received with timestamp " << data.timestamp << ", sequence_counter " << data.sequence_counter
                 << ", and run_number " << data.run_number;
 
   if (data.run_number != m_run_number) {
@@ -142,7 +149,7 @@ TimingTriggerCandidateMaker::receive_hsievent(dfmessages::HSIEvent& data)
   }
 
   if (m_hsi_passthrough == true){
-    TLOG_DEBUG(3) << "Signal_map: " << data.signal_map << ", trigger bits: " << (std::bitset<16>)data.signal_map;
+    TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TTCM] Signal_map: " << data.signal_map << ", trigger bits: " << (std::bitset<16>)data.signal_map;
     try {
       if ((data.signal_map & 0xffffff00) != 0){
         throw dunedaq::trigger::BadTriggerBitmask(ERS_HERE, get_name(), (std::bitset<16>)data.signal_map);

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -19,9 +19,7 @@
 #include <string>
 
 using dunedaq::trigger::logging::TLVL_VERY_IMPORTANT;
-using dunedaq::trigger::logging::TLVL_IMPORTANT;
 using dunedaq::trigger::logging::TLVL_GENERAL;
-using dunedaq::trigger::logging::TLVL_DEBUG_HIGH;
 using dunedaq::trigger::logging::TLVL_DEBUG_MEDIUM;
 
 namespace dunedaq {
@@ -46,7 +44,7 @@ TimingTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEve
   // TODO Trigger Team <dune-daq@github.com> Nov-18-2021: the signal field ia now a signal bit map, rather than unique
   // value -> change logic of below?
   if (m_hsi_passthrough == true) {
-    TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TTCM] HSI passthrough applied, modified readout window is set";
+    TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TTCM] HSI passthrough applied, modified readout window is set";
     candidate.time_start = data.timestamp - m_hsi_pt_before;
     candidate.time_end = data.timestamp + m_hsi_pt_after;
   } else {
@@ -115,7 +113,7 @@ TimingTriggerCandidateMaker::do_start(const nlohmann::json& startobj)
 
   m_hsievent_input->add_callback(std::bind(&TimingTriggerCandidateMaker::receive_hsievent, this, std::placeholders::_1));
   
-  TLOG_DEBUG(TLVL_IMPORTANT) << "[TTCM] " << get_name() + " successfully started.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TTCM] " << get_name() + " successfully started.";
 }
 
 void
@@ -123,9 +121,9 @@ TimingTriggerCandidateMaker::do_stop(const nlohmann::json&)
 {
   m_hsievent_input->remove_callback();
 
-  TLOG_DEBUG(TLVL_VERY_IMPORTANT) << "[TTCM] Received " << m_tsd_received_count << " HSIEvent messages. Successfully sent " << m_tc_sent_count
+  TLOG(1) << "[TTCM] Received " << m_tsd_received_count << " HSIEvent messages. Successfully sent " << m_tc_sent_count
          << " TriggerCandidates";
-  TLOG_DEBUG(TLVL_IMPORTANT) << "[TTCM] " << get_name() + " successfully stopped.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TTCM] " << get_name() + " successfully stopped.";
 }
 
 void

--- a/plugins/TriggerPrimitiveMaker.cpp
+++ b/plugins/TriggerPrimitiveMaker.cpp
@@ -84,7 +84,7 @@ TriggerPrimitiveMaker::do_configure(const nlohmann::json& obj)
 void
 TriggerPrimitiveMaker::do_start(const nlohmann::json& args)
 {
-  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Entering do_start() method";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TPM] " << get_name() << ": Entering do_start() method";
 
   rcif::cmd::StartParams start_params = args.get<rcif::cmd::StartParams>();
   m_run_number = start_params.run;
@@ -110,13 +110,13 @@ TriggerPrimitiveMaker::do_start(const nlohmann::json& args)
     name += std::to_string(i);
     pthread_setname_np(m_threads[i]->native_handle(), name.c_str());
   }
-  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Exiting do_start() method";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TPM] " << get_name() << ": Exiting do_start() method";
 }
 
 void
 TriggerPrimitiveMaker::do_stop(const nlohmann::json& /*args*/)
 {
-  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Entering do_stop() method";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TPM] " << get_name() << ": Entering do_stop() method";
   m_running_flag.store(false);
   for (auto& thr : m_threads) {
     if (thr != nullptr && thr->joinable()) {
@@ -124,15 +124,15 @@ TriggerPrimitiveMaker::do_stop(const nlohmann::json& /*args*/)
     }
   }
   m_threads.clear();
-  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Exiting do_stop() method";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TPM] " << get_name() << ": Exiting do_stop() method";
 }
 
 void
 TriggerPrimitiveMaker::do_scrap(const nlohmann::json& /*args*/)
 {
-  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Entering do_scrap() method";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TPM] " << get_name() << ": Entering do_scrap() method";
   m_tp_streams.clear();
-  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Exiting do_scrap() method";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TPM] " << get_name() << ": Exiting do_scrap() method";
 }
 
 std::vector<TPSet>
@@ -210,7 +210,7 @@ TriggerPrimitiveMaker::read_tpsets(std::string filename, int element)
     // We don't send empty TPSets, so there's no point creating them
     tpsets.push_back(tpset);
   }
-  TLOG_DEBUG(TLVL_GENERAL) << "[TPM] Read " << seqno << " TPs into " << tpsets.size() << " TPSets, from file " << filename;
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] Read " << seqno << " TPs into " << tpsets.size() << " TPSets, from file " << filename;
   return tpsets;
 }
 
@@ -220,7 +220,7 @@ TriggerPrimitiveMaker::do_work(std::atomic<bool>& running_flag,
                                std::shared_ptr<iomanager::SenderConcept<TPSet>>& tpset_sink,
                                std::chrono::steady_clock::time_point earliest_timestamp_time)
 {
-  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Entering do_work() method";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TPM] " << get_name() << ": Entering do_work() method";
   uint64_t current_iteration = 0; // NOLINT(build/unsigned)
   size_t generated_count = 0;
   size_t push_failed_count = 0;
@@ -315,7 +315,7 @@ TriggerPrimitiveMaker::do_work(std::atomic<bool>& running_flag,
   TLOG(1) << "[TPM] Generated " << generated_count << " TP sets (" << generated_tp_count << " TPs) in " << time_ms << " ms. ("
          << rate_hz << " TPSets/s). " << push_failed_count << " failed to push";
 
-  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Exiting do_work() method";
+  TLOG_DEBUG(TLVL_GENERAL) << "[TPM] " << get_name() << ": Exiting do_work() method";
 }
 
 } // namespace dunedaq::trigger

--- a/plugins/TriggerPrimitiveMaker.cpp
+++ b/plugins/TriggerPrimitiveMaker.cpp
@@ -312,7 +312,7 @@ TriggerPrimitiveMaker::do_work(std::atomic<bool>& running_flag,
   auto time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(run_end_time - run_start_time).count();
   float rate_hz = 1e3 * static_cast<float>(generated_count) / time_ms;
 
-  TLOG(1) << "[TPM] Generated " << generated_count << " TP sets (" << generated_tp_count << " TPs) in " << time_ms << " ms. ("
+  TLOG() << "[TPM] Generated " << generated_count << " TP sets (" << generated_tp_count << " TPs) in " << time_ms << " ms. ("
          << rate_hz << " TPSets/s). " << push_failed_count << " failed to push";
 
   TLOG_DEBUG(TLVL_GENERAL) << "[TPM] " << get_name() << ": Exiting do_work() method";

--- a/plugins/TriggerPrimitiveMaker.cpp
+++ b/plugins/TriggerPrimitiveMaker.cpp
@@ -9,6 +9,7 @@
 #include "TriggerPrimitiveMaker.hpp"
 
 #include "trigger/Issues.hpp" // For TLVL_*
+#include "trigger/Logging.hpp"
 
 #include "appfwk/DAQModuleHelper.hpp"
 #include "appfwk/cmd/Nljs.hpp"
@@ -24,6 +25,10 @@
 #include <string>
 #include <thread>
 #include <vector>
+
+using dunedaq::trigger::logging::TLVL_GENERAL;
+using dunedaq::trigger::logging::TLVL_DEBUG_INFO;
+using dunedaq::trigger::logging::TLVL_IMPORTANT;
 
 using namespace triggeralgs;
 
@@ -79,7 +84,7 @@ TriggerPrimitiveMaker::do_configure(const nlohmann::json& obj)
 void
 TriggerPrimitiveMaker::do_start(const nlohmann::json& args)
 {
-  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_start() method";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Entering do_start() method";
 
   rcif::cmd::StartParams start_params = args.get<rcif::cmd::StartParams>();
   m_run_number = start_params.run;
@@ -105,13 +110,13 @@ TriggerPrimitiveMaker::do_start(const nlohmann::json& args)
     name += std::to_string(i);
     pthread_setname_np(m_threads[i]->native_handle(), name.c_str());
   }
-  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_start() method";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Exiting do_start() method";
 }
 
 void
 TriggerPrimitiveMaker::do_stop(const nlohmann::json& /*args*/)
 {
-  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_stop() method";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Entering do_stop() method";
   m_running_flag.store(false);
   for (auto& thr : m_threads) {
     if (thr != nullptr && thr->joinable()) {
@@ -119,15 +124,15 @@ TriggerPrimitiveMaker::do_stop(const nlohmann::json& /*args*/)
     }
   }
   m_threads.clear();
-  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_stop() method";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Exiting do_stop() method";
 }
 
 void
 TriggerPrimitiveMaker::do_scrap(const nlohmann::json& /*args*/)
 {
-  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_scrap() method";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Entering do_scrap() method";
   m_tp_streams.clear();
-  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_scrap() method";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Exiting do_scrap() method";
 }
 
 std::vector<TPSet>
@@ -205,7 +210,7 @@ TriggerPrimitiveMaker::read_tpsets(std::string filename, int element)
     // We don't send empty TPSets, so there's no point creating them
     tpsets.push_back(tpset);
   }
-  TLOG_DEBUG(0) << "Read " << seqno << " TPs into " << tpsets.size() << " TPSets, from file " << filename;
+  TLOG_DEBUG(TLVL_GENERAL) << "[TPM] Read " << seqno << " TPs into " << tpsets.size() << " TPSets, from file " << filename;
   return tpsets;
 }
 
@@ -215,7 +220,7 @@ TriggerPrimitiveMaker::do_work(std::atomic<bool>& running_flag,
                                std::shared_ptr<iomanager::SenderConcept<TPSet>>& tpset_sink,
                                std::chrono::steady_clock::time_point earliest_timestamp_time)
 {
-  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_work() method";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Entering do_work() method";
   uint64_t current_iteration = 0; // NOLINT(build/unsigned)
   size_t generated_count = 0;
   size_t push_failed_count = 0;
@@ -263,7 +268,7 @@ TriggerPrimitiveMaker::do_work(std::atomic<bool>& running_flag,
       bool break_flag = false;
       while (next_tpset_send_time > next_slice_send_time + slice_period) {
         if (!running_flag.load()) {
-          TLOG() << "while waiting to send next TP, negative running flag detected.";
+          TLOG_DEBUG(TLVL_IMPORTANT) << "[TPM] while waiting to send next TP, negative running flag detected.";
           break_flag = true;
           break;
         }
@@ -307,10 +312,10 @@ TriggerPrimitiveMaker::do_work(std::atomic<bool>& running_flag,
   auto time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(run_end_time - run_start_time).count();
   float rate_hz = 1e3 * static_cast<float>(generated_count) / time_ms;
 
-  TLOG() << "Generated " << generated_count << " TP sets (" << generated_tp_count << " TPs) in " << time_ms << " ms. ("
+  TLOG(1) << "[TPM] Generated " << generated_count << " TP sets (" << generated_tp_count << " TPs) in " << time_ms << " ms. ("
          << rate_hz << " TPSets/s). " << push_failed_count << " failed to push";
 
-  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_work() method";
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TPM] " << get_name() << ": Exiting do_work() method";
 }
 
 } // namespace dunedaq::trigger

--- a/plugins/TriggerZipper.hpp
+++ b/plugins/TriggerZipper.hpp
@@ -12,6 +12,7 @@
 #include "zipper.hpp"
 
 #include "trigger/Issues.hpp"
+#include "trigger/Logging.hpp"
 #include "trigger/triggerzipper/Nljs.hpp"
 #include "trigger/triggerzipperinfo/InfoNljs.hpp"
 
@@ -36,6 +37,8 @@
 
 const char* inqs_name = "inputs";
 const char* outq_name = "output";
+
+using dunedaq::trigger::logging::TLVL_DEBUG_INFO;
 
 namespace dunedaq::trigger {
 
@@ -165,13 +168,13 @@ public:
     m_thread.join();
     flush();
     m_zm.clear();
-    TLOG() << "Received " << m_n_received << " Sets. Sent " << m_n_sent << " Sets. " << m_n_tardy << " were tardy";
+    TLOG(1) << "[Zipper] Received " << m_n_received << " Sets. Sent " << m_n_sent << " Sets. " << m_n_tardy << " were tardy";
     std::stringstream ss;
     ss << std::endl;
     for (auto& [id, n] : m_tardy_counts) {
       ss << id << "\t" << n << std::endl;
     }
-    TLOG_DEBUG(1) << "Tardy counts:" << ss.str();
+    TLOG_DEBUG(TLVL_DEBUG_INFO) << "[Zipper] Tardy counts:" << ss.str();
   }
 
   // thread worker

--- a/plugins/TriggerZipper.hpp
+++ b/plugins/TriggerZipper.hpp
@@ -168,7 +168,7 @@ public:
     m_thread.join();
     flush();
     m_zm.clear();
-    TLOG(1) << "[Zipper] Received " << m_n_received << " Sets. Sent " << m_n_sent << " Sets. " << m_n_tardy << " were tardy";
+    TLOG() << "[Zipper] Received " << m_n_received << " Sets. Sent " << m_n_sent << " Sets. " << m_n_tardy << " were tardy";
     std::stringstream ss;
     ss << std::endl;
     for (auto& [id, n] : m_tardy_counts) {

--- a/src/LivetimeCounter.cpp
+++ b/src/LivetimeCounter.cpp
@@ -1,8 +1,12 @@
 #include "trigger/LivetimeCounter.hpp"
+#include "trigger/Logging.hpp"
 
 #include "logging/Logging.hpp"
 
 #include <sstream>
+
+using dunedaq::trigger::logging::TLVL_VERY_IMPORTANT;
+using dunedaq::trigger::logging::TLVL_IMPORTANT;
 
 namespace dunedaq::trigger {
 
@@ -10,7 +14,7 @@ LivetimeCounter::LivetimeCounter(LivetimeCounter::State state)
   : m_state(state)
   , m_last_state_change_time(now())
 {
-  TLOG_DEBUG(1) << "Starting LivetimeCounter in state " << get_state_name(state);
+  TLOG_DEBUG(TLVL_VERY_IMPORTANT) << "[Livetime] Starting LivetimeCounter in state " << get_state_name(state);
   m_state_times[State::kLive]=0;
   m_state_times[State::kDead]=0;
   m_state_times[State::kPaused]=0;
@@ -19,7 +23,7 @@ LivetimeCounter::LivetimeCounter(LivetimeCounter::State state)
 LivetimeCounter::~LivetimeCounter()
 {
   std::string report=get_report_string();
-  TLOG() << "LivetimeCounter stopping. Counts: " << report;
+  TLOG() << "[Livetime] LivetimeCounter stopping. Counts: " << report;
 }
 
 void
@@ -38,7 +42,7 @@ LivetimeCounter::set_state(LivetimeCounter::State state)
 {
   std::lock_guard<std::mutex> l(m_mutex);
   update_map(); // Add the time to the old state
-  TLOG_DEBUG(1) << "Changing state from " << get_state_name(m_state) << " to " << get_state_name(state);
+  TLOG_DEBUG(TLVL_IMPORTANT) << "[Livetime] Changing state from " << get_state_name(m_state) << " to " << get_state_name(state);
   m_state=state;
 }
 

--- a/src/TokenManager.cpp
+++ b/src/TokenManager.cpp
@@ -15,8 +15,8 @@
 #include <memory>
 #include <string>
 
-using dunedaq::trigger::logging::TLVL_GENERAL;
 using dunedaq::trigger::logging::TLVL_DEBUG_INFO;
+using dunedaq::trigger::logging::TLVL_DEBUG_LOW;
 using dunedaq::trigger::logging::TLVL_DEBUG_MEDIUM;
 
 namespace dunedaq::trigger {
@@ -59,7 +59,7 @@ TokenManager::~TokenManager()
         }
         o << "]";
       }
-      TLOG_DEBUG(TLVL_GENERAL) << "[TokenManager] " << o.str();
+      TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TokenManager] " << o.str();
     }
   }
 }
@@ -84,13 +84,13 @@ TokenManager::trigger_sent(dfmessages::trigger_number_t trigger_number)
 void
 TokenManager::receive_token(dfmessages::TriggerDecisionToken& token)
 {
-  TLOG_DEBUG(TLVL_GENERAL) << "[TokenManager] Received token with run number " << token.run_number << ", current run number " << m_run_number;
+  TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TokenManager] Received token with run number " << token.run_number << ", current run number " << m_run_number;
   if (token.run_number == m_run_number) {
     if (m_n_tokens.load() == 0) {
       m_livetime_counter->set_state(LivetimeCounter::State::kLive);
     }
     m_n_tokens++;
-    TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TokenManager] There are now " << m_n_tokens.load() << " tokens available";
+    TLOG_DEBUG(TLVL_DEBUG_LOW) << "[TokenManager] There are now " << m_n_tokens.load() << " tokens available";
 
     if (token.trigger_number != dfmessages::TypeDefaults::s_invalid_trigger_number) {
       if (m_open_trigger_decisions.count(token.trigger_number)) {

--- a/src/TokenManager.cpp
+++ b/src/TokenManager.cpp
@@ -8,11 +8,16 @@
 
 #include "trigger/TokenManager.hpp"
 #include "trigger/LivetimeCounter.hpp"
+#include "trigger/Logging.hpp"
 
 #include "iomanager/IOManager.hpp"
 
 #include <memory>
 #include <string>
+
+using dunedaq::trigger::logging::TLVL_GENERAL;
+using dunedaq::trigger::logging::TLVL_DEBUG_INFO;
+using dunedaq::trigger::logging::TLVL_DEBUG_MEDIUM;
 
 namespace dunedaq::trigger {
 
@@ -54,7 +59,7 @@ TokenManager::~TokenManager()
         }
         o << "]";
       }
-      TLOG_DEBUG(0) << o.str();
+      TLOG_DEBUG(TLVL_GENERAL) << "[TokenManager] " << o.str();
     }
   }
 }
@@ -79,19 +84,19 @@ TokenManager::trigger_sent(dfmessages::trigger_number_t trigger_number)
 void
 TokenManager::receive_token(dfmessages::TriggerDecisionToken& token)
 {
-  TLOG_DEBUG(1) << "Received token with run number " << token.run_number << ", current run number " << m_run_number;
+  TLOG_DEBUG(TLVL_GENERAL) << "[TokenManager] Received token with run number " << token.run_number << ", current run number " << m_run_number;
   if (token.run_number == m_run_number) {
     if (m_n_tokens.load() == 0) {
       m_livetime_counter->set_state(LivetimeCounter::State::kLive);
     }
     m_n_tokens++;
-    TLOG_DEBUG(1) << "There are now " << m_n_tokens.load() << " tokens available";
+    TLOG_DEBUG(TLVL_DEBUG_INFO) << "[TokenManager] There are now " << m_n_tokens.load() << " tokens available";
 
     if (token.trigger_number != dfmessages::TypeDefaults::s_invalid_trigger_number) {
       if (m_open_trigger_decisions.count(token.trigger_number)) {
         std::lock_guard<std::mutex> lk(m_open_trigger_decisions_mutex);
         m_open_trigger_decisions.erase(token.trigger_number);
-        TLOG_DEBUG(1) << "Token indicates that trigger decision " << token.trigger_number
+        TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TokenManager] Token indicates that trigger decision " << token.trigger_number
                       << " has been completed. There are now " << m_open_trigger_decisions.size()
                       << " triggers in flight";
       } else {

--- a/src/trigger/TimeSliceOutputBuffer.hpp
+++ b/src/trigger/TimeSliceOutputBuffer.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-using dunedaq::trigger::logging::TLVL_DEBUG_HIGH;
+using dunedaq::trigger::logging::TLVL_DEBUG_MEDIUM;
 
 namespace dunedaq::trigger {
 
@@ -145,7 +145,7 @@ public:
     // buffer
     if (!m_heartbeat_buffer.empty() && m_heartbeat_buffer.top().start_time == m_next_window_start) {
       auto& hb = m_heartbeat_buffer.top();
-      TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TimeSliceOutputBuffer] Flushing heartbeat with start time " << hb.start_time;
+      TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TimeSliceOutputBuffer] Flushing heartbeat with start time " << hb.start_time;
       out_set.start_time = hb.start_time;
       out_set.end_time = hb.end_time;
       out_set.origin = hb.origin;
@@ -167,7 +167,7 @@ public:
       }
       m_buffer.pop();
     }
-    TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TimeSliceOutputBuffer] Filled payload from " << out_set.start_time << " to " << out_set.end_time << " with " << out_set.objects.size() << " objects";
+    TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TimeSliceOutputBuffer] Filled payload from " << out_set.start_time << " to " << out_set.end_time << " with " << out_set.objects.size() << " objects";
   }
 
 private:

--- a/src/trigger/TimeSliceOutputBuffer.hpp
+++ b/src/trigger/TimeSliceOutputBuffer.hpp
@@ -11,12 +11,15 @@
 
 #include "trigger/Issues.hpp"
 #include "trigger/Set.hpp"
+#include "trigger/Logging.hpp"
 
 #include "logging/Logging.hpp"
 
 #include <queue>
 #include <string>
 #include <vector>
+
+using dunedaq::trigger::logging::TLVL_DEBUG_HIGH;
 
 namespace dunedaq::trigger {
 
@@ -142,7 +145,7 @@ public:
     // buffer
     if (!m_heartbeat_buffer.empty() && m_heartbeat_buffer.top().start_time == m_next_window_start) {
       auto& hb = m_heartbeat_buffer.top();
-      TLOG_DEBUG(4) << "Flushing heartbeat with start time " << hb.start_time;
+      TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TimeSliceOutputBuffer] Flushing heartbeat with start time " << hb.start_time;
       out_set.start_time = hb.start_time;
       out_set.end_time = hb.end_time;
       out_set.origin = hb.origin;
@@ -164,7 +167,7 @@ public:
       }
       m_buffer.pop();
     }
-    TLOG_DEBUG(4) << "Filled payload from " << out_set.start_time << " to " << out_set.end_time << " with " << out_set.objects.size() << " objects";
+    TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TimeSliceOutputBuffer] Filled payload from " << out_set.start_time << " to " << out_set.end_time << " with " << out_set.objects.size() << " objects";
   }
 
 private:

--- a/src/trigger/TriggerGenericMaker.hpp
+++ b/src/trigger/TriggerGenericMaker.hpp
@@ -10,6 +10,7 @@
 #define TRIGGER_SRC_TRIGGER_TRIGGERGENERICMAKER_HPP_
 
 #include "trigger/Issues.hpp"
+#include "trigger/Logging.hpp"
 #include "trigger/Set.hpp"
 #include "trigger/TimeSliceInputBuffer.hpp"
 #include "trigger/TimeSliceOutputBuffer.hpp"
@@ -30,6 +31,11 @@
 #include <memory>
 #include <string>
 #include <vector>
+
+using dunedaq::trigger::logging::TLVL_IMPORTANT;
+using dunedaq::trigger::logging::TLVL_DEBUG_MEDIUM;
+using dunedaq::trigger::logging::TLVL_DEBUG_HIGH;
+using dunedaq::trigger::logging::TLVL_DEBUG_ALL;
 
 namespace dunedaq::trigger {
 
@@ -191,7 +197,7 @@ private:
     // outputs are stale and will cause tardy warnings from the zipper
     // downstream
     worker.drain(true);
-    TLOG() << get_name() << ": Exiting do_work() method for run " << m_run_number << ", received " << m_received_count
+    TLOG_DEBUG(TLVL_IMPORTANT) << "[TGM] " << get_name() << ": Exiting do_work() method for run " << m_run_number << ", received " << m_received_count
            << " inputs (" << worker.get_low_level_input_count() << " sub-inputs) and successfully sent " << m_sent_count
            << " outputs. ";
     worker.reset();
@@ -365,7 +371,7 @@ public: // NOLINT
         heartbeat.origin = daqdataformats::SourceID(
           daqdataformats::SourceID::Subsystem::kTrigger, m_parent.m_sourceid);
 
-        TLOG_DEBUG(4) << "Buffering heartbeat with start time " << heartbeat.start_time;
+        TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TGM] Buffering heartbeat with start time " << heartbeat.start_time;
         m_out_buffer.buffer_heartbeat(heartbeat);
 
         // flush the maker
@@ -400,7 +406,7 @@ public: // NOLINT
           daqdataformats::SourceID::Subsystem::kTrigger, m_parent.m_sourceid);
 
       if (out.type == Set<B>::Type::kHeartbeat) {
-        TLOG_DEBUG(4) << "Sending heartbeat with start time " << out.start_time;
+        TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TGM] Sending heartbeat with start time " << out.start_time;
         if (!m_parent.send(std::move(out))) {
           ers::error(AlgorithmFailedToSend(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
           // out is dropped
@@ -408,7 +414,7 @@ public: // NOLINT
       }
       // Only form and send Set<B> if it has a nonzero number of objects
       else if (out.type == Set<B>::Type::kPayload && out.objects.size() != 0) {
-        TLOG_DEBUG(4) << "Output set window ready with start time " << out.start_time << " end time " << out.end_time
+        TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TGM] Output set window ready with start time " << out.start_time << " end time " << out.end_time
                       << " and " << out.objects.size() << " members";
         if (!m_parent.send(std::move(out))) {
           ers::error(AlgorithmFailedToSend(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
@@ -416,7 +422,7 @@ public: // NOLINT
         }
       }
     }
-    TLOG_DEBUG(4) << "process() done. Advanced output buffer by " << n_output_windows << " output windows";
+    TLOG_DEBUG(TLVL_DEBUG_ALL) << "[TGM] process() done. Advanced output buffer by " << n_output_windows << " output windows";
   }
 
   void drain(bool drop)
@@ -452,7 +458,7 @@ public: // NOLINT
       }
       // Only form and send Set<B> if it has a nonzero number of objects
       else if (out.type == Set<B>::Type::kPayload && out.objects.size() != 0) {
-        TLOG_DEBUG(1) << "Output set window ready with start time " << out.start_time << " end time " << out.end_time
+        TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TGM] Output set window ready with start time " << out.start_time << " end time " << out.end_time
                       << " and " << out.objects.size() << " members";
         if (!drop) {
           if (!m_parent.send(std::move(out))) {

--- a/src/trigger/TriggerGenericMaker.hpp
+++ b/src/trigger/TriggerGenericMaker.hpp
@@ -195,7 +195,7 @@ private:
     // outputs are stale and will cause tardy warnings from the zipper
     // downstream
     worker.drain(true);
-    TLOG(1) << "[TGM] " << get_name() << ": Exiting do_work() method for run " << m_run_number << ", received " << m_received_count
+    TLOG() << "[TGM] " << get_name() << ": Exiting do_work() method for run " << m_run_number << ", received " << m_received_count
            << " inputs (" << worker.get_low_level_input_count() << " sub-inputs) and successfully sent " << m_sent_count
            << " outputs. ";
     worker.reset();

--- a/src/trigger/TriggerGenericMaker.hpp
+++ b/src/trigger/TriggerGenericMaker.hpp
@@ -32,10 +32,8 @@
 #include <string>
 #include <vector>
 
-using dunedaq::trigger::logging::TLVL_IMPORTANT;
 using dunedaq::trigger::logging::TLVL_DEBUG_MEDIUM;
 using dunedaq::trigger::logging::TLVL_DEBUG_HIGH;
-using dunedaq::trigger::logging::TLVL_DEBUG_ALL;
 
 namespace dunedaq::trigger {
 
@@ -197,7 +195,7 @@ private:
     // outputs are stale and will cause tardy warnings from the zipper
     // downstream
     worker.drain(true);
-    TLOG_DEBUG(TLVL_IMPORTANT) << "[TGM] " << get_name() << ": Exiting do_work() method for run " << m_run_number << ", received " << m_received_count
+    TLOG(1) << "[TGM] " << get_name() << ": Exiting do_work() method for run " << m_run_number << ", received " << m_received_count
            << " inputs (" << worker.get_low_level_input_count() << " sub-inputs) and successfully sent " << m_sent_count
            << " outputs. ";
     worker.reset();
@@ -414,7 +412,7 @@ public: // NOLINT
       }
       // Only form and send Set<B> if it has a nonzero number of objects
       else if (out.type == Set<B>::Type::kPayload && out.objects.size() != 0) {
-        TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TGM] Output set window ready with start time " << out.start_time << " end time " << out.end_time
+        TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TGM] Output set window ready with start time " << out.start_time << " end time " << out.end_time
                       << " and " << out.objects.size() << " members";
         if (!m_parent.send(std::move(out))) {
           ers::error(AlgorithmFailedToSend(ERS_HERE, m_parent.get_name(), m_parent.m_algorithm_name));
@@ -422,7 +420,7 @@ public: // NOLINT
         }
       }
     }
-    TLOG_DEBUG(TLVL_DEBUG_ALL) << "[TGM] process() done. Advanced output buffer by " << n_output_windows << " output windows";
+    TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TGM] process() done. Advanced output buffer by " << n_output_windows << " output windows";
   }
 
   void drain(bool drop)
@@ -458,7 +456,7 @@ public: // NOLINT
       }
       // Only form and send Set<B> if it has a nonzero number of objects
       else if (out.type == Set<B>::Type::kPayload && out.objects.size() != 0) {
-        TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TGM] Output set window ready with start time " << out.start_time << " end time " << out.end_time
+        TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TGM] Output set window ready with start time " << out.start_time << " end time " << out.end_time
                       << " and " << out.objects.size() << " members";
         if (!drop) {
           if (!m_parent.send(std::move(out))) {

--- a/test/plugins/TPSetSink.cpp
+++ b/test/plugins/TPSetSink.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "TPSetSink.hpp"
+#include "trigger/Logging.hpp"
 
 #include "appfwk/DAQModuleHelper.hpp"
 #include "appfwk/app/Nljs.hpp"
@@ -17,6 +18,9 @@
 #include <chrono>
 #include <sstream>
 #include <string>
+
+using dunedaq::trigger::logging::TLVL_VERY_IMPORTANT;
+using dunedaq::trigger::logging::TLVL_GENERAL;
 
 namespace dunedaq {
 namespace trigger {
@@ -80,22 +84,22 @@ TPSetSink::do_work()
 
     // Do some checks on the received TPSet
     if (last_seqno != 0 && tpset.seqno != last_seqno + 1) {
-      TLOG() << "Missed TPSets: last_seqno=" << last_seqno << ", current seqno=" << tpset.seqno;
+      TLOG() << "[TPSetSink] Missed TPSets: last_seqno=" << last_seqno << ", current seqno=" << tpset.seqno;
     }
     last_seqno = tpset.seqno;
 
     if (tpset.start_time < last_timestamp) {
-      TLOG() << "TPSets out of order: last start time " << last_timestamp << ", current start time "
+      TLOG_DEBUG(TLVL_VERY_IMPORTANT) << "[TPSetSink] TPSets out of order: last start time " << last_timestamp << ", current start time "
              << tpset.start_time;
     }
     if (tpset.type == TPSet::Type::kHeartbeat) {
-      TLOG() << "Heartbeat TPSet with start time " << tpset.start_time;
+      TLOG_DEBUG(TLVL_GENERAL) << "[TPSetSink] Heartbeat TPSet with start time " << tpset.start_time;
     } else if (tpset.objects.empty()) {
-      TLOG() << "Empty TPSet with start time " << tpset.start_time;
+      TLOG_DEBUG(TLVL_GENERAL) << "[TPSetSink] Empty TPSet with start time " << tpset.start_time;
     }
     for (auto const& tp : tpset.objects) {
       if (tp.time_start < tpset.start_time || tp.time_start > tpset.end_time) {
-        TLOG() << "TPSet with start time " << tpset.start_time << ", end time " << tpset.end_time
+        TLOG_DEBUG(TLVL_GENERAL) << "[TPSetSink] TPSet with start time " << tpset.start_time << ", end time " << tpset.end_time
                << " contains out-of-bounds TP with start time " << tp.time_start;
       }
     }
@@ -111,7 +115,7 @@ TPSetSink::do_work()
   float rate_hz = 1e3 * static_cast<float>(n_tpset_received) / time_ms;
   float inferred_clock_frequency = 1e3 * (last_timestamp - first_timestamp) / time_ms;
 
-  TLOG() << "Received " << n_tpset_received << " TPSets in " << time_ms << "ms. " << rate_hz
+  TLOG_DEBUG(TLVL_VERY_IMPORTANT) << "[TPSetSink] Received " << n_tpset_received << " TPSets in " << time_ms << "ms. " << rate_hz
          << " TPSet/s. Inferred clock frequency " << inferred_clock_frequency << "Hz";
 }
 


### PR DESCRIPTION
This was initiated by issues with trigger log files being too big (https://github.com/DUNE-DAQ/ehn1-operations-issues/issues/32)
There is accompanying PR in triggerals: https://github.com/DUNE-DAQ/triggeralgs/pull/59

This solution introduces new logging system with predefined levels. 

The idea is to:
- always see very important messages
- get important debug messages with low debug levels
- get increasingly more debug messages with higher debug levels, ordered by both presumed importance and also expected frequency
- the order of importance of objects is roughly TD > TC > TA > TP
- one line summary messages are kept as TLOG, so that they are always seen (ei MLT's message about # of TDs, TCs, Livetime)
- the levels are kept at consistent levels across modules, ie 'entering start method' is always the same level regardless of module (well, I tried) 

- I have added little 'tag' at the start of each TLOG(_DEBUG) to highlight the module
- changed some messages to warning/errors
- added few more details to some messages
- no (other) logic changes

Tested with configs from the instructions page & custom configs (RTCM, CTCM, ROI).
Also tested with integtests:
- minimal_system_quick_test.py
- fake_data_producer_test.py
- readout_type_scan.py
- tpstream_writing_test.py

One can change the debug level with:
```export DUNEDAQ_ERS_DEBUG_LEVEL=X```
