### PR TITLE
Bugfixing the TAWrapper and TCWrapper

### DIFF
--- a/include/trigger/TAWrapper.hpp
+++ b/include/trigger/TAWrapper.hpp
@@ -41,7 +41,7 @@ namespace trigger {
     // comparable based on first timestamp
     bool operator<(const TAWrapper& other) const
     {
-      return this->activity.time_start < other.activity.time_start;
+      return std::tie(this->activity.time_start, this->activity.channel_start) < std::tie(other.activity.time_start, other.activity.channel_start);
     }
 
     uint64_t get_first_timestamp() const // NOLINT(build/unsigned)
@@ -67,7 +67,7 @@ namespace trigger {
 
     TAWrapper* begin()
     {
-      return this;
+      return (TAWrapper*)(activity_overlay_buffer.data());
     }
     
     TAWrapper* end()
@@ -78,7 +78,7 @@ namespace trigger {
     static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kTrigger;
     static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTriggerActivity;
     // No idea what this should really be set to
-    static const constexpr uint64_t expected_tick_difference = 16; // NOLINT(build/unsigned)
+    static const constexpr uint64_t expected_tick_difference = 1; // NOLINT(build/unsigned)
 
 };
 

--- a/include/trigger/TCWrapper.hpp
+++ b/include/trigger/TCWrapper.hpp
@@ -40,7 +40,7 @@ namespace trigger {
     // comparable based on first timestamp
     bool operator<(const TCWrapper& other) const
     {
-      return this->candidate.time_start < other.candidate.time_start;
+      return std::tie(this->candidate.time_start, this->candidate.type) < std::tie(other.candidate.time_start, other.candidate.type);
     }
 
     uint64_t get_timestamp() const // NOLINT(build/unsigned)
@@ -66,8 +66,7 @@ namespace trigger {
 
     TCWrapper* begin()
     {
-      //return candidate_overlay_buffer.data();
-      return this;
+      return (TCWrapper*)(candidate_overlay_buffer.data());
     }
     
     TCWrapper* end()
@@ -79,7 +78,7 @@ namespace trigger {
     static const constexpr daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::Subsystem::kTrigger;
     static const constexpr daqdataformats::FragmentType fragment_type = daqdataformats::FragmentType::kTriggerCandidate;
     // No idea what this should really be set to
-    static const constexpr uint64_t expected_tick_difference = 16; // NOLINT(build/unsigned)
+    static const constexpr uint64_t expected_tick_difference = 1; // NOLINT(build/unsigned)
 
 };
 } // namespace trigger


### PR DESCRIPTION
Bugfixing the TA and TC wrapper objects that are needed to insert TAs and TCs into the latency buffers.

First bugfix is the same as in v4 https://github.com/DUNE-DAQ/trigger/pull/314.
The TC and TA objects need to have expected tick-difference between adjacent TAs to be 1, rather than 16 -- because:
1. TA/TC size differs from object to object 
2. Buffer can contain TAs from different parallel streams, meaning there can be 2 TAs in the buffer that have the same timestamp (coming from different APAs, planes, algorithms etc).

Second bugfix is specific to v5, the object's `begin()` function needs to start at the beginning of the serialised vector of bits. `TAWrapper`s and `TCWrapper`s store both the object itself, and it's serialised form (should change this!), but buffers, dfo etc. only read the latter.

Tested by running the `test-session`, and using `HDF5LIBS_TestDumpRecord` on the output raw data files.
Before the bugfix the "number of TAs in TC" was nonsense.
After the bugfix it was always 1 for the prescale algorithm, which is the expected number.