### PR TITLE
Starting TriggerRecord trigger_number from 1

### DIFF
--- a/plugins/MLTModule.cpp
+++ b/plugins/MLTModule.cpp
@@ -31,7 +31,7 @@ namespace trigger {
 
 MLTModule::MLTModule(const std::string& name)
   : DAQModule(name)
-  , m_last_trigger_number(0)
+  , m_last_trigger_number(1)
   , m_run_number(0)
 {
   // clang-format off
@@ -113,7 +113,7 @@ MLTModule::do_start(const nlohmann::json& startobj)
 {
   m_run_number = startobj.value<dunedaq::daqdataformats::run_number_t>("run", 0);
   // We get here at start of run, so reset the trigger number
-  m_last_trigger_number = 0;
+  m_last_trigger_number = 1;
 
   // OpMon.
   m_td_msg_received_count.store(0);


### PR DESCRIPTION
This PR addresses issue https://github.com/DUNE-DAQ/trigger/issues/343.

The `trigger_number` counter is now initialized at 1, so we never get trigger_number == 0.

hdf5 dump (of the first record) before:
```
============================= TriggerRecord Header =============================
Path                          :	TriggerRecord00000.0000
Size                          :	(608, 1)
Data type                     :	int8
Marker word                   : 0x33334444
Version                       : 4
Trigger number                : 0
Trigger timestamp             : 107987227775010630 (2024-10-01 17:14:04.400170)
No. of requested components   : 17
Run number                    : 100
Error bits                    : 0
Trigger type                  : 2
Sequence number               : 0
Max sequence num              : 0
Source ID subsystem           : Unknown
Source ID                     : 4294967295
```
 and after:
 ```
 ============================= TriggerRecord Header =============================
Path                          :	TriggerRecord00001.0000
Size                          :	(608, 1)
Data type                     :	int8
Marker word                   : 0x33334444
Version                       : 4
Trigger number                : 1
Trigger timestamp             : 107987213816493432 (2024-10-01 17:10:21.063895)
No. of requested components   : 17
Run number                    : 101
Error bits                    : 0
Trigger type                  : 32
Sequence number               : 0
Max sequence num              : 0
Source ID subsystem           : Unknown
Source ID                     : 4294967295
```

And from HDF5LIBS_TestDumpRecord, 
before:
```
2024-Oct-01 17:24:57,011 LOG [main(...) at /tmp/root/spack-stage/spack-stage-hdf5libs-NB_DEV_240926_A9-zzhgcs2fr6qznzk6cgywy6wolgmwwmtk/spack-src/test/apps/HDF5LIBS_TestDumpRecord.cpp:60] 
File name: test_raw_run000100_0000_df-02_dw_0_20241001T151405.hdf5
	Recorded size from class: 1932720
	Recorded size from attribute: 1932720
Record type = TriggerRecord
2024-Oct-01 17:24:57,074 LOG [main(...) at /tmp/root/spack-stage/spack-stage-hdf5libs-NB_DEV_240926_A9-zzhgcs2fr6qznzk6cgywy6wolgmwwmtk/spack-src/test/apps/HDF5LIBS_TestDumpRecord.cpp:74] 
	Run number: 100
	File index: 0
	Creation timestamp: 1727795645508
	Writer app name: df-02_dw_0
2024-Oct-01 17:24:57,074 LOG [main(...) at /tmp/root/spack-stage/spack-stage-hdf5libs-NB_DEV_240926_A9-zzhgcs2fr6qznzk6cgywy6wolgmwwmtk/spack-src/test/apps/HDF5LIBS_TestDumpRecord.cpp:90] 
Number of records: 4
	First record: 0,0
	Last record: 9,0
2024-Oct-01 17:27:41,205 LOG [main(...) at /tmp/root/spack-stage/spack-stage-hdf5libs-NB_DEV_240926_A9-zzhgcs2fr6qznzk6cgywy6wolgmwwmtk/spack-src/test/apps/HDF5LIBS_TestDumpRecord.cpp:101] 
	TriggerRecordHeader: check_word: 33334444, version: 4, trigger_number: 0, run_number: 100, trigger_timestamp: 107987227775010630, trigger_type: 2, error_bits: 0, num_requested_components: 17, sequence_number: 0, max_sequence_number: 0, element_id: { subsystem: TR_Builder id: 2 }
```

after:
```
2024-Oct-01 17:25:53,475 LOG [main(...) at /tmp/root/spack-stage/spack-stage-hdf5libs-NB_DEV_240926_A9-zzhgcs2fr6qznzk6cgywy6wolgmwwmtk/spack-src/test/apps/HDF5LIBS_TestDumpRecord.cpp:60] 
File name: test_raw_run000101_0000_df-02_dw_0_20241001T151021.hdf5
	Recorded size from class: 2159496
	Recorded size from attribute: 2159496
Record type = TriggerRecord
2024-Oct-01 17:25:53,508 LOG [main(...) at /tmp/root/spack-stage/spack-stage-hdf5libs-NB_DEV_240926_A9-zzhgcs2fr6qznzk6cgywy6wolgmwwmtk/spack-src/test/apps/HDF5LIBS_TestDumpRecord.cpp:74] 
	Run number: 101
	File index: 0
	Creation timestamp: 1727795421945
	Writer app name: df-02_dw_0
2024-Oct-01 17:25:53,508 LOG [main(...) at /tmp/root/spack-stage/spack-stage-hdf5libs-NB_DEV_240926_A9-zzhgcs2fr6qznzk6cgywy6wolgmwwmtk/spack-src/test/apps/HDF5LIBS_TestDumpRecord.cpp:90] 
Number of records: 6
	First record: 1,0
	Last record: 16,0
2024-Oct-01 17:25:53,509 LOG [main(...) at /tmp/root/spack-stage/spack-stage-hdf5libs-NB_DEV_240926_A9-zzhgcs2fr6qznzk6cgywy6wolgmwwmtk/spack-src/test/apps/HDF5LIBS_TestDumpRecord.cpp:101] 
	TriggerRecordHeader: check_word: 33334444, version: 4, trigger_number: 1, run_number: 101, trigger_timestamp: 107987213816493432, trigger_type: 32, error_bits: 0, num_requested_components: 17, sequence_number: 0, max_sequence_number: 0, element_id: { subsystem: TR_Builder id: 2 }
```
