### PR TITLE
Asztuc/tpwrapper fix

### DIFF
--- a/plugins/TPBuffer.hpp
+++ b/plugins/TPBuffer.hpp
@@ -94,7 +94,7 @@ private:
     static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kTrigger;
     static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTriggerPrimitive;
     // No idea what this should really be set to
-    static const constexpr uint64_t expected_tick_difference = 1; // NOLINT(build/unsigned)
+    static const constexpr uint64_t expected_tick_difference = 0; // NOLINT(build/unsigned)
 };
 
   void do_conf(const nlohmann::json& config);

--- a/plugins/TPBuffer.hpp
+++ b/plugins/TPBuffer.hpp
@@ -56,7 +56,7 @@ private:
     // comparable based on first timestamp
     bool operator<(const TPWrapper& other) const
     {
-      return this->primitive.time_start < other.primitive.time_start;
+      return std::tie(this->primitive.time_start, this->primitive.channel) < std::tie(other.primitive.time_start, other.primitive.channel);
     }
 
     uint64_t get_first_timestamp() const // NOLINT(build/unsigned)
@@ -74,28 +74,27 @@ private:
       return primitive.time_start;
     }
 
-
     size_t get_payload_size() { return sizeof(triggeralgs::TriggerPrimitive); }
 
     size_t get_num_frames() { return 1; }
 
     size_t get_frame_size() { return get_payload_size(); }
 
-    triggeralgs::TriggerPrimitive* begin()
+    TPWrapper* begin()
     {
-      return &primitive;
+      return this;
     }
     
-    triggeralgs::TriggerPrimitive* end()
+    TPWrapper* end()
     {
-      return &primitive + 1;
+      return (this + 1);
     }
 
     //static const constexpr size_t fixed_payload_size = 5568;
     static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kTrigger;
     static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTriggerPrimitive;
     // No idea what this should really be set to
-    static const constexpr uint64_t expected_tick_difference = 16; // NOLINT(build/unsigned)
+    static const constexpr uint64_t expected_tick_difference = 1; // NOLINT(build/unsigned)
 };
 
   void do_conf(const nlohmann::json& config);

--- a/plugins/TPBuffer.hpp
+++ b/plugins/TPBuffer.hpp
@@ -94,7 +94,7 @@ private:
     static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kTrigger;
     static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTriggerPrimitive;
     // No idea what this should really be set to
-    static const constexpr uint64_t expected_tick_difference = 0; // NOLINT(build/unsigned)
+    static const constexpr uint64_t expected_tick_difference = 1; // NOLINT(build/unsigned)
 };
 
   void do_conf(const nlohmann::json& config);

--- a/python/trigger/replay_tps/__main__.py
+++ b/python/trigger/replay_tps/__main__.py
@@ -190,6 +190,7 @@ def trigger_app(the_system, daq_common, get_trigger_app, trigger, detector, tp_i
         use_hsi_input=False,
         use_fake_hsi_input=False,
         use_ctb_input=False,
+        use_cib_input=False,
         fake_hsi_to_ctb=False,
         DEBUG=debug)
 


### PR DESCRIPTION
This PR has two bug-fixes:
1. Correct the expected tick difference between TPs in trigger's TP buffer's `TPWrapper` to match the one in the readout's `TriggerPrimitiveAdapter`, fixing the missing-tps from the Trigger's TP buffer issue.
2. Fixing the replay application by adding the CIB line, needed after the CIB integration into the trigger.

Tests done:
1. Everything from https://github.com/DUNE-DAQ/integrationtest/tree/develop/python/integrationtest
2. Ran replay application with HMA algorithm before and after the fix: before the fix n TPs from buffer fragment is lower than in TA fragment, after the fix n TPs from buffer fragment is higher than in the TA fragment, as expected.
3. Ran offline on raw fragment asset with TPG using BundleN algorithm: the number of TPs is identical number of TPs from the readout buffer and from the trigger buffer fragments.
4. @aeoranday ran extra comparisons showing the discrepancy between the fragments from the two TP buffers (readout vs trigger) is fixed with this PR.

The very last TP from the readout window is always missing, however, from both buffers. This is because the SkipListLatencyBuffer (or maybe the Handler itself) is inclusive for the start of the readout window, and exclusive for the end of the readout window.

For comparison, here's the readouts `TriggerPrimitiveAdapter`: https://github.com/DUNE-DAQ/fdreadoutlibs/blob/production/v4/include/fdreadoutlibs/TriggerPrimitiveTypeAdapter.hpp.
We probably should be using the same code in the future.