### PR TITLE
Removed Separate Fragment Time Comparisons

### DIFF
--- a/plugins/TriggerPrimitiveMaker.cpp
+++ b/plugins/TriggerPrimitiveMaker.cpp
@@ -173,6 +173,7 @@ TriggerPrimitiveMaker::read_tpsets(std::string filename, int element)
 
     trgdataformats::TriggerPrimitive* tp_array = static_cast<trgdataformats::TriggerPrimitive*>(frag->get_data());
 
+    old_time_start = 0;
     for (size_t i(0); i < num_tps; i++) {
       auto& tp = tp_array[i];
       if (tp.time_start < old_time_start) {


### PR DESCRIPTION
The check on TP ordering assumed that there was only one TP fragment per TimeSlice. Any TimeSlice that has multiple TP fragments then compares across fragments, and the last TP of the first is likely much later than the first TPs in the next fragments. This change resets the time comparison per fragment.

This was tested by running the replay application on TPStreams which contain multiple TP fragments per TimeSlice and weakly checking the resulting RawData file. The weak check was done by using the BundleN algorithms and assuring the bundle sizes were correct. There was not a cross comparison between the original TPStream and the resulting RawData.