### PR TITLE
Bugfix for the TA & TC adapters in the trigger

### DIFF
--- a/plugins/TABuffer.hpp
+++ b/plugins/TABuffer.hpp
@@ -68,6 +68,7 @@ private:
     bool operator<(const TAWrapper& other) const
     {
       return this->activity.time_start < other.activity.time_start;
+      return std::tie(this->activity.time_start, this->activity.channel_start) < std::tie(other.activity.time_start, other.activity.channel_start);
     }
 
     uint64_t get_first_timestamp() const // NOLINT(build/unsigned)
@@ -105,7 +106,7 @@ private:
     static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kTrigger;
     static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTriggerActivity;
     // No idea what this should really be set to
-    static const constexpr uint64_t expected_tick_difference = 16; // NOLINT(build/unsigned)
+    static const constexpr uint64_t expected_tick_difference = 1; // NOLINT(build/unsigned)
 
 };
 

--- a/plugins/TCBuffer.hpp
+++ b/plugins/TCBuffer.hpp
@@ -69,7 +69,7 @@ private:
     // comparable based on first timestamp
     bool operator<(const TCWrapper& other) const
     {
-      return this->candidate.time_start < other.candidate.time_start;
+      return std::tie(this->candidate.time_start, this->candidate.type) < std::tie(other.candidate.time_start, other.candidate.type);
     }
 
     uint64_t get_first_timestamp() const // NOLINT(build/unsigned)
@@ -102,7 +102,7 @@ private:
     static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kTrigger;
     static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTriggerCandidate;
     // No idea what this should really be set to
-    static const constexpr uint64_t expected_tick_difference = 16; // NOLINT(build/unsigned)
+    static const constexpr uint64_t expected_tick_difference = 1; // NOLINT(build/unsigned)
 
 };
 


### PR DESCRIPTION
Fix to the expected width of the trigger candidate & trigger activity for the TA/TC adapter (when placing in the latency buffer).

Tested by running online with eight CTB bits on: `CTBTriggerCandidateMaker` would create eight TCs with identical `start_time`. MLT would merge this into one TD, so in the trigger-words from the raw dat we would see all eight for each TD, but only one TC being retrieved from the trigger. This is no longer the case, now we have all 8 TCs being retrieved from the latencybuffer.