### PR TITLE
Updating trigger HSISourceModel with v4 changes

### DIFF
--- a/src/trigger/HSISourceModel.hpp
+++ b/src/trigger/HSISourceModel.hpp
@@ -26,6 +26,16 @@
 
 namespace dunedaq::trigger {
 
+/**
+ * @struct HSISignal
+ * @brief Struct holding configuration for one HSI signal bit
+ */
+struct HSISignal
+{
+  triggeralgs::TriggerCandidate::Type type;
+  triggeralgs::timestamp_t time_before;
+  triggeralgs::timestamp_t time_after;
+};
 
 class HSISourceModel : public datahandlinglibs::SourceConcept
 {
@@ -36,11 +46,11 @@ public:
    * @brief SourceModel Constructor
    * @param name Instance name for this SourceModel instance
    */
-  
   HSISourceModel(): datahandlinglibs::SourceConcept() {}
   ~HSISourceModel() {}
 
-  void init(const confmodel::DaqModule* cfg) override {
+  void init(const confmodel::DaqModule* cfg) override
+  {
     if (cfg->get_outputs().size() != 1) {
       throw datahandlinglibs::InitializationError(ERS_HERE, "Only 1 output supported for subscribers");
     }
@@ -52,15 +62,40 @@ public:
     m_data_receiver = get_iom_receiver<dfmessages::HSIEvent>(cfg->get_inputs()[0]->UID());
     auto data_reader = cfg->cast<appmodel::DataSubscriberModule>();
     if (data_reader == nullptr) {
-       throw datahandlinglibs::InitializationError(ERS_HERE, "DAQ module is not a DataReader");
+      throw datahandlinglibs::InitializationError(ERS_HERE, "DAQ module is not a DataReader");
     }
     auto hsi_conf = data_reader->get_configuration()->cast<appmodel::HSI2TCTranslatorConf>();
     if (hsi_conf == nullptr) {
-	throw datahandlinglibs::InitializationError(ERS_HERE, "Missing HSI2TCTranslatorConf");
+      throw datahandlinglibs::InitializationError(ERS_HERE, "Missing HSI2TCTranslatorConf");
     }
+
+    // Get the HSI-signal to TC-output map
     for (auto win : hsi_conf->get_signals()) {
-	   m_signals[win->get_signal_type()] = std::pair<uint32_t, uint32_t>(win->get_time_before(), win->get_time_after());
+      triggeralgs::TriggerCandidate::Type tc_type;
+      tc_type = static_cast<triggeralgs::TriggerCandidate::Type>(
+          dunedaq::trgdataformats::string_to_fragment_type_value(win->get_tc_type_name()));
+
+      // Throw error if unknown TC type
+      if (tc_type == triggeralgs::TriggerCandidate::Type::kUnknown) {
+        throw datahandlinglibs::InitializationError(ERS_HERE, "Provided an unknown TC type output to HSISourceModel");
+      }
+
+      // Throw error if already exists
+      uint32_t signal = win->get_signal_type();
+      if (m_signals.count(signal)) {
+        throw datahandlinglibs::InitializationError(ERS_HERE, "Provided more than one of the same HSI signal ID input to HSISourceModel");
+      }
+
+      // Fill the signal-tctype map
+      m_signals[signal] = { tc_type,
+                            win->get_time_before(),
+                            win->get_time_after() };
+
+      TLOG() << "Will cover HSI signal id: " << signal << " to TC type: " << win->get_tc_type_name() 
+             << " window before: " << win->get_time_before() << " window after: " << win->get_time_after();
     }
+
+    m_prescale = hsi_conf->get_prescale();
   }
 
   void start() {
@@ -75,28 +110,49 @@ public:
 
   bool handle_payload(dfmessages::HSIEvent& data) // NOLINT(build/unsigned)
   {
-    TLOG_DEBUG(1) << "Received HSIEvent with signal map " << data.signal_map << " and timestamp " << data.timestamp; 
-    triggeralgs::TriggerCandidate candidate;
-    auto signal_info = m_signals.find(data.signal_map);
-    if (signal_info != m_signals.end()) {
-        // clang-format off
-        candidate.time_start = data.timestamp - signal_info->second.first;  // time_start
-        candidate.time_end   = data.timestamp + signal_info->second.second; // time_end,
-        // clang-format on    
-    } else {
-        throw dunedaq::trigger::SignalTypeError(ERS_HERE, "HSI subscriber" , data.signal_map);
+    ++m_hsievents_received;
+
+    // Prescale after n-hsi received
+    if (m_hsievents_received % m_prescale != 0) {
+      return true;
     }
-    
-    candidate.time_candidate = data.timestamp;
-    // throw away bits 31-16 of header, that's OK for now
-    candidate.detid = (uint)detdataformats::DetID::Subdetector::kDAQ ; // NOLINT(build/unsigned)
-    candidate.type = triggeralgs::TriggerCandidate::Type::kTiming;
 
-    candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
-    candidate.inputs = {};
+    TLOG_DEBUG(1) << "Received HSIEvent with signal map " << data.signal_map << " and timestamp " << data.timestamp;
 
-    if (!m_data_sender->try_send(std::move(candidate), iomanager::Sender::s_no_block)) {
-      ++m_dropped_packets;
+    // Iterate over all the signals
+    uint32_t signal_map = data.signal_map;
+    while (signal_map) {
+      // Get the index of the least significant bit
+      int bit_index = __builtin_ctzll(signal_map);
+      uint32_t signal = 1 << bit_index;
+
+      // Throw an error if we don't have this signal bit configured
+      if (!m_signals.count(signal)) {
+        throw dunedaq::trigger::SignalTypeError(ERS_HERE, "HSI subscriber" , data.signal_map);
+      }
+
+      // Create the trigger candidate
+      triggeralgs::TriggerCandidate candidate;
+      candidate.time_start = data.timestamp - m_signals[signal].time_before;
+      candidate.time_end = data.timestamp + m_signals[signal].time_after;
+      candidate.time_candidate = data.timestamp;
+      // throw away bits 31-16 of header, that's OK for now
+      candidate.detid = (uint)detdataformats::DetID::Subdetector::kDAQ ; // NOLINT(build/unsigned)
+      candidate.type = m_signals[signal].type;
+      candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kHSIEventToTriggerCandidate;
+      candidate.inputs = {};
+      ++m_tc_made;
+
+      // Send the TC
+      if (!m_data_sender->try_send(std::move(candidate), iomanager::Sender::s_no_block)) {
+        ++m_dropped_packets;
+      }
+      else {
+        ++m_tc_sent;
+      }
+
+      // Clear the least significant bit
+      signal_map &= signal_map - 1;
     }
     
     return true;
@@ -109,10 +165,17 @@ private:
   using sink_t = dunedaq::iomanager::SenderConcept<triggeralgs::TriggerCandidate>;
   std::shared_ptr<sink_t> m_data_sender;
 
-  std::map<uint32_t, std::pair<uint32_t,uint32_t>> m_signals;
+  /// @brief map of HSI signal ID bits to TC output configurations
+  std::map<uint32_t, HSISignal> m_signals;
 
   //Stats
   std::atomic<uint64_t> m_dropped_packets{0};
+  std::atomic<uint64_t> m_hsievents_received{0};
+  std::atomic<uint64_t> m_tc_made{0};
+  std::atomic<uint64_t> m_tc_sent{0};
+
+  /// @brief {rescale for the input HSIEvents, default 1
+  uint64_t m_prescale;
 };
 
 } // namespace dunedaq::trigger


### PR DESCRIPTION
This PR needs to go together with https://github.com/DUNE-DAQ/appmodel/pull/99.

`HSISourceModel` now has configurable output TC-types, can deal with scenarios where there are multiple signal bits switched on in `HSIEvent` simultaneously, and has an option for prescaling.

This can be also considered as "initial port" of CTB TCM and CIB TCM on the trigger side: since `HSISourceModel` can now output any TC-type, we can configure e.g. a separate `HSIEventToTCApplication` application, with input connection to the CTBModule (when written), and `HSIEvent` bits configured to output specific CTB TC types. The same goes for CIB.