### PR TITLE
Custom subdetector readout for MLT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ daq_codegen(
   tasetsink.jsonnet
   tpchannelfilter.jsonnet
   cibtriggercandidatemaker.jsonnet
+  DEP_PKGS hdf5libs
   TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 
 daq_codegen(
@@ -79,7 +80,7 @@ daq_add_plugin(TriggerCandidateMaker duneDAQModule LINK_LIBRARIES trigger)
 daq_add_plugin(TriggerDecisionMaker duneDAQModule LINK_LIBRARIES trigger)
 daq_add_plugin(RandomTriggerCandidateMaker duneDAQModule LINK_LIBRARIES trigger)
 daq_add_plugin(CustomTriggerCandidateMaker duneDAQModule LINK_LIBRARIES trigger)
-daq_add_plugin(ModuleLevelTrigger duneDAQModule LINK_LIBRARIES trigger)
+daq_add_plugin(ModuleLevelTrigger duneDAQModule LINK_LIBRARIES trigger hdf5libs::hdf5libs detdataformats::detdataformats)
 daq_add_plugin(TPSetSink duneDAQModule LINK_LIBRARIES trigger TEST)
 daq_add_plugin(TASetSink duneDAQModule LINK_LIBRARIES trigger TEST)
 daq_add_plugin(FakeTPCreatorHeartbeatMaker duneDAQModule LINK_LIBRARIES trigger)

--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -215,6 +215,13 @@ ERS_DECLARE_ISSUE_BASE(trigger,
                        ((std::string)name),
                        ((std::string)item))
 
+ERS_DECLARE_ISSUE_BASE(trigger,
+                       MLTConfigurationProblem,
+                       appfwk::GeneralDAQModuleIssue,
+                       "Configuration error: " << item,
+                       ((std::string)name),
+                       ((std::string)item))
+
 } // namespace dunedaq
 
 #endif // TRIGGER_INCLUDE_TRIGGER_ISSUES_HPP_

--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -20,11 +20,13 @@
 #include "trigger/moduleleveltriggerinfo/InfoNljs.hpp"
 
 #include "appfwk/DAQModule.hpp"
+#include "detdataformats/DetID.hpp"
 #include "daqdataformats/SourceID.hpp"
 #include "dfmessages/TriggerDecision.hpp"
 #include "dfmessages/TriggerDecisionToken.hpp"
 #include "dfmessages/TriggerInhibit.hpp"
 #include "dfmessages/Types.hpp"
+#include "hdf5libs/hdf5rawdatafile/Structs.hpp"
 #include "iomanager/Receiver.hpp"
 #include "trgdataformats/TriggerCandidateData.hpp"
 #include "trgdataformats/Types.hpp"
@@ -180,6 +182,14 @@ private:
   bool check_trigger_bitwords();
   void print_bitword_flags(nlohmann::json m_trigger_bitwords_json);
   void set_trigger_bitwords();
+
+  /// @brief SourceID to GeoID map
+  /// @todo Would be nice to have GeoID as part of dfmessagesm or even detdataformats
+  std::map<dfmessages::SourceID, dunedaq::hdf5libs::hdf5rawdatafile::GeoID> m_srcid_geoid_map;
+
+  /// @brief Subdetector--readout-window map config
+  std::map<dunedaq::detdataformats::DetID::Subdetector, std::pair<triggeralgs::timestamp_t, triggeralgs::timestamp_t>>
+    m_subdetector_readout_window_map;
 
   // Readout map config
   bool m_use_readout_map;

--- a/plugins/TimingTriggerCandidateMaker.cpp
+++ b/plugins/TimingTriggerCandidateMaker.cpp
@@ -118,7 +118,6 @@ TimingTriggerCandidateMaker::do_conf(const nlohmann::json& config)
           "Created TTCM, but supplied an empty signal map!");
   }
 
-  auto first_entry = *std::begin(m_hsisignal_map);
   m_prescale = params.prescale;
   m_prescale_flag = (m_prescale > 1) ? true : false;
   TLOG_DEBUG(TLVL_GENERAL) << "[TTCM] " << get_name() + " configured.";

--- a/python/trigger/replay_tps/__main__.py
+++ b/python/trigger/replay_tps/__main__.py
@@ -179,11 +179,12 @@ def replay_app(the_system, input_file, slowdown_factor, number_of_loops, tpset_t
 
     return
 
-def trigger_app(the_system, daq_common, get_trigger_app, trigger, detector, tp_infos, debug):
+def trigger_app(the_system, dro_map, daq_common, get_trigger_app, trigger, detector, tp_infos, debug):
     trigger_data_request_timeout = daq_common.data_request_timeout_ms
     the_system.apps['trigger'] = get_trigger_app(
         trigger=trigger,
         detector=detector,
+        src_geo_id_map=dro_map.get_src_geo_map(),
         daq_common=daq_common,
         tp_infos=tp_infos,
         trigger_data_request_timeout=trigger_data_request_timeout,
@@ -472,7 +473,7 @@ def cli(
     #--------------------------------------------------------------------------
     # Trigger
     #--------------------------------------------------------------------------
-    trigger_app(the_system, daq_common, get_trigger_app, trigger, detector, tp_infos, debug)
+    trigger_app(the_system, dro_map, daq_common, get_trigger_app, trigger, detector, tp_infos, debug)
 
     #--------------------------------------------------------------------------
     # DFO

--- a/schema/trigger/moduleleveltrigger.jsonnet
+++ b/schema/trigger/moduleleveltrigger.jsonnet
@@ -3,10 +3,14 @@ local ns = "dunedaq.trigger.moduleleveltrigger";
 local s = moo.oschema.schema(ns);
 local nc = moo.oschema.numeric_constraints;
 
+local s_hdf5rdf = import "hdf5libs/hdf5rawdatafile.jsonnet";
+local hdf5rdf = moo.oschema.hier(s_hdf5rdf).dunedaq.hdf5libs.hdf5rawdatafile;
+
 local types = {
   group_id: s.number("group_id", "i4"),
   element_id : s.number("element_id_t", "u4"),
   subsystem : s.string("subsystem_t"),
+  subdetector_name: s.string("subdetector_name_t"),
   flag : s.boolean("Boolean", doc="Option for flags, true/false"),
   candidate_type_t : s.number("candidate_type_t", "u4", doc="Candidate type"),
   time_t : s.number("time_t", "i8", doc="Time"),
@@ -48,8 +52,18 @@ local types = {
   ]),
 
   roi_conf_map: s.sequence("roi_conf_map", self.roi_group_conf),
+
+  subdetector_readout_conf: s.record("subdetector_readout_conf", [
+    s.field("subdetector",  self.subdetector_name,      default="DAQ"),
+    s.field("time_before",  self.readout_time,          default=1000, doc="Readout time before time stamp"),
+    s.field("time_after",   self.readout_time,          default=1000, doc="Readout time after time stamp"),
+  ]),
+
+  subdetector_readout_map : s.sequence("subdetector_readout_map", self.subdetector_readout_conf),
  
   conf : s.record("ConfParams", [
+      s.field("srcid_geoid_map", hdf5rdf.SrcIDGeoIDMap, doc="The Source-Geo Id map"),
+      s.field("detector_readout_map", self.subdetector_readout_map, [], doc="Custom detector readout map per sub-dector as defined in dunedaq::detdataformats::DetID::Subdetector"),
       s.field("mandatory_links", self.linkvec, doc="List of link identifiers that will be included in trigger decision"),
       s.field("groups_links", self.grouplinks, doc="List of link identifiers that may be included in trigger decision"),
       s.field("merge_overlapping_tcs", self.flag, default=true, doc="Flag to allow(true)/disable(false) merging of overlapping TCs when forming TD"),
@@ -69,4 +83,4 @@ local types = {
   
 };
 
-moo.oschema.sort_select(types, ns)
+s_hdf5rdf + moo.oschema.sort_select(types, ns)


### PR DESCRIPTION
With this PR the user can add custom subdetector readout window map for the MLT, which will set the readout window for specific subdetector -- e.g. 5ms for the PDS, but 3ms for the TPC etc.

This PR goes together with PRs:  https://github.com/DUNE-DAQ/daqconf/pull/482, https://github.com/DUNE-DAQ/fddaqconf/pull/45

In the trigger configuration, simply add something along:
```
"trigger": {
    "mlt_detector_readout_map": [
        {"subdetector": "HD_PDS", "time_before": 150000, "time_after": 150000},
        {"subdetector": "HD_CRT", "time_before": 50000, "time_after": 100000},
    ]
}
```
The above will result in the PDS readout always being 300k ticks wide, CRT always being 150k ticks wide, and all the rest (TPC, software triggers etc) will have their defaults.

This only works for the raw detector readout buffers, not e.g. trigger buffers (so effectively, only for `SourceID` with subsystem of `kDetectorReadout`).

The names of the available subdetectors are all defined inside of `detdataformats::DetID` [HERE](https://github.com/DUNE-DAQ/detdataformats/blob/11a10360c1b16fb1596793253ec90dd61bdcef95/include/detdataformats/DetID.hpp#L39-L53) and [HERE](https://github.com/DUNE-DAQ/detdataformats/blob/11a10360c1b16fb1596793253ec90dd61bdcef95/include/detdataformats/detail/DetID.hxx#L66-L95), if the user supplies wrong subdetector name the trigger application will crash at conf time with an appropriate error message.

Tests:
1. `3ru_3df_multirun_test.py` integration fully passes.
2. Offline test with custom detector map for `HD_TPC` on an asset file.
The written WIBeth fragments were of that exact window, whereas all the other fragments had windows set by the TCs (prescale trigger algorithm).