### PR TITLE
Fake hsi split

### DIFF
--- a/python/trigger/replay_tps/__main__.py
+++ b/python/trigger/replay_tps/__main__.py
@@ -190,6 +190,7 @@ def trigger_app(the_system, daq_common, get_trigger_app, trigger, detector, tp_i
         use_hsi_input=False,
         use_fake_hsi_input=False,
         use_ctb_input=False,
+        fake_hsi_to_ctb=False,
         DEBUG=debug)
 
     return


### PR DESCRIPTION
Allows sending fake HSI signals to CTB trigger modules (testing).
More details in: https://github.com/DUNE-DAQ/daqconf/pull/449