### PR TITLE
Fix for MLT deadtime, it now sets to kLive when DFO is "unbusy"

### DIFF
--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -699,7 +699,8 @@ ModuleLevelTrigger::dfo_busy_callback(dfmessages::TriggerInhibit& inhibit)
     TLOG_DEBUG(18) << "Changing our flag for the DFO busy state from " << m_dfo_is_busy.load() << " to "
                    << inhibit.busy;
     m_dfo_is_busy = inhibit.busy;
-    m_livetime_counter->set_state(LivetimeCounter::State::kDead);
+    LivetimeCounter::State state = (inhibit.busy) ? LivetimeCounter::State::kDead : LivetimeCounter::State::kLive;
+    m_livetime_counter->set_state(state);
   }
 }
 


### PR DESCRIPTION
Found a bug in MLT deadtime accounting: it was setting the livetime to `kDead` for every relevant `TriggerInhibit` message. `TriggerInhibit`, can have 2 values: 1 = busy, 0 = not busy. 0 is sent when the DFO was busy, but can now accept triggers once again, which is when the MLT should have set the livetime to `kLive`.

This should go to both v4 and v5, but it's particularly important for PD2, that's why it's going into v4.4.

Two tests ran:
1. Everything from https://github.com/DUNE-DAQ/integrationtest/tree/develop/python/integrationtest
2. Run the replay application with two configurations, both configurations ran on pre-fix and post-fix code:
    1. HMA on run `23582` that got us ~4Hz triggers. DFO always not-busy, so ~100% livetime
    2. HMA on run `23582` that got us ~400Hz triggers, causing DFO being often busy. 
         - On pre-fix setup, MLT set Livetime to kDead at first DFO-busy message, and staid that way, meaning ~0% livetime, despite half of triggers being saved.
         - On post-fix setup, MLT sets Livetime to kDead and kLive based on both types of DFO messages, with ~50% livetime, half of triggers being saved.