### PR TITLE
Ignoring overlap TCs (pileups) option in MLT

### DIFF
--- a/plugins/ModuleLevelTrigger.hpp
+++ b/plugins/ModuleLevelTrigger.hpp
@@ -127,6 +127,9 @@ private:
   std::atomic<bool> m_dfo_is_busy;
   std::atomic<bool> m_tc_merging;
 
+  /// @brief Ignore TCs that overlap with already made TD
+  bool m_ignore_tc_pileup;
+
   dfmessages::trigger_number_t m_last_trigger_number;
 
   dfmessages::run_number_t m_run_number;

--- a/schema/trigger/moduleleveltrigger.jsonnet
+++ b/schema/trigger/moduleleveltrigger.jsonnet
@@ -67,6 +67,7 @@ local types = {
       s.field("mandatory_links", self.linkvec, doc="List of link identifiers that will be included in trigger decision"),
       s.field("groups_links", self.grouplinks, doc="List of link identifiers that may be included in trigger decision"),
       s.field("merge_overlapping_tcs", self.flag, default=true, doc="Flag to allow(true)/disable(false) merging of overlapping TCs when forming TD"),
+      s.field("ignore_overlapping_tcs", types.flag, default=false, doc="Option to ignore consecutive overlapping TCs/pileup events. Cannot run with mlt_merge_overlapping_tcs"),
       s.field("td_out_of_timeout", self.flag, default=true, doc="Option to send TD if TC comes out of timeout window (late, overlapping already sent TD"),
       s.field("buffer_timeout", self.time_t, 100, doc="Buffering timeout [ms] for new TCs"),
       s.field("td_readout_limit", self.time_t, 1000, doc="Time limit [ms] for the length of TD readout window"),


### PR DESCRIPTION
Added an option to ignore TCs that would overlap with a TD, rather than merging them in. This should help to deal with the beam pileup events in np04. I also took the opportunity to cleanup some of the MLT code, but not by much.

This PR goes together with: https://github.com/DUNE-DAQ/daqconf/pull/483

There's now a new daqconf option, `mlt_ignore_overlapping_tcs`, set to false by default. Use it like so:

```
"trigger": {
    "mlt_ignore_overlapping_tcs": true,
    "mlt_merge_overlapping_tcs": false
}
```

Note that `mlt_merge_overlapping_tcs` has to be set to false (we cannot merge overlapping TCs and ignore them at the same time...), with an appropriate error printout at conf time if the user does try.

Tests done:
### 1. `3ru_3df_multirun_test.py` passes
### 2. Using custom trigger candidate maker with options: 
 ```  
use_custom_maker: true, 
ctcm_trigger_types: [7, 8],
ctcm_trigger_intervals: [2000, 1000],
ctcm_timestamp_method: kTimeSync
```
to make fake `HorizontalMuon` triggers spaced 2k ticks apart (window of 2k), and `MichelElectron` triggers spaced 1k ticks apart (window of 2k). Ran it in three mlt settings, 60s each:
       1. `"mlt_merge_overlapping_tcs":false, "mlt_ignore_overlapping_tcs":false` to test no merging no overlap, generated 48Mb file, lots of overlapping trigger records, all with the same window.
       2. `"mlt_merge_overlapping_tcs":false, "mlt_ignore_overlapping_tcs":true`, to test ignoring the overlapping TCs, 15Mb file, no overlapping TC records, all with the same window.
       3. `"mlt_merge_overlapping_tcs":true, "mlt_ignore_overlapping_tcs":false`, to test merging the overlapping TCs, 5.6s, no overlapping TC records (all timing), all merged into kTiming with large window.

Plots:
Trigger rate per trigger type. First run no merging no ignoring, every TC made into separate TD, `MichelElectron` at ~55Hz, `HorizontalMuon` at ~27Hz. Second run no merging but ignoring overlapping TCs, `MichelElectron` at 14Hz `HorizontalMuon` at ~5Hz. Third run, merging TCs, all merged into `Timing` trigger. In hindsight, should have removed the timing trigger...
![grafana_triggerrate_per_trigger](https://github.com/DUNE-DAQ/trigger/assets/25038499/fe885202-ee1c-4101-8ea3-bf0c30ef7e93)





Number of TCs & TDs dealt with by the MLT. In second run we see the same number of TCs going in, but drop in number of TDs made. Unfortunately, although MLT tracks number of TCs dropped (not merged, ignored), there is no Grafana display for it.
![grafana_tcreceived_to_tdsent](https://github.com/DUNE-DAQ/trigger/assets/25038499/7a77c7a8-3e73-449a-9b8c-86a41e50389b)

