### PR TITLE
Fixed compiler error in Issues.hpp and cleaned up a couple of typos t…

### DIFF
--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -170,7 +170,7 @@ ERS_DECLARE_ISSUE_BASE(trigger,
 ERS_DECLARE_ISSUE_BASE(trigger,
                        TCTimestampsSizeError,
                        appfwk::GeneralDAQModuleIssue,
-                       "There are no next timestamps!",
+                       "There are no next timestamps! (size=" << size <<")",
                        ((std::string)name),
 		       ((int)size))
 
@@ -193,20 +193,17 @@ ERS_DECLARE_ISSUE_BASE(trigger,
 		       ((std::bitset<32>)bits)
 		       ((size_t)map_size))
 
-ERS_DECLARE_ISSUE_BASE(trigger,
-                       MissingFactoryItemError,
-                       appfwk::GeneralDAQModuleIssue,
-                       "Factory could not find requested item " << item << ".",
-                       ((std::string)item),
-                       ERS_EMPTY)
+ERS_DECLARE_ISSUE(trigger,
+                  MissingFactoryItemError,
+                  "Factory could not find requested item " << item << ".",
+                  ((std::string)item))
 
 ERS_DECLARE_ISSUE_BASE(trigger,
                        TTCMConfigurationProblem,
                        appfwk::GeneralDAQModuleIssue,
                        "Configuration error: " << item,
                        ((std::string)name),
-                       ((std::string)item),
-                       ERS_EMPTY)
+                       ((std::string)item))
 
 } // namespace dunedaq
 


### PR DESCRIPTION
…hat would have caused odd messages to be printed out

I removed the extra ERS_EMPTY parameter in the TTCMConfigurationParameter Issue declaration.  This was causing a compiler error.

I also added the "size" parameter to the message string in the TCTimestampsSizeError Issue.  That seemed appropriate  (why have it if it isn't displayed?)

and, I changed the declaration type for MissingFactoryItemError since it is not being passed a get_name() value in the code that makes use of it.