### PR TITLE
Asztuc/trigger neutron source

### DIFF
--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -189,6 +189,14 @@ ERS_DECLARE_ISSUE_BASE(trigger,
                        "Factory could not find requested item " << item << ".",
                        ((std::string)item),
                        ERS_EMPTY)
+
+ERS_DECLARE_ISSUE_BASE(trigger,
+                       ConfigurationProblem,
+                       appfwk::GeneralDAQModuleIssue,
+                       "Configuration error: " << item,
+                       ((std::string)item),
+                       ERS_EMPTY)
+
 } // namespace dunedaq
 
 #endif // TRIGGER_INCLUDE_TRIGGER_ISSUES_HPP_

--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -204,6 +204,7 @@ ERS_DECLARE_ISSUE_BASE(trigger,
                        TTCMConfigurationProblem,
                        appfwk::GeneralDAQModuleIssue,
                        "Configuration error: " << item,
+                       ((std::string)name),
                        ((std::string)item),
                        ERS_EMPTY)
 

--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -201,7 +201,7 @@ ERS_DECLARE_ISSUE_BASE(trigger,
                        ERS_EMPTY)
 
 ERS_DECLARE_ISSUE_BASE(trigger,
-                       ConfigurationProblem,
+                       TTCMConfigurationProblem,
                        appfwk::GeneralDAQModuleIssue,
                        "Configuration error: " << item,
                        ((std::string)item),

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -122,7 +122,6 @@ ModuleLevelTrigger::do_configure(const nlohmann::json& confobj)
 
   // m_trigger_decision_connection = params.dfo_connection;
   // m_inhibit_connection = params.dfo_busy_connection;
-  m_hsi_passthrough = params.hsi_trigger_type_passthrough;
 
   m_configured_flag.store(true);
 
@@ -273,19 +272,9 @@ ModuleLevelTrigger::create_decision(const ModuleLevelTrigger::PendingTD& pending
   decision.trigger_timestamp = pending_td.contributing_tcs[m_earliest_tc_index].time_candidate;
   decision.readout_type = dfmessages::ReadoutType::kLocalized;
 
-  if (m_hsi_passthrough == true) {
-    if (pending_td.contributing_tcs[m_earliest_tc_index].type == triggeralgs::TriggerCandidate::Type::kTiming) {
-      decision.trigger_type = pending_td.contributing_tcs[m_earliest_tc_index].detid & 0xff;
-    } else {
-      m_trigger_type_shifted = (static_cast<int>(pending_td.contributing_tcs[m_earliest_tc_index].type) << 8);
-      decision.trigger_type = m_trigger_type_shifted;
-    }
-  } else {
-    decision.trigger_type = static_cast<dfmessages::trigger_type_t>(m_TD_bitword.to_ulong()); // m_trigger_type;
-  }
+  decision.trigger_type = static_cast<dfmessages::trigger_type_t>(m_TD_bitword.to_ulong()); // m_trigger_type;
 
-  TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[MLT] HSI passthrough: " << m_hsi_passthrough
-                << ", TC detid: " << pending_td.contributing_tcs[m_earliest_tc_index].detid
+  TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[MLT] TC detid: " << pending_td.contributing_tcs[m_earliest_tc_index].detid
                 << ", TC type: " << static_cast<int>(pending_td.contributing_tcs[m_earliest_tc_index].type)
                 << ", TC cont number: " << pending_td.contributing_tcs.size()
                 << ", DECISION trigger type: " << decision.trigger_type

--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -123,7 +123,6 @@ private:
   // paused state, in which we don't send triggers
   std::atomic<bool> m_paused;
   std::atomic<bool> m_dfo_is_busy;
-  std::atomic<bool> m_hsi_passthrough;
   std::atomic<bool> m_tc_merging;
 
   dfmessages::trigger_number_t m_last_trigger_number;

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -75,7 +75,7 @@ TimingTriggerCandidateMaker::do_conf(const nlohmann::json& config)
   for (auto hsi_input : params.hsi_configs) {
     triggeralgs::TriggerCandidate::Type type;
     type = static_cast<triggeralgs::TriggerCandidate::Type>(
-        dunedaq::trgdataformats::string_to_fragment_type_value(hsi_input.tc_trigger_type));
+        dunedaq::trgdataformats::string_to_fragment_type_value(hsi_input.tc_type_name));
     if (type == triggeralgs::TriggerCandidate::Type::kUnknown) {
       throw ConfigurationProblem(ERS_HERE,
           "Unknown TriggerCandidate supplied to TTCM HSI map");
@@ -90,7 +90,7 @@ TimingTriggerCandidateMaker::do_conf(const nlohmann::json& config)
                                               hsi_input.time_before,
                                               hsi_input.time_after };
 
-    TLOG() << "TTCM will convert HSI signal id: " << hsi_input.signal << " to TC type: " << hsi_input.tc_trigger_type;
+    TLOG() << "TTCM will convert HSI signal id: " << hsi_input.signal << " to TC type: " << hsi_input.tc_type_name;
   }
 
   if (m_detid_offsets_map.empty()) {

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -72,7 +72,7 @@ TimingTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEve
     candidate.time_end   = data.timestamp + m_hsisignal_map[data.signal_map].time_after; // time_end,
     candidate.time_candidate = data.timestamp;
     // throw away bits 31-16 of header, that's OK for now
-    candidate.detid = { static_cast<triggeralgs::detid_t>(signal) }; // NOLINT(build/unsigned)
+    candidate.detid = data.header; // NOLINT(build/unsigned)
 
     candidate.type = m_hsisignal_map[signal].type; // type,
 
@@ -97,12 +97,12 @@ TimingTriggerCandidateMaker::do_conf(const nlohmann::json& config)
     type = static_cast<triggeralgs::TriggerCandidate::Type>(
         dunedaq::trgdataformats::string_to_fragment_type_value(hsi_input.tc_type_name));
     if (type == triggeralgs::TriggerCandidate::Type::kUnknown) {
-      throw TTCMConfigurationProblem(ERS_HERE,
+      throw TTCMConfigurationProblem(ERS_HERE, get_name(),
           "Unknown TriggerCandidate supplied to TTCM HSI map");
     }
 
     if (m_hsisignal_map.count(hsi_input.signal)) {
-      throw TTCMConfigurationProblem(ERS_HERE,
+      throw TTCMConfigurationProblem(ERS_HERE, get_name(),
           "Supplied more than one of the same hsi signal ID to TTCM HSI map");
     }
 
@@ -114,7 +114,7 @@ TimingTriggerCandidateMaker::do_conf(const nlohmann::json& config)
   }
 
   if (m_hsisignal_map.empty()) {
-      throw TTCMConfigurationProblem(ERS_HERE,
+      throw TTCMConfigurationProblem(ERS_HERE, get_name(),
           "Created TTCM, but supplied an empty signal map!");
   }
 

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -55,7 +55,13 @@ TimingTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEve
   candidate.time_candidate = data.timestamp;
   // throw away bits 31-16 of header, that's OK for now
   candidate.detid = { static_cast<triggeralgs::detid_t>(data.signal_map) }; // NOLINT(build/unsigned)
-  candidate.type = triggeralgs::TriggerCandidate::Type::kTiming;
+
+  if (data.signal_map == m_neutron_source_signal) {
+    candidate.type = triggeralgs::TriggerCandidate::Type::kNeutronSourceCalib;
+  }
+  else {
+    candidate.type = triggeralgs::TriggerCandidate::Type::kTiming;
+  }
 
   candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
   candidate.inputs = {};
@@ -71,9 +77,11 @@ TimingTriggerCandidateMaker::do_conf(const nlohmann::json& config)
   m_detid_offsets_map[params.s0.signal_type] = { params.s0.time_before, params.s0.time_after };
   m_detid_offsets_map[params.s1.signal_type] = { params.s1.time_before, params.s1.time_after };
   m_detid_offsets_map[params.s2.signal_type] = { params.s2.time_before, params.s2.time_after };
+  m_detid_offsets_map[params.s3.signal_type] = { params.s3.time_before, params.s3.time_after };
   m_hsi_passthrough = params.hsi_trigger_type_passthrough;
   m_hsi_pt_before = params.s0.time_before;
   m_hsi_pt_after = params.s0.time_after;
+  m_neutron_source_signal = params.s3.signal_type;
   m_prescale = params.prescale;
   m_prescale_flag = (m_prescale > 1) ? true : false;
   TLOG_DEBUG(2) << get_name() + " configured.";

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -97,12 +97,12 @@ TimingTriggerCandidateMaker::do_conf(const nlohmann::json& config)
     type = static_cast<triggeralgs::TriggerCandidate::Type>(
         dunedaq::trgdataformats::string_to_fragment_type_value(hsi_input.tc_type_name));
     if (type == triggeralgs::TriggerCandidate::Type::kUnknown) {
-      throw ConfigurationProblem(ERS_HERE,
+      throw TTCMConfigurationProblem(ERS_HERE,
           "Unknown TriggerCandidate supplied to TTCM HSI map");
     }
 
     if (m_hsisignal_map.count(hsi_input.signal)) {
-      throw ConfigurationProblem(ERS_HERE,
+      throw TTCMConfigurationProblem(ERS_HERE,
           "Supplied more than one of the same hsi signal ID to TTCM HSI map");
     }
 
@@ -114,7 +114,7 @@ TimingTriggerCandidateMaker::do_conf(const nlohmann::json& config)
   }
 
   if (m_hsisignal_map.empty()) {
-      throw ConfigurationProblem(ERS_HERE,
+      throw TTCMConfigurationProblem(ERS_HERE,
           "Created TTCM, but supplied an empty signal map!");
   }
 

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -70,25 +70,32 @@ TimingTriggerCandidateMaker::do_conf(const nlohmann::json& config)
 {
   auto params = config.get<dunedaq::trigger::timingtriggercandidatemaker::Conf>();
 
+  // Fill the internal hsi signal map. The map contains signal ID, TC type to
+  // create, and the readout time window.
   for (auto hsi_input : params.hsi_configs) {
     triggeralgs::TriggerCandidate::Type type;
     type = static_cast<triggeralgs::TriggerCandidate::Type>(
         dunedaq::trgdataformats::string_to_fragment_type_value(hsi_input.tc_trigger_type));
     if (type == triggeralgs::TriggerCandidate::Type::kUnknown) {
-      // TODO: throw here
+      throw ConfigurationProblem(ERS_HERE,
+          "Unknown TriggerCandidate supplied to TTCM HSI map");
     }
 
     if (m_detid_offsets_map.count(hsi_input.signal)) {
-      // TODO: throw here
+      throw ConfigurationProblem(ERS_HERE,
+          "Supplied more than one of the same hsi signal ID to TTCM HSI map");
     }
 
     m_detid_offsets_map[hsi_input.signal] = { type,
                                               hsi_input.time_before,
                                               hsi_input.time_after };
+
+    TLOG() << "TTCM will convert HSI signal id: " << hsi_input.signal << " to TC type: " << hsi_input.tc_trigger_type;
   }
 
   if (m_detid_offsets_map.empty()) {
-    // TODO: throw here
+      throw ConfigurationProblem(ERS_HERE,
+          "Created TTCM, but supplied an empty signal map!");
   }
 
   m_hsi_passthrough = params.hsi_trigger_type_passthrough;

--- a/plugins/TimingTriggerCandidateMaker.hpp
+++ b/plugins/TimingTriggerCandidateMaker.hpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace dunedaq {
 namespace trigger {
@@ -57,18 +58,16 @@ private:
   void do_stop(const nlohmann::json& obj);
   void do_scrap(const nlohmann::json& obj);
 
+  template<typename T>
+  std::vector<int> GetTriggeredBits(T signal_map);
+
   std::string m_hsievent_receive_connection;
 
   // Prescale functionality
   bool m_prescale_flag;
   int m_prescale;
 
-  // HSI Passthrough changes
-  std::atomic<bool> m_hsi_passthrough;
-  int m_hsi_pt_before;
-  int m_hsi_pt_after;
-
-  triggeralgs::TriggerCandidate HSIEventToTriggerCandidate(const dfmessages::HSIEvent& data);
+  std::vector<triggeralgs::TriggerCandidate> HSIEventToTriggerCandidate(const dfmessages::HSIEvent& data);
   void receive_hsievent(dfmessages::HSIEvent& data);
 
   using sink_t = dunedaq::iomanager::SenderConcept<triggeralgs::TriggerCandidate>;
@@ -78,7 +77,7 @@ private:
   std::chrono::milliseconds m_queue_timeout;
 
   // NOLINTNEXTLINE(build/unsigned)
-  std::map<uint32_t, HSISignal> m_detid_offsets_map;
+  std::map<uint32_t, HSISignal> m_hsisignal_map;
 
   // Opmon variables
   using metric_counter_type = decltype(timingtriggercandidatemakerinfo::Info::tsd_received_count);

--- a/plugins/TimingTriggerCandidateMaker.hpp
+++ b/plugins/TimingTriggerCandidateMaker.hpp
@@ -60,6 +60,9 @@ private:
   int m_hsi_pt_before;
   int m_hsi_pt_after;
 
+  // Neutron source signal
+  uint32_t m_neutron_source_signal;
+
   triggeralgs::TriggerCandidate HSIEventToTriggerCandidate(const dfmessages::HSIEvent& data);
   void receive_hsievent(dfmessages::HSIEvent& data);
 

--- a/plugins/TimingTriggerCandidateMaker.hpp
+++ b/plugins/TimingTriggerCandidateMaker.hpp
@@ -30,6 +30,14 @@
 
 namespace dunedaq {
 namespace trigger {
+
+struct HSISignal
+{
+  triggeralgs::TriggerCandidate::Type type;
+  triggeralgs::timestamp_t time_before;
+  triggeralgs::timestamp_t time_after;
+};
+
 class TimingTriggerCandidateMaker : public dunedaq::appfwk::DAQModule
 {
 public:
@@ -60,9 +68,6 @@ private:
   int m_hsi_pt_before;
   int m_hsi_pt_after;
 
-  // Neutron source signal
-  uint32_t m_neutron_source_signal;
-
   triggeralgs::TriggerCandidate HSIEventToTriggerCandidate(const dfmessages::HSIEvent& data);
   void receive_hsievent(dfmessages::HSIEvent& data);
 
@@ -73,7 +78,7 @@ private:
   std::chrono::milliseconds m_queue_timeout;
 
   // NOLINTNEXTLINE(build/unsigned)
-  std::map<uint32_t, std::pair<triggeralgs::timestamp_t, triggeralgs::timestamp_t>> m_detid_offsets_map;
+  std::map<uint32_t, HSISignal> m_detid_offsets_map;
 
   // Opmon variables
   using metric_counter_type = decltype(timingtriggercandidatemakerinfo::Info::tsd_received_count);

--- a/python/trigger/replay_tp_to_chain/__main__.py
+++ b/python/trigger/replay_tp_to_chain/__main__.py
@@ -139,7 +139,6 @@ def cli(slowdown_factor, input_file, trigger_activity_plugin, trigger_activity_c
         # TTCM_S2=ttcm_s2,
         # TRIGGER_WINDOW_BEFORE_TICKS = trigger_window_before_ticks,
         # TRIGGER_WINDOW_AFTER_TICKS = trigger_window_after_ticks,
-        # HSI_TRIGGER_TYPE_PASSTHROUGH = hsi_trigger_type_passthrough,
         USE_CHANNEL_FILTER = False,
         # CHANNEL_MAP_NAME = tpg_channel_map,
         # DATA_REQUEST_TIMEOUT=trigger_data_request_timeout,

--- a/schema/trigger/moduleleveltrigger.jsonnet
+++ b/schema/trigger/moduleleveltrigger.jsonnet
@@ -52,7 +52,6 @@ local types = {
   conf : s.record("ConfParams", [
       s.field("mandatory_links", self.linkvec, doc="List of link identifiers that will be included in trigger decision"),
       s.field("groups_links", self.grouplinks, doc="List of link identifiers that may be included in trigger decision"),
-      s.field("hsi_trigger_type_passthrough", self.flag, default=false, doc="Option to override the trigger type inside MLT"),
       s.field("merge_overlapping_tcs", self.flag, default=true, doc="Flag to allow(true)/disable(false) merging of overlapping TCs when forming TD"),
       s.field("td_out_of_timeout", self.flag, default=true, doc="Option to send TD if TC comes out of timeout window (late, overlapping already sent TD"),
       s.field("buffer_timeout", self.time_t, 100, doc="Buffering timeout [ms] for new TCs"),

--- a/schema/trigger/timingtriggercandidatemaker.jsonnet
+++ b/schema/trigger/timingtriggercandidatemaker.jsonnet
@@ -47,6 +47,14 @@ local types = {
 				time_after: 2000000
 			},
 			doc="Example 2"),
+		s.field("s3",
+			self.map_t,
+			{
+				signal_type: 3,
+				time_before: 10000,
+				time_after: 20000
+			},
+			doc="Neutron Source"),
 		s.field("hsi_trigger_type_passthrough", self.hsi_tt_pt, doc="Option to override the trigger type values"),
                 s.field("prescale", self.count_t, default=1, doc="Option to prescale TTCM TCs")
 	], doc="Configuration of the different readout time maps"),

--- a/schema/trigger/timingtriggercandidatemaker.jsonnet
+++ b/schema/trigger/timingtriggercandidatemaker.jsonnet
@@ -22,7 +22,6 @@ local types = {
 
   conf: s.record("Conf", [
     s.field("hsi_configs", self.hsi_inputs, [], doc="List of the input HSI configurations"),
-		s.field("hsi_trigger_type_passthrough", self.hsi_tt_pt, default=false, doc="Option to override the trigger type values"),
     s.field("prescale", self.count_t, default=1, doc="Option to prescale TTCM TCs")
 	], doc="Configuration of the different readout time maps"),
 

--- a/schema/trigger/timingtriggercandidatemaker.jsonnet
+++ b/schema/trigger/timingtriggercandidatemaker.jsonnet
@@ -13,7 +13,7 @@ local types = {
 
   hsi_input: s.record("hsi_input", [
     s.field("signal",   self.signal_type_t,   default=0),
-    s.field("tc_trigger_type", self.trigger_type_t,  default="kTiming"),
+    s.field("tc_type_name", self.trigger_type_t,  default="kTiming"),
     s.field("time_before",  self.time_t,          default=10000, doc="Readout time before time stamp"),
     s.field("time_after",   self.time_t,          default=20000, doc="Readout time after time stamp"),
     ]),

--- a/schema/trigger/timingtriggercandidatemaker.jsonnet
+++ b/schema/trigger/timingtriggercandidatemaker.jsonnet
@@ -3,60 +3,27 @@ local ns = "dunedaq.trigger.timingtriggercandidatemaker";
 local s = moo.oschema.schema(ns);
 local nc = moo.oschema.numeric_constraints;
 
+
 local types = {
-	time_t : s.number("time_t", "i8", doc="Time"),
-	signal_type_t : s.number("signal_type_t", "u4", doc="Signal type"),
+	time_t : s.number("time_t", "u8", doc="Time"),
+	signal_type_t : s.number("signal_type_t", "u8", doc="Signal type"),
+	trigger_type_t : s.string("trigger_type_t"),
 	hsi_tt_pt : s.boolean("hsi_tt_pt"),
-        count_t : s.number("count_t", "i8", nc(minimum=1), doc="Counter"),
-	map_t : s.record("map_t", [
-			s.field("signal_type",
-				self.signal_type_t,
-				0,
-				doc="Readout time before time stamp"),
-			s.field("time_before",
-				self.time_t,
-				10000,
-				doc="Readout time before time stamp"),
-			s.field("time_after",
-				self.time_t,
-				20000,
-				doc="Readout time after time stamp"),
-			], doc="Map from signal type to readout window"),
-	conf: s.record("Conf", [
-		s.field("s0",
-			self.map_t,
-			{
-				signal_type: 0,
-				time_before: 10000,
-				time_after: 20000
-			} ,
-			doc="Iceberg"),
-		s.field("s1",
-			self.map_t,
-			{
-				signal_type: 1,
-				time_before: 100000,
-				time_after: 200000
-			},
-			doc="Example 1"),
-		s.field("s2",
-			self.map_t,
-			{
-				signal_type: 2,
-				time_before: 1000000,
-				time_after: 2000000
-			},
-			doc="Example 2"),
-		s.field("s3",
-			self.map_t,
-			{
-				signal_type: 3,
-				time_before: 10000,
-				time_after: 20000
-			},
-			doc="Neutron Source"),
-		s.field("hsi_trigger_type_passthrough", self.hsi_tt_pt, doc="Option to override the trigger type values"),
-                s.field("prescale", self.count_t, default=1, doc="Option to prescale TTCM TCs")
+  count_t : s.number("count_t", "u8", nc(minimum=1), doc="Counter"),
+
+  hsi_input: s.record("hsi_input", [
+    s.field("signal",   self.signal_type_t,   default=0),
+    s.field("tc_trigger_type", self.trigger_type_t,  default="kTiming"),
+    s.field("time_before",  self.time_t,          default=10000, doc="Readout time before time stamp"),
+    s.field("time_after",   self.time_t,          default=20000, doc="Readout time after time stamp"),
+    ]),
+
+  hsi_inputs: s.sequence("hsi_inputs", self.hsi_input),
+
+  conf: s.record("Conf", [
+    s.field("hsi_configs", self.hsi_inputs, [], doc="List of the input HSI configurations"),
+		s.field("hsi_trigger_type_passthrough", self.hsi_tt_pt, default=false, doc="Option to override the trigger type values"),
+    s.field("prescale", self.count_t, default=1, doc="Option to prescale TTCM TCs")
 	], doc="Configuration of the different readout time maps"),
 
 };


### PR DESCRIPTION
Changes to allow for pulsed neutron source calibration input and conversion to it's individual TriggerCandidate type. New TriggerCandidate type named `kNeutronSourceCalib = 10`.

Dependent on PRs in
- daqconf:  https://github.com/DUNE-DAQ/daqconf/pull/437
- trgdataformats: https://github.com/DUNE-DAQ/trgdataformats/pull/13

Ended up with a small overhaul of `TimingTriggerCandidateMaker` configuration, so it can accept any number of HSIEvent signal types. Moreso, these signal types can now be mapped to different TriggerCandidate Types at config time (by providing their string names), by supplying signal map in `daqconf.json` , e.g.:
```
"trigger":
   "ttcm_input_map": [
       {
          "signal": 0,
          "tc_type_name": "kTiming",
          "time_before": 1000,
          "time_before": 2000
       },
       {
          "signal": 1,
          "tc_type_name": "kTiming",
          "time_before": 1000,
          "time_before": 2000
       },
       {
          "signal": 3,
          "tc_type_name": "kNeutronSourceCalib",
          "time_before": 1000,
          "time_before": 2000
       }
```

By default config will create signals `[0, 1, 2, 3]`, all with `kTiming` as TC-type.

Tests ran:
1. Everything from https://github.com/DUNE-DAQ/integrationtest/tree/develop/python/integrationtest
2. Default config generation, checking if signal map for `[0, 1, 2, 3]` exists and tuned to `kTiming` in the config, ran offline with fake hsi on, and seen `kTiming` TCs in the output hdf5.
3. Ran offline with custom configuration to tune one of the signals to the new `kNeutronSourceCalib` TriggerCandidate type.  Seen output like:
   ``` 
        Trigger_Candidate fragment with SourceID Trigger_0x00000003 from subdetector DAQ has size = 128
                Readout window before = 2000, after = 2000
                TC type =  (10), TC algorithm = 2, number of TAs = 0
                Start time = 79554165758489587, end time = 79554165758493587, and candidate time = 79554165758491587
   ``` 
   where TC type 10 corresponds to the new `kNeutronSourceCalib`.