### PR TITLE
Extra operational monitoring in the trigger

### DIFF
--- a/plugins/TABuffer.hpp
+++ b/plugins/TABuffer.hpp
@@ -9,17 +9,26 @@
 #ifndef TRIGGER_PLUGINS_TABUFFER_HPP_
 #define TRIGGER_PLUGINS_TABUFFER_HPP_
 
+#include "appfwk/app/Nljs.hpp"
+#include "appfwk/cmd/Nljs.hpp"
+#include "appfwk/cmd/Structs.hpp"
+
+#include "opmonlib/InfoCollector.hpp"
+
 #include "daqdataformats/Fragment.hpp"
 #include "iomanager/Receiver.hpp"
 #include "readoutlibs/FrameErrorRegistry.hpp"
 #include "readoutlibs/models/DefaultSkipListRequestHandler.hpp"
 #include "readoutlibs/models/SkipListLatencyBufferModel.hpp"
+#include "readoutlibs/readoutinfo/InfoNljs.hpp"
 #include "triggeralgs/TriggerObjectOverlay.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
 #include "utilities/WorkerThread.hpp"
 
 #include "trigger/Issues.hpp"
 #include "trigger/TASet.hpp"
+#include "trigger/txbufferinfo/InfoNljs.hpp"
+
 
 #include <chrono>
 #include <map>
@@ -107,7 +116,7 @@ private:
     // No idea what this should really be set to
     static const constexpr uint64_t expected_tick_difference = 16; // NOLINT(build/unsigned)
 
-};
+  };
 
   void do_conf(const nlohmann::json& config);
   void do_start(const nlohmann::json& obj);
@@ -130,6 +139,11 @@ private:
   std::unique_ptr<latency_buffer_t> m_latency_buffer_impl{nullptr};
   using request_handler_t = readoutlibs::DefaultSkipListRequestHandler<buffer_object_t>;
   std::unique_ptr<request_handler_t> m_request_handler_impl{nullptr};
+
+  // operational monitoring stats
+  std::atomic<int> m_num_payloads{0};
+  std::atomic<int> m_num_payloads_overwritten{0};
+  std::atomic<int> m_num_requests{0};
 
   // Don't actually use this, but it's currently needed as arg to request handler ctor
   std::unique_ptr<readoutlibs::FrameErrorRegistry> m_error_registry;

--- a/plugins/TCBuffer.hpp
+++ b/plugins/TCBuffer.hpp
@@ -9,6 +9,12 @@
 #ifndef TRIGGER_PLUGINS_TCBUFFER_HPP_
 #define TRIGGER_PLUGINS_TCBUFFER_HPP_
 
+#include "appfwk/app/Nljs.hpp"
+#include "appfwk/cmd/Nljs.hpp"
+#include "appfwk/cmd/Structs.hpp"
+
+#include "opmonlib/InfoCollector.hpp"
+
 #include "appfwk/DAQModule.hpp"
 #include "daqdataformats/Fragment.hpp"
 #include "iomanager/Receiver.hpp"
@@ -17,12 +23,14 @@
 #include "readoutlibs/models/DefaultRequestHandlerModel.hpp"
 #include "readoutlibs/models/SkipListLatencyBufferModel.hpp"
 #include "readoutlibs/models/DefaultSkipListRequestHandler.hpp"
+#include "readoutlibs/readoutinfo/InfoNljs.hpp"
 #include "triggeralgs/TriggerActivity.hpp"
 #include "triggeralgs/TriggerObjectOverlay.hpp"
 #include "utilities/WorkerThread.hpp"
 
 #include "trigger/Issues.hpp"
 #include "triggeralgs/TriggerCandidate.hpp"
+#include "trigger/txbufferinfo/InfoNljs.hpp"
 
 #include <chrono>
 #include <map>
@@ -104,7 +112,7 @@ private:
     // No idea what this should really be set to
     static const constexpr uint64_t expected_tick_difference = 16; // NOLINT(build/unsigned)
 
-};
+  };
 
   void do_conf(const nlohmann::json& config);
   void do_start(const nlohmann::json& obj);
@@ -127,6 +135,11 @@ private:
   std::unique_ptr<latency_buffer_t> m_latency_buffer_impl{nullptr};
   using request_handler_t = readoutlibs::DefaultSkipListRequestHandler<buffer_object_t>;
   std::unique_ptr<request_handler_t> m_request_handler_impl{nullptr};
+
+  // operational monitoring stats
+  std::atomic<int> m_num_payloads{0};
+  std::atomic<int> m_num_payloads_overwritten{0};
+  std::atomic<int> m_num_requests{0};
 
   // Don't actually use this, but it's currently needed as arg to request handler ctor
   std::unique_ptr<readoutlibs::FrameErrorRegistry> m_error_registry;

--- a/plugins/TriggerZipper.hpp
+++ b/plugins/TriggerZipper.hpp
@@ -95,6 +95,8 @@ public:
   std::atomic<metric_counter_type> m_n_received{ 0 };
   std::atomic<metric_counter_type> m_n_sent{ 0 };
   std::atomic<metric_counter_type> m_n_tardy{ 0 };
+  std::atomic<metric_counter_type> m_n_cache_occupancy{ 0 };
+  std::atomic<metric_counter_type> m_n_zipper_occupancy{ 0 };
 
   std::map<daqdataformats::SourceID, size_t> m_tardy_counts;
 
@@ -123,6 +125,8 @@ public:
     i.n_received = m_n_received.load();
     i.n_sent = m_n_sent.load();
     i.n_tardy = m_n_tardy.load();
+    i.n_cache_occupancy = m_n_cache_occupancy.load();
+    i.n_zipper_occupancy = m_n_zipper_occupancy.load();
 
     ci.add(i);
   }
@@ -156,6 +160,8 @@ public:
     m_n_received = 0;
     m_n_sent = 0;
     m_n_tardy = 0;
+    m_n_cache_occupancy = 0;
+    m_n_zipper_occupancy = 0;
     m_tardy_counts.clear();
     m_running.store(true);
     m_thread = std::thread(&TriggerZipper::worker, this);
@@ -243,6 +249,9 @@ public:
       m_cache.pop_front(); // vestigial
     }
     drain();
+
+    m_n_cache_occupancy = m_cache.size();
+    m_n_zipper_occupancy = m_zm.get_occupancy();
     return true;
   }
 

--- a/plugins/zipper.hpp
+++ b/plugins/zipper.hpp
@@ -89,6 +89,8 @@ public:
     : cardinality(k)
     , latency(max_latency)
     , origin(0) // ordering
+    , occupancy(0)
+
   {}
 
   /**
@@ -128,6 +130,8 @@ public:
 
   ordering_t get_origin() const { return origin; }
 
+  size_t get_occupancy() { return occupancy; }
+
   /**
      Clear the zipper merge buffer.
   */
@@ -153,6 +157,7 @@ public:
     }
     auto& s = streams[node.identity];
     s.occupancy += 1;
+    occupancy++;
     s.last_seen = node.debut;
     this->push(node);
     return true;
@@ -187,6 +192,7 @@ public:
     auto& s = streams.at(node.identity);
     s.occupancy -= 1;
     origin = node.ordering;
+    occupancy--;
 
     return node;
   }
@@ -344,6 +350,7 @@ private:
   ordering_t origin;
   bool tolerate_incompleteness = false;
   size_t completeness_tolerance = 1;
+  size_t occupancy;
   struct Stream
   {
     size_t occupancy{ 0 };

--- a/schema/trigger/triggerzipperinfo.jsonnet
+++ b/schema/trigger/triggerzipperinfo.jsonnet
@@ -12,7 +12,9 @@ local info = {
    info: s.record("Info", [
        s.field("n_received",                  self.uint8, 0, doc="Number of inputs received."), 
        s.field("n_sent",                      self.uint8, 0, doc="Number of results added to queue."), 
-       s.field("n_tardy",                     self.uint8, 0, doc="Number of Tarfy added to queue."), 
+       s.field("n_tardy",                     self.uint8, 0, doc="Number of Tardy added to queue."),
+       s.field("n_cache_occupancy",           self.uint8, 0, doc="Occupancy of the TXZipper cache."),
+       s.field("n_zipper_occupancy",          self.uint8, 0, doc="Occupancy of the TXZipper buffer."),
    ], doc="Trigger Generic Maker information")
 };
 

--- a/schema/trigger/txbufferinfo.jsonnet
+++ b/schema/trigger/txbufferinfo.jsonnet
@@ -1,0 +1,20 @@
+// This is the application info schema used by the TXBuffer modules.
+// It describes the information object structure passed by the application 
+// for operational monitoring
+
+local moo = import "moo.jsonnet";
+local s = moo.oschema.schema("dunedaq.trigger.txbufferinfo");
+
+local info = {
+    uint8  : s.number("uint8", "u8",
+                     doc="An unsigned of 8 bytes"),
+
+   info: s.record("Info", [
+       s.field("num_payloads",                  self.uint8, 0, doc="Number of payloads received."), 
+       s.field("num_payloads_overwritten",      self.uint8, 0, doc="Number of payloads overwritten."), 
+       s.field("num_requests",                  self.uint8, 0, doc="Number of fragment requests received."), 
+       s.field("num_buffer_elements",           self.uint8, 0, doc="Occupancy of the TXBuffer's latencybuffer."), 
+   ], doc="TXBuffer operational monitoring information")
+};
+
+moo.oschema.sort_select(info) 


### PR DESCRIPTION
Extra operational monitoring for the trigger's buffers (both TA and TC), and TAZipper (added occupancy monitoring). Still need to update grafana.

Tested by:
1. Running the the integration test `3ru_3df_multirun_test.py`.
2. Running with monitoring enabled, and scanning through the generated info file for the new monitoring information.