### PR TITLE
CTB: Trigger integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ daq_codegen(
   randomtriggercandidatemaker.jsonnet
   customtriggercandidatemaker.jsonnet
   timingtriggercandidatemaker.jsonnet
+  ctbtriggercandidatemaker.jsonnet
   triggerprimitivemaker.jsonnet
   triggeractivitymaker.jsonnet
   triggercandidatemaker.jsonnet
@@ -69,6 +70,7 @@ daq_codegen( *info.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp.
 # Plugins
 
 daq_add_plugin(TimingTriggerCandidateMaker duneDAQModule SCHEMA LINK_LIBRARIES trigger)
+daq_add_plugin(CTBTriggerCandidateMaker duneDAQModule SCHEMA LINK_LIBRARIES trigger)
 daq_add_plugin(TriggerPrimitiveMaker duneDAQModule LINK_LIBRARIES trigger)
 daq_add_plugin(TriggerActivityMaker duneDAQModule LINK_LIBRARIES trigger)
 daq_add_plugin(TriggerCandidateMaker duneDAQModule LINK_LIBRARIES trigger)

--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -184,6 +184,16 @@ ERS_DECLARE_ISSUE_BASE(trigger,
                        ((size_t)received)((size_t)expected)((size_t)ts)((size_t)seq))
 
 ERS_DECLARE_ISSUE_BASE(trigger,
+                       InvalidCTBSignal,
+                       appfwk::GeneralDAQModuleIssue,
+                       "An invalid CTB signal was received, signal: " << signal << ", bits: " << bits
+		         << ", configured CTB bits: " << map_size,
+                       ((std::string)name),
+                       ((uint32_t)signal)
+		       ((std::bitset<32>)bits)
+		       ((size_t)map_size))
+
+ERS_DECLARE_ISSUE_BASE(trigger,
                        MissingFactoryItemError,
                        appfwk::GeneralDAQModuleIssue,
                        "Factory could not find requested item " << item << ".",

--- a/plugins/CTBTriggerCandidateMaker.cpp
+++ b/plugins/CTBTriggerCandidateMaker.cpp
@@ -1,0 +1,200 @@
+/**
+ * @file CTBTriggerCandidateMaker.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "CTBTriggerCandidateMaker.hpp"
+
+#include "appfwk/DAQModuleHelper.hpp"
+#include "trgdataformats/Types.hpp"
+#include "trigger/TriggerCandidate_serialization.hpp"
+#include "iomanager/IOManager.hpp"
+#include "rcif/cmd/Nljs.hpp"
+
+#include <regex>
+#include <string>
+
+namespace dunedaq {
+namespace trigger {
+
+CTBTriggerCandidateMaker::CTBTriggerCandidateMaker(const std::string& name)
+  : DAQModule(name)
+  , m_output_queue(nullptr)
+  , m_queue_timeout(100)
+{
+
+  register_command("conf", &CTBTriggerCandidateMaker::do_conf);
+  register_command("start", &CTBTriggerCandidateMaker::do_start);
+  register_command("stop", &CTBTriggerCandidateMaker::do_stop);
+  register_command("scrap", &CTBTriggerCandidateMaker::do_scrap);
+}
+
+triggeralgs::TriggerCandidate
+CTBTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEvent& data)
+{
+  triggeralgs::TriggerCandidate candidate;
+  if (m_hsi_passthrough == true) {
+    TLOG_DEBUG(3) << "HSI passthrough applied, modified readout window is set";
+    candidate.time_start = data.timestamp - m_hsi_pt_before;
+    candidate.time_end = data.timestamp + m_hsi_pt_after;
+  } else {
+    if (m_detid_offsets_map.count(data.signal_map)) {
+      // clang-format off
+      candidate.time_start = data.timestamp - m_detid_offsets_map[data.signal_map].first;  // time_start
+      candidate.time_end   = data.timestamp + m_detid_offsets_map[data.signal_map].second; // time_end,
+      // clang-format on    
+    } else {
+      throw dunedaq::trigger::SignalTypeError(ERS_HERE, get_name(), data.signal_map);
+    }
+  }
+  candidate.time_candidate = data.timestamp;
+  // throw away bits 31-16 of header, that's OK for now
+  candidate.detid = { static_cast<triggeralgs::detid_t>(data.signal_map) }; // NOLINT(build/unsigned)
+  candidate.type = triggeralgs::TriggerCandidate::Type::kCTB;
+
+  candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
+  candidate.inputs = {};
+
+  return candidate;
+}
+
+
+void
+CTBTriggerCandidateMaker::do_conf(const nlohmann::json& config)
+{
+  auto params = config.get<dunedaq::trigger::ctbtriggercandidatemaker::Conf>();
+  m_detid_offsets_map[params.s0.signal_type] = { params.s0.time_before, params.s0.time_after };
+  m_detid_offsets_map[params.s1.signal_type] = { params.s1.time_before, params.s1.time_after };
+  m_detid_offsets_map[params.s2.signal_type] = { params.s2.time_before, params.s2.time_after };
+  m_hsi_passthrough = params.hsi_trigger_type_passthrough;
+  m_hsi_pt_before = params.s0.time_before;
+  m_hsi_pt_after = params.s0.time_after;
+  m_prescale = params.prescale;
+  m_prescale_flag = (m_prescale > 1) ? true : false;
+  TLOG_DEBUG(2) << get_name() + " configured.";
+  if (m_prescale_flag){
+    TLOG(2) << "Running with prescale at: " << m_prescale;
+  }
+}
+
+void
+CTBTriggerCandidateMaker::init(const nlohmann::json& iniobj)
+{
+  try {
+    auto ci = appfwk::connection_index(iniobj, {"output", "hsi_input"});	   
+    m_output_queue = get_iom_sender<triggeralgs::TriggerCandidate>(ci["output"]);
+    m_hsievent_input = get_iom_receiver<dfmessages::HSIEvent>(ci["hsi_input"]);
+  } catch (const ers::Issue& excpt) {
+    throw dunedaq::trigger::InvalidQueueFatalError(ERS_HERE, get_name(), "input/output", excpt);
+  }
+}
+
+void
+CTBTriggerCandidateMaker::do_start(const nlohmann::json& startobj)
+{
+  // OpMon.
+  m_tsd_received_count.store(0);
+  m_tc_sent_count.store(0);
+  m_tc_sig_type_err_count.store(0);
+  m_tc_total_count.store(0);
+
+  auto start_params = startobj.get<rcif::cmd::StartParams>();
+  m_run_number.store(start_params.run);
+
+  m_hsievent_input->add_callback(std::bind(&CTBTriggerCandidateMaker::receive_hsievent, this, std::placeholders::_1));
+  
+  TLOG_DEBUG(2) << get_name() + " successfully started.";
+}
+
+void
+CTBTriggerCandidateMaker::do_stop(const nlohmann::json&)
+{
+  m_hsievent_input->remove_callback();
+
+  TLOG() << "Received " << m_tsd_received_count << " HSIEvent messages. Successfully sent " << m_tc_sent_count
+         << " TriggerCandidates";
+  TLOG_DEBUG(2) << get_name() + " successfully stopped.";
+}
+
+void
+CTBTriggerCandidateMaker::receive_hsievent(dfmessages::HSIEvent& data)
+{
+  TLOG_DEBUG(3) << "Activity received with timestamp " << data.timestamp << ", sequence_counter " << data.sequence_counter
+                << ", and run_number " << data.run_number;
+
+  if (data.run_number != m_run_number) {
+    ers::error(dunedaq::trigger::InvalidHSIEventRunNumber(ERS_HERE, get_name(), data.run_number, m_run_number,
+                                                          data.timestamp, data.sequence_counter));
+    return;
+  }
+
+  ++m_tsd_received_count;
+
+  if (m_prescale_flag) {
+    if (m_tsd_received_count % m_prescale != 0){
+      return;
+    } 
+  }
+
+  if (m_hsi_passthrough == true){
+    TLOG_DEBUG(3) << "Signal_map: " << data.signal_map << ", trigger bits: " << (std::bitset<16>)data.signal_map;
+    try {
+      if ((data.signal_map & 0xffffff00) != 0){
+        throw dunedaq::trigger::BadTriggerBitmask(ERS_HERE, get_name(), (std::bitset<16>)data.signal_map);
+      }
+    } catch (BadTriggerBitmask& e) {
+      ers::error(e);
+      return;
+    }
+  }
+
+  triggeralgs::TriggerCandidate candidate;
+  try {
+    candidate = HSIEventToTriggerCandidate(data);
+  } catch (SignalTypeError& e) {
+    m_tc_sig_type_err_count++;
+    ers::error(e);
+    return;
+  }
+
+  bool successfullyWasSent = false;
+  while (!successfullyWasSent) {
+    try {
+        triggeralgs::TriggerCandidate candidate_copy(candidate);
+      m_output_queue->send(std::move(candidate_copy), m_queue_timeout);
+      successfullyWasSent = true;
+      ++m_tc_sent_count;
+    } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
+      std::ostringstream oss_warn;
+      oss_warn << "push to output queue \"" << m_output_queue->get_name() << "\"";
+      ers::warning(
+        dunedaq::iomanager::TimeoutExpired(ERS_HERE, get_name(), oss_warn.str(), m_queue_timeout.count()));
+    }
+  }
+  m_tc_total_count++;
+}
+
+void
+CTBTriggerCandidateMaker::do_scrap(const nlohmann::json&)
+{}
+
+void
+CTBTriggerCandidateMaker::get_info(opmonlib::InfoCollector& ci, int /*level*/)
+{
+  ctbtriggercandidatemakerinfo::Info i;
+
+  i.tsd_received_count = m_tsd_received_count.load();
+  i.tc_sent_count = m_tc_sent_count.load();
+  i.tc_sig_type_err_count = m_tc_sig_type_err_count.load();
+  i.tc_total_count = m_tc_total_count.load();
+
+  ci.add(i);
+}
+
+} // namespace trigger
+} // namespace dunedaq
+
+DEFINE_DUNE_DAQ_MODULE(dunedaq::trigger::CTBTriggerCandidateMaker)

--- a/plugins/CTBTriggerCandidateMaker.cpp
+++ b/plugins/CTBTriggerCandidateMaker.cpp
@@ -37,14 +37,15 @@ CTBTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEvent&
 {
   TLOG_DEBUG(3) << "[CTB] Converting HSI event, signal: " << data.signal_map;
   TLOG_DEBUG(3) << "[CTB] header: " << data.header;
+  TLOG_DEBUG(3) << "[CTB] TC type: " << static_cast<int>(m_HLT_TC_map[data.signal_map]);
 
   triggeralgs::TriggerCandidate candidate;
   candidate.time_candidate = data.timestamp;
-  candidate.time_start = data.timestamp;
-  candidate.time_end = data.timestamp;
+  candidate.time_start = data.timestamp - m_time_before;
+  candidate.time_end = data.timestamp + m_time_after;
   //candidate.detid = 1;
   candidate.detid = data.header;
-  candidate.type = triggeralgs::TriggerCandidate::Type::kCTBFakeTrigger;
+  candidate.type = m_HLT_TC_map[data.signal_map];
   candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kCTBToTriggerCandidate;
   candidate.inputs = {};
 
@@ -56,11 +57,15 @@ void
 CTBTriggerCandidateMaker::do_conf(const nlohmann::json& config)
 {
   auto params = config.get<dunedaq::trigger::ctbtriggercandidatemaker::Conf>();
+  m_time_before = params.time_before; 
+  m_time_after = params.time_after;
   m_prescale = params.prescale;
   m_prescale_flag = (m_prescale > 1) ? true : false;
   TLOG_DEBUG(2) << get_name() + " configured.";
+  TLOG(2) << "[CTB] Time before: " << m_time_before;
+  TLOG(2) << "[CTB] Time after: " << m_time_after;
   if (m_prescale_flag){
-    TLOG(2) << "Running with prescale at: " << m_prescale;
+    TLOG(2) << "[CTB] Running with prescale at: " << m_prescale;
   }
 }
 

--- a/plugins/CTBTriggerCandidateMaker.cpp
+++ b/plugins/CTBTriggerCandidateMaker.cpp
@@ -46,19 +46,24 @@ CTBTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEvent&
     if (bits.test(i)) {
   
       TLOG() << "this bit: " << i;
-      TLOG_DEBUG(3) << "[CTB] TC type: " << static_cast<int>(m_HLT_TC_map[i]);
-    
-      triggeralgs::TriggerCandidate candidate;
-      candidate.time_candidate = data.timestamp;
-      candidate.time_start = data.timestamp - m_time_before;
-      candidate.time_end = data.timestamp + m_time_after;
-      //candidate.detid = 1;
-      candidate.detid = data.header;
-      candidate.type = m_HLT_TC_map[i];
-      candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
-      candidate.inputs = {};
 
-      candidates.push_back(candidate);
+      if (m_HLT_TC_map.count(i)) {
+        TLOG_DEBUG(3) << "[CTB] TC type: " << static_cast<int>(m_HLT_TC_map[i]);
+    
+        triggeralgs::TriggerCandidate candidate;
+        candidate.time_candidate = data.timestamp;
+        candidate.time_start = data.timestamp - m_time_before;
+        candidate.time_end = data.timestamp + m_time_after;
+        //candidate.detid = 1;
+        candidate.detid = data.header;
+        candidate.type = m_HLT_TC_map[i];
+        candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
+        candidate.inputs = {};
+
+        candidates.push_back(candidate);
+      } else {
+        ers::error(dunedaq::trigger::InvalidCTBSignal(ERS_HERE, get_name(), data.signal_map, bits, m_HLT_TC_map.size()));
+      }
     }
   }
 

--- a/plugins/CTBTriggerCandidateMaker.cpp
+++ b/plugins/CTBTriggerCandidateMaker.cpp
@@ -47,12 +47,12 @@ CTBTriggerCandidateMaker::HSIEventToTriggerCandidate(const dfmessages::HSIEvent&
 
   std::vector<triggeralgs::TriggerCandidate> candidates;
   std::bitset<32> bits(data.signal_map);
-  TLOG_DEBUG(TLVL_DEBUG_HIGH) << "BITS: " << bits;
+  TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[CTB] BITS: " << bits;
 
   for (size_t i = 0; i < bits.size(); ++i) {
     if (bits.test(i)) {
   
-      TLOG_DEBUG(TLVL_DEBUG_ALL) << "this bit: " << i;
+      TLOG_DEBUG(TLVL_DEBUG_ALL) << "[CTB] this bit: " << i;
 
       if (m_HLT_TC_map.count(i)) {
         TLOG_DEBUG(TLVL_DEBUG_ALL) << "[CTB] TC type: " << static_cast<int>(m_HLT_TC_map[i]);
@@ -86,7 +86,7 @@ CTBTriggerCandidateMaker::do_conf(const nlohmann::json& config)
   m_time_after = params.time_after;
   m_prescale = params.prescale;
   m_prescale_flag = (m_prescale > 1) ? true : false;
-  TLOG_DEBUG(TLVL_GENERAL) << get_name() + " configured.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[CTB] " << get_name() + " configured.";
   TLOG_DEBUG(TLVL_VERY_IMPORTANT) << "[CTB] Time before: " << m_time_before;
   TLOG_DEBUG(TLVL_VERY_IMPORTANT) << "[CTB] Time after: " << m_time_after;
   if (m_prescale_flag){
@@ -120,7 +120,7 @@ CTBTriggerCandidateMaker::do_start(const nlohmann::json& startobj)
 
   m_hsievent_input->add_callback(std::bind(&CTBTriggerCandidateMaker::receive_hsievent, this, std::placeholders::_1));
   
-  TLOG_DEBUG(TLVL_GENERAL) << get_name() + " successfully started.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[CTB] " << get_name() + " successfully started.";
 }
 
 void
@@ -128,15 +128,15 @@ CTBTriggerCandidateMaker::do_stop(const nlohmann::json&)
 {
   m_hsievent_input->remove_callback();
 
-  TLOG() << "Received " << m_tsd_received_count << " HSIEvent messages. Successfully sent " << m_tc_sent_count
+  TLOG() << "[CTB] Received " << m_tsd_received_count << " HSIEvent messages. Successfully sent " << m_tc_sent_count
          << " TriggerCandidates";
-  TLOG_DEBUG(TLVL_GENERAL) << get_name() + " successfully stopped.";
+  TLOG_DEBUG(TLVL_GENERAL) << "[CTB] " << get_name() + " successfully stopped.";
 }
 
 void
 CTBTriggerCandidateMaker::receive_hsievent(dfmessages::HSIEvent& data)
 {
-  TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "Activity received with timestamp " << data.timestamp << ", sequence_counter " << data.sequence_counter
+  TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[CTB] Activity received with timestamp " << data.timestamp << ", sequence_counter " << data.sequence_counter
                 << ", and run_number " << data.run_number;
 
   if (data.run_number != m_run_number) {

--- a/plugins/CTBTriggerCandidateMaker.hpp
+++ b/plugins/CTBTriggerCandidateMaker.hpp
@@ -55,11 +55,6 @@ private:
   bool m_prescale_flag;
   int m_prescale;
 
-  // HSI Passthrough changes
-  std::atomic<bool> m_hsi_passthrough;
-  int m_hsi_pt_before;
-  int m_hsi_pt_after;
-
   triggeralgs::TriggerCandidate HSIEventToTriggerCandidate(const dfmessages::HSIEvent& data);
   void receive_hsievent(dfmessages::HSIEvent& data);
 
@@ -69,8 +64,20 @@ private:
 
   std::chrono::milliseconds m_queue_timeout;
 
-  // NOLINTNEXTLINE(build/unsigned)
-  std::map<uint32_t, std::pair<triggeralgs::timestamp_t, triggeralgs::timestamp_t>> m_detid_offsets_map;
+  // HLT to TC type map
+  std::map<int, trgdataformats::TriggerCandidateData::Type> m_HLT_TC_map =
+  {
+    {0, trgdataformats::TriggerCandidateData::Type::kCTBFakeTrigger},
+    {1, trgdataformats::TriggerCandidateData::Type::kCTBBeam},
+    {2, trgdataformats::TriggerCandidateData::Type::kCTBBeamHiLoPressChkv},
+    {3, trgdataformats::TriggerCandidateData::Type::kCTBBeamLoPressChkv},
+    {4, trgdataformats::TriggerCandidateData::Type::kCTBBeamHiPressChkv},
+    {5, trgdataformats::TriggerCandidateData::Type::kCTBOffSpillCosmic},
+    {6, trgdataformats::TriggerCandidateData::Type::kCTBCosmic},
+    {7, trgdataformats::TriggerCandidateData::Type::kCTBBeamNoChkv},
+    {8, trgdataformats::TriggerCandidateData::Type::kCTBCosmicJura},
+    {9, trgdataformats::TriggerCandidateData::Type::kCTBCosmicSaleve},
+  }; 
 
   // Opmon variables
   using metric_counter_type = decltype(ctbtriggercandidatemakerinfo::Info::tsd_received_count);

--- a/plugins/CTBTriggerCandidateMaker.hpp
+++ b/plugins/CTBTriggerCandidateMaker.hpp
@@ -55,6 +55,10 @@ private:
   bool m_prescale_flag;
   int m_prescale;
 
+  // Config
+  int m_time_before;
+  int m_time_after;
+
   triggeralgs::TriggerCandidate HSIEventToTriggerCandidate(const dfmessages::HSIEvent& data);
   void receive_hsievent(dfmessages::HSIEvent& data);
 

--- a/plugins/CTBTriggerCandidateMaker.hpp
+++ b/plugins/CTBTriggerCandidateMaker.hpp
@@ -1,0 +1,87 @@
+/**
+ * @file CTBTriggerCandidateMaker.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGER_PLUGINS_CTBTRIGGERCANDIDATEMAKER_HPP_
+#define TRIGGER_PLUGINS_CTBTRIGGERCANDIDATEMAKER_HPP_
+
+#include "trigger/Issues.hpp"
+#include "trigger/ctbtriggercandidatemaker/Nljs.hpp"
+#include "trigger/ctbtriggercandidatemakerinfo/InfoNljs.hpp"
+
+#include "appfwk/DAQModule.hpp"
+#include "daqdataformats/Types.hpp"
+#include "dfmessages/HSIEvent.hpp"
+#include "iomanager/Receiver.hpp"
+#include "iomanager/Sender.hpp"
+#include "triggeralgs/TriggerActivity.hpp"
+#include "triggeralgs/TriggerCandidate.hpp"
+#include "utilities/WorkerThread.hpp"
+
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace dunedaq {
+namespace trigger {
+class CTBTriggerCandidateMaker : public dunedaq::appfwk::DAQModule
+{
+public:
+  explicit CTBTriggerCandidateMaker(const std::string& name);
+
+  CTBTriggerCandidateMaker(const CTBTriggerCandidateMaker&) = delete;
+  CTBTriggerCandidateMaker& operator=(const CTBTriggerCandidateMaker&) = delete;
+  CTBTriggerCandidateMaker(CTBTriggerCandidateMaker&&) = delete;
+  CTBTriggerCandidateMaker& operator=(CTBTriggerCandidateMaker&&) = delete;
+
+  void init(const nlohmann::json& iniobj) override;
+  void get_info(opmonlib::InfoCollector& ci, int level) override;
+
+private:
+  void do_conf(const nlohmann::json& config);
+  void do_start(const nlohmann::json& obj);
+  void do_stop(const nlohmann::json& obj);
+  void do_scrap(const nlohmann::json& obj);
+
+  std::string m_hsievent_receive_connection;
+
+  // Prescale functionality
+  bool m_prescale_flag;
+  int m_prescale;
+
+  // HSI Passthrough changes
+  std::atomic<bool> m_hsi_passthrough;
+  int m_hsi_pt_before;
+  int m_hsi_pt_after;
+
+  triggeralgs::TriggerCandidate HSIEventToTriggerCandidate(const dfmessages::HSIEvent& data);
+  void receive_hsievent(dfmessages::HSIEvent& data);
+
+  using sink_t = dunedaq::iomanager::SenderConcept<triggeralgs::TriggerCandidate>;
+  std::shared_ptr<sink_t> m_output_queue;
+  std::shared_ptr<iomanager::ReceiverConcept<dfmessages::HSIEvent>> m_hsievent_input;
+
+  std::chrono::milliseconds m_queue_timeout;
+
+  // NOLINTNEXTLINE(build/unsigned)
+  std::map<uint32_t, std::pair<triggeralgs::timestamp_t, triggeralgs::timestamp_t>> m_detid_offsets_map;
+
+  // Opmon variables
+  using metric_counter_type = decltype(ctbtriggercandidatemakerinfo::Info::tsd_received_count);
+  std::atomic<metric_counter_type> m_tsd_received_count{ 0 };
+  std::atomic<metric_counter_type> m_tc_sent_count{ 0 };
+  std::atomic<metric_counter_type> m_tc_sig_type_err_count{ 0 };
+  std::atomic<metric_counter_type> m_tc_total_count{ 0 };
+
+  std::atomic<daqdataformats::run_number_t> m_run_number;
+};
+} // namespace trigger
+} // namespace dunedaq
+
+#endif // TRIGGER_PLUGINS_CTBTRIGGERCANDIDATEMAKER_HPP_

--- a/plugins/CTBTriggerCandidateMaker.hpp
+++ b/plugins/CTBTriggerCandidateMaker.hpp
@@ -59,7 +59,7 @@ private:
   int m_time_before;
   int m_time_after;
 
-  triggeralgs::TriggerCandidate HSIEventToTriggerCandidate(const dfmessages::HSIEvent& data);
+  std::vector<triggeralgs::TriggerCandidate> HSIEventToTriggerCandidate(const dfmessages::HSIEvent& data);
   void receive_hsievent(dfmessages::HSIEvent& data);
 
   using sink_t = dunedaq::iomanager::SenderConcept<triggeralgs::TriggerCandidate>;

--- a/plugins/CTBTriggerCandidateMaker.hpp
+++ b/plugins/CTBTriggerCandidateMaker.hpp
@@ -69,19 +69,18 @@ private:
   std::chrono::milliseconds m_queue_timeout;
 
   // HLT to TC type map
-  std::map<int, trgdataformats::TriggerCandidateData::Type> m_HLT_TC_map =
-  {
-    {0, trgdataformats::TriggerCandidateData::Type::kCTBFakeTrigger},
-    {1, trgdataformats::TriggerCandidateData::Type::kCTBBeam},
-    {2, trgdataformats::TriggerCandidateData::Type::kCTBBeamHiLoPressChkv},
-    {3, trgdataformats::TriggerCandidateData::Type::kCTBBeamLoPressChkv},
-    {4, trgdataformats::TriggerCandidateData::Type::kCTBBeamHiPressChkv},
-    {5, trgdataformats::TriggerCandidateData::Type::kCTBOffSpillCosmic},
-    {6, trgdataformats::TriggerCandidateData::Type::kCTBCosmic},
-    {7, trgdataformats::TriggerCandidateData::Type::kCTBBeamNoChkv},
-    {8, trgdataformats::TriggerCandidateData::Type::kCTBCosmicJura},
-    {9, trgdataformats::TriggerCandidateData::Type::kCTBCosmicSaleve},
-  }; 
+  std::map<int, trgdataformats::TriggerCandidateData::Type> m_HLT_TC_map = {
+    { 0, trgdataformats::TriggerCandidateData::Type::kCTBFakeTrigger },
+    { 1, trgdataformats::TriggerCandidateData::Type::kCTBBeam },
+    { 2, trgdataformats::TriggerCandidateData::Type::kCTBBeamHiLoPressChkv },
+    { 3, trgdataformats::TriggerCandidateData::Type::kCTBBeamLoPressChkv },
+    { 4, trgdataformats::TriggerCandidateData::Type::kCTBBeamHiPressChkv },
+    { 5, trgdataformats::TriggerCandidateData::Type::kCTBOffSpillCosmic },
+    { 6, trgdataformats::TriggerCandidateData::Type::kCTBCosmic },
+    { 7, trgdataformats::TriggerCandidateData::Type::kCTBBeamNoChkv },
+    { 8, trgdataformats::TriggerCandidateData::Type::kCTBCosmicJura },
+    { 9, trgdataformats::TriggerCandidateData::Type::kCTBCosmicSaleve },
+  };
 
   // Opmon variables
   using metric_counter_type = decltype(ctbtriggercandidatemakerinfo::Info::tsd_received_count);

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -717,7 +717,7 @@ ModuleLevelTrigger::check_trigger_type_ignore(int tc_type)
   return ignore;
 }
 
-std::bitset<16>
+std::bitset<64>
 ModuleLevelTrigger::get_TD_bitword(const PendingTD& ready_td)
 {
   // get only unique types
@@ -728,7 +728,7 @@ ModuleLevelTrigger::get_TD_bitword(const PendingTD& ready_td)
   tc_types.erase(std::unique(tc_types.begin(), tc_types.end()), tc_types.end());
 
   // form TD bitword
-  std::bitset<16> td_bitword = 0b0000000000000000;
+  std::bitset<64> td_bitword;
   for (auto tc_type : tc_types) {
     td_bitword.set(tc_type);
   }
@@ -736,7 +736,7 @@ ModuleLevelTrigger::get_TD_bitword(const PendingTD& ready_td)
 }
 
 void
-ModuleLevelTrigger::print_trigger_bitwords(std::vector<std::bitset<16>> trigger_bitwords)
+ModuleLevelTrigger::print_trigger_bitwords(std::vector<std::bitset<64>> trigger_bitwords)
 {
   TLOG_DEBUG(3) << "Configured trigger words:";
   for (auto bitword : trigger_bitwords) {
@@ -774,7 +774,7 @@ void
 ModuleLevelTrigger::set_trigger_bitwords()
 {
   for (auto flag : m_trigger_bitwords_json) {
-    std::bitset<16> temp_bitword = 0b0000000000000000;
+    std::bitset<64> temp_bitword;
     for (auto bit : flag) {
       temp_bitword.set(bit);
     }

--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -174,10 +174,10 @@ private:
   bool m_use_bitwords;
   nlohmann::json m_trigger_bitwords_json;
   bool m_bitword_check;
-  std::bitset<16> m_TD_bitword;
-  std::vector<std::bitset<16>> m_trigger_bitwords;
-  std::bitset<16> get_TD_bitword(const PendingTD& ready_td);
-  void print_trigger_bitwords(std::vector<std::bitset<16>> trigger_bitwords);
+  std::bitset<64> m_TD_bitword;
+  std::vector<std::bitset<64>> m_trigger_bitwords;
+  std::bitset<64> get_TD_bitword(const PendingTD& ready_td);
+  void print_trigger_bitwords(std::vector<std::bitset<64>> trigger_bitwords);
   bool check_trigger_bitwords();
   void print_bitword_flags(nlohmann::json m_trigger_bitwords_json);
   void set_trigger_bitwords();

--- a/schema/trigger/ctbtriggercandidatemaker.jsonnet
+++ b/schema/trigger/ctbtriggercandidatemaker.jsonnet
@@ -1,0 +1,56 @@
+local moo = import "moo.jsonnet";
+local ns = "dunedaq.trigger.ctbtriggercandidatemaker";
+local s = moo.oschema.schema(ns);
+local nc = moo.oschema.numeric_constraints;
+
+local types = {
+	time_t : s.number("time_t", "i8", doc="Time"),
+	signal_type_t : s.number("signal_type_t", "u4", doc="Signal type"),
+	hsi_tt_pt : s.boolean("hsi_tt_pt"),
+        count_t : s.number("count_t", "i8", nc(minimum=1), doc="Counter"),
+	map_t : s.record("map_t", [
+			s.field("signal_type",
+				self.signal_type_t,
+				0,
+				doc="Readout time before time stamp"),
+			s.field("time_before",
+				self.time_t,
+				10000,
+				doc="Readout time before time stamp"),
+			s.field("time_after",
+				self.time_t,
+				20000,
+				doc="Readout time after time stamp"),
+			], doc="Map from signal type to readout window"),
+	conf: s.record("Conf", [
+		s.field("s0",
+			self.map_t,
+			{
+				signal_type: 0,
+				time_before: 10000,
+				time_after: 20000
+			} ,
+			doc="Iceberg"),
+		s.field("s1",
+			self.map_t,
+			{
+				signal_type: 1,
+				time_before: 100000,
+				time_after: 200000
+			},
+			doc="Example 1"),
+		s.field("s2",
+			self.map_t,
+			{
+				signal_type: 2,
+				time_before: 1000000,
+				time_after: 2000000
+			},
+			doc="Example 2"),
+		s.field("hsi_trigger_type_passthrough", self.hsi_tt_pt, doc="Option to override the trigger type values"),
+                s.field("prescale", self.count_t, default=1, doc="Option to prescale TTCM TCs")
+	], doc="Configuration of the different readout time maps"),
+
+};
+
+moo.oschema.sort_select(types, ns)

--- a/schema/trigger/ctbtriggercandidatemaker.jsonnet
+++ b/schema/trigger/ctbtriggercandidatemaker.jsonnet
@@ -4,49 +4,9 @@ local s = moo.oschema.schema(ns);
 local nc = moo.oschema.numeric_constraints;
 
 local types = {
-	time_t : s.number("time_t", "i8", doc="Time"),
-	signal_type_t : s.number("signal_type_t", "u4", doc="Signal type"),
 	hsi_tt_pt : s.boolean("hsi_tt_pt"),
         count_t : s.number("count_t", "i8", nc(minimum=1), doc="Counter"),
-	map_t : s.record("map_t", [
-			s.field("signal_type",
-				self.signal_type_t,
-				0,
-				doc="Readout time before time stamp"),
-			s.field("time_before",
-				self.time_t,
-				10000,
-				doc="Readout time before time stamp"),
-			s.field("time_after",
-				self.time_t,
-				20000,
-				doc="Readout time after time stamp"),
-			], doc="Map from signal type to readout window"),
 	conf: s.record("Conf", [
-		s.field("s0",
-			self.map_t,
-			{
-				signal_type: 0,
-				time_before: 10000,
-				time_after: 20000
-			} ,
-			doc="Iceberg"),
-		s.field("s1",
-			self.map_t,
-			{
-				signal_type: 1,
-				time_before: 100000,
-				time_after: 200000
-			},
-			doc="Example 1"),
-		s.field("s2",
-			self.map_t,
-			{
-				signal_type: 2,
-				time_before: 1000000,
-				time_after: 2000000
-			},
-			doc="Example 2"),
 		s.field("hsi_trigger_type_passthrough", self.hsi_tt_pt, doc="Option to override the trigger type values"),
                 s.field("prescale", self.count_t, default=1, doc="Option to prescale TTCM TCs")
 	], doc="Configuration of the different readout time maps"),

--- a/schema/trigger/ctbtriggercandidatemaker.jsonnet
+++ b/schema/trigger/ctbtriggercandidatemaker.jsonnet
@@ -4,12 +4,13 @@ local s = moo.oschema.schema(ns);
 local nc = moo.oschema.numeric_constraints;
 
 local types = {
-	hsi_tt_pt : s.boolean("hsi_tt_pt"),
         count_t : s.number("count_t", "i8", nc(minimum=1), doc="Counter"),
+        time_t : s.number("time_t", "i8", doc="Time"),
 	conf: s.record("Conf", [
-		s.field("hsi_trigger_type_passthrough", self.hsi_tt_pt, doc="Option to override the trigger type values"),
-                s.field("prescale", self.count_t, default=1, doc="Option to prescale TTCM TCs")
-	], doc="Configuration of the different readout time maps"),
+                s.field("prescale", self.count_t, default=1, doc="Option to prescale TTCM TCs"),
+ 	        s.field("time_before", self.time_t, 1000, doc="Readout time before time stamp"),
+                s.field("time_after",  self.time_t, 1000, doc="Readout time after time stamp")
+	], doc="CTB configuration block"),
 
 };
 

--- a/schema/trigger/ctbtriggercandidatemakerinfo.jsonnet
+++ b/schema/trigger/ctbtriggercandidatemakerinfo.jsonnet
@@ -1,0 +1,20 @@
+// This is the application info schema used by the ctb trigger candidate maker module.
+// It describes the information object structure passed by the application 
+// for operational monitoring
+
+local moo = import "moo.jsonnet";
+local s = moo.oschema.schema("dunedaq.trigger.ctbtriggercandidatemakerinfo");
+
+local info = {
+    uint8  : s.number("uint8", "u8",
+                     doc="An unsigned of 8 bytes"),
+
+   info: s.record("Info", [
+       s.field("tsd_received_count",    self.uint8, 0, doc="Number of HSIEvent messages received."), 
+       s.field("tc_sent_count",         self.uint8, 0, doc="Number of trigger candidates added to queue."), 
+       s.field("tc_sig_type_err_count", self.uint8, 0, doc="Number of trigger candidates not added to queue due to a signal type error."), 
+       s.field("tc_total_count",        self.uint8, 0, doc="Total number of trigger candidates created."), 
+   ], doc="CTB trigger candidate maker information.")
+};
+
+moo.oschema.sort_select(info) 


### PR DESCRIPTION
Implementation of the CTB signals into trigger.

There is a new plugin `CTBTriggerCandidateMaker` based on the `TimingTriggerCandidateMaker`. The plugin is 'standalone' (not part of the TP flow) and connects to the MLT (and to TC Buffer). 
This plugin receives HSIEvents and converts them to TCs. New TC types have been added to reflect this (pybinds included).
The creation of the TCs works in a loop as it is possible to receive a signal with multiple bits on, each bit corresponding to a (to-be-made) TC of a different type. 
There is a map of signal bits to TC types in the header file.
There is an error thrown if the received bit is not known (not in the map).
There is functional opmon for the hsi events and TC objects. 

Because there are now many new TC types, several other wrappers had to be extended. This includes the `bitsets` in the MLT as well as the `trigger_type` in the TriggerDecision message. This is also propagated all the way to the TriggerRecordHeaderData. As a consequence the TRHD is now bigger (!) and padding had to be adjusted to accommodate for this.


!!! IMPORTANTLY, the version of both TriggerCandidateData and TriggerRecordHeaderData were increased to reflect these big changes. !!!
-

The CTB plugin has 3 configurable parameters:
	"ctb_prescale": 1,                 <- we can prescale the events
	"ctb_time_before": 1000,     <- extension to the readout window before hsievent timestamp
	"ctb_time_after": 1000,        <- extension to the readout window after hsievent timestamp

This passes the integration tests: minimal_system_quick_test.py, readout_type_scan.py, fake_data_producer_test.py.

From custom test, I was able to use fake_hsi to get HSI events of different signals.
These are picked by the CTB:
```
[CTB] Converting HSI event, signal: 8880680
```
Bits are extracted:
```
BITS: 00000000100001111000001000101000
```
and appropriate TCs are created:
```
this bit: 3
TC type: 13
```
These are received at MLT:
```
 Got TC of type 13, timestamp 79554162131545930, start/end 79554162131544930/79554162131546930
```
As was the case before, the trigger_type inside the HDF5 file corresponds to the trigger_type sent by the MLT.
