### PR TITLE
Unique and short thread names for trigger's DAQModules

### DIFF
--- a/include/trigger/Tee.hxx
+++ b/include/trigger/Tee.hxx
@@ -59,7 +59,7 @@ template<class T>
 void
 Tee<T>::do_start(const nlohmann::json&)
 {
-  m_thread.start_working_thread("tee");
+  m_thread.start_working_thread(get_name());
   TLOG_DEBUG(TLVL_GENERAL) << "[Tee] " << get_name() + " successfully started.";
 }
 

--- a/plugins/CustomTriggerCandidateMaker.cpp
+++ b/plugins/CustomTriggerCandidateMaker.cpp
@@ -120,7 +120,7 @@ CustomTriggerCandidateMaker::do_start(const nlohmann::json& obj)
   }
 
   m_send_trigger_candidates_thread = std::thread(&CustomTriggerCandidateMaker::send_trigger_candidates, this);
-  pthread_setname_np(m_send_trigger_candidates_thread.native_handle(), get_name());
+  pthread_setname_np(m_send_trigger_candidates_thread.native_handle(), get_name().c_str());
 }
 
 void

--- a/plugins/CustomTriggerCandidateMaker.cpp
+++ b/plugins/CustomTriggerCandidateMaker.cpp
@@ -120,7 +120,7 @@ CustomTriggerCandidateMaker::do_start(const nlohmann::json& obj)
   }
 
   m_send_trigger_candidates_thread = std::thread(&CustomTriggerCandidateMaker::send_trigger_candidates, this);
-  pthread_setname_np(m_send_trigger_candidates_thread.native_handle(), "custom-tc-maker");
+  pthread_setname_np(m_send_trigger_candidates_thread.native_handle(), get_name());
 }
 
 void

--- a/plugins/FakeTPCreatorHeartbeatMaker.cpp
+++ b/plugins/FakeTPCreatorHeartbeatMaker.cpp
@@ -70,7 +70,7 @@ FakeTPCreatorHeartbeatMaker::do_start(const nlohmann::json& args)
   rcif::cmd::StartParams start_params = args.get<rcif::cmd::StartParams>();
   m_run_number = start_params.run;
 
-  m_thread.start_working_thread("heartbeater");
+  m_thread.start_working_thread(get_name());
   TLOG_DEBUG(TLVL_GENERAL) << "[FHM] " << get_name() + " successfully started.";
 }
 

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -189,7 +189,7 @@ ModuleLevelTrigger::do_start(const nlohmann::json& startobj)
   m_inhibit_input->add_callback(std::bind(&ModuleLevelTrigger::dfo_busy_callback, this, std::placeholders::_1));
 
   m_send_trigger_decisions_thread = std::thread(&ModuleLevelTrigger::send_trigger_decisions, this);
-  pthread_setname_np(m_send_trigger_decisions_thread.native_handle(), "mlt-trig-dec");
+  pthread_setname_np(m_send_trigger_decisions_thread.native_handle(), get_name());
 
   ers::info(TriggerStartOfRun(ERS_HERE, m_run_number));
 

--- a/plugins/ModuleLevelTrigger.cpp
+++ b/plugins/ModuleLevelTrigger.cpp
@@ -189,7 +189,7 @@ ModuleLevelTrigger::do_start(const nlohmann::json& startobj)
   m_inhibit_input->add_callback(std::bind(&ModuleLevelTrigger::dfo_busy_callback, this, std::placeholders::_1));
 
   m_send_trigger_decisions_thread = std::thread(&ModuleLevelTrigger::send_trigger_decisions, this);
-  pthread_setname_np(m_send_trigger_decisions_thread.native_handle(), get_name());
+  pthread_setname_np(m_send_trigger_decisions_thread.native_handle(), get_name().c_str());
 
   ers::info(TriggerStartOfRun(ERS_HERE, m_run_number));
 

--- a/plugins/RandomTriggerCandidateMaker.cpp
+++ b/plugins/RandomTriggerCandidateMaker.cpp
@@ -99,7 +99,7 @@ RandomTriggerCandidateMaker::do_start(const nlohmann::json& obj)
   }
 
   m_send_trigger_candidates_thread = std::thread(&RandomTriggerCandidateMaker::send_trigger_candidates, this);
-  pthread_setname_np(m_send_trigger_candidates_thread.native_handle(), get_name());
+  pthread_setname_np(m_send_trigger_candidates_thread.native_handle(), get_name().c_str());
 }
 
 void

--- a/plugins/RandomTriggerCandidateMaker.cpp
+++ b/plugins/RandomTriggerCandidateMaker.cpp
@@ -99,7 +99,7 @@ RandomTriggerCandidateMaker::do_start(const nlohmann::json& obj)
   }
 
   m_send_trigger_candidates_thread = std::thread(&RandomTriggerCandidateMaker::send_trigger_candidates, this);
-  pthread_setname_np(m_send_trigger_candidates_thread.native_handle(), "random-tc-maker");
+  pthread_setname_np(m_send_trigger_candidates_thread.native_handle(), get_name());
 }
 
 void

--- a/plugins/TABuffer.cpp
+++ b/plugins/TABuffer.cpp
@@ -69,7 +69,7 @@ void
 TABuffer::do_start(const nlohmann::json& args)
 {
   m_request_handler_impl->start(args);
-  m_thread.start_working_thread("tabuffer");
+  m_thread.start_working_thread(get_name());
   TLOG_DEBUG(TLVL_GENERAL) << "[TAB] "  << get_name() + " successfully started.";
 }
 

--- a/plugins/TCBuffer.cpp
+++ b/plugins/TCBuffer.cpp
@@ -73,7 +73,7 @@ void
 TCBuffer::do_start(const nlohmann::json& args)
 {
   m_request_handler_impl->start(args);
-  m_thread.start_working_thread("tcbuffer");
+  m_thread.start_working_thread(get_name());
   TLOG_DEBUG(TLVL_GENERAL) << "[TCB] " << get_name() + " successfully started.";
 }
 

--- a/plugins/TPChannelFilter.cpp
+++ b/plugins/TPChannelFilter.cpp
@@ -72,7 +72,7 @@ TPChannelFilter::do_start(const nlohmann::json&)
   m_running_flag.store(true);
   m_received_count.store(0);
   m_sent_count.store(0);
-  m_thread.start_working_thread("channelfilter");
+  m_thread.start_working_thread(get_name());
   TLOG_DEBUG(TLVL_GENERAL) << "[TPCF] " << get_name() + " successfully started.";
 }
 

--- a/plugins/TPSetBufferCreator.cpp
+++ b/plugins/TPSetBufferCreator.cpp
@@ -93,7 +93,7 @@ TPSetBufferCreator::do_configure(const nlohmann::json& obj)
 void
 TPSetBufferCreator::do_start(const nlohmann::json& /*args*/)
 {
-  m_thread.start_working_thread("buffer-man");
+  m_thread.start_working_thread(get_name());
   TLOG_DEBUG(TLVL_GENERAL) << "[TPSetBufferCreator] " << get_name() << " successfully started";
 }
 

--- a/plugins/TriggerZipper.hpp
+++ b/plugins/TriggerZipper.hpp
@@ -159,7 +159,7 @@ public:
     m_tardy_counts.clear();
     m_running.store(true);
     m_thread = std::thread(&TriggerZipper::worker, this);
-    pthread_setname_np(m_thread.native_handle(), get_name());
+    pthread_setname_np(m_thread.native_handle(), get_name().c_str());
   }
 
   void do_stop(const nlohmann::json& /*stopobj*/)

--- a/plugins/TriggerZipper.hpp
+++ b/plugins/TriggerZipper.hpp
@@ -159,7 +159,7 @@ public:
     m_tardy_counts.clear();
     m_running.store(true);
     m_thread = std::thread(&TriggerZipper::worker, this);
-    pthread_setname_np(m_thread.native_handle(), "zipper");
+    pthread_setname_np(m_thread.native_handle(), get_name());
   }
 
   void do_stop(const nlohmann::json& /*stopobj*/)

--- a/test/plugins/TASetSink.cpp
+++ b/test/plugins/TASetSink.cpp
@@ -43,7 +43,7 @@ TASetSink::do_start(const nlohmann::json& /*obj*/)
 {
   m_running_flag.store(true);
   m_thread = std::thread(&TASetSink::do_work, this);
-  pthread_setname_np(m_thread.native_handle(), get_name());
+  pthread_setname_np(m_thread.native_handle(), get_name().c_str());
 }
 
 void

--- a/test/plugins/TASetSink.cpp
+++ b/test/plugins/TASetSink.cpp
@@ -43,7 +43,7 @@ TASetSink::do_start(const nlohmann::json& /*obj*/)
 {
   m_running_flag.store(true);
   m_thread = std::thread(&TASetSink::do_work, this);
-  pthread_setname_np(m_thread.native_handle(), "tasink");
+  pthread_setname_np(m_thread.native_handle(), get_name());
 }
 
 void

--- a/test/plugins/TPSetSink.cpp
+++ b/test/plugins/TPSetSink.cpp
@@ -43,7 +43,7 @@ TPSetSink::do_start(const nlohmann::json& /*obj*/)
 {
   m_running_flag.store(true);
   m_thread = std::thread(&TPSetSink::do_work, this);
-  pthread_setname_np(m_thread.native_handle(), get_name());
+  pthread_setname_np(m_thread.native_handle(), get_name().c_str());
 }
 
 void

--- a/test/plugins/TPSetSink.cpp
+++ b/test/plugins/TPSetSink.cpp
@@ -43,7 +43,7 @@ TPSetSink::do_start(const nlohmann::json& /*obj*/)
 {
   m_running_flag.store(true);
   m_thread = std::thread(&TPSetSink::do_work, this);
-  pthread_setname_np(m_thread.native_handle(), "tpsink");
+  pthread_setname_np(m_thread.native_handle(), get_name());
 }
 
 void


### PR DESCRIPTION
All the trigger `DAQModule`s `do_work` threads now have unique names, taken from the module's unique name -- which is in turn set in the `daqconf`.  At the same time, some of the modules unique names had to be renamed as they were more than 16 characters long -- and they must be 16 chars or less, as explained [HERE](https://linux.die.net/man/3/pthread_setname_np).
This doesn't change how the trigger works in any way, but will enable us to pin threads to specific CPUs if we require this for NP04. 

This PR goes together with: 

Tested by:
1. Running the he integration test `3ru_3df_multirun_test.py`.
2. Successfully generating a configuration with `--debug` to generate .dot files and looking through them.
3. Running offline with 3 readout units, and seeing triggers as expected.

![trigger](https://github.com/DUNE-DAQ/trigger/assets/25038499/7edc58b2-518c-4370-9aae-7bc21b4722c7)

