### PR TITLE
Modify TCMakers so that the TriggerCandidates they create can be sent

### DIFF
--- a/plugins/CustomTCMaker.cpp
+++ b/plugins/CustomTCMaker.cpp
@@ -41,7 +41,6 @@ sortbysec(const std::pair<int, dunedaq::dfmessages::timestamp_t>& a,
 }
 
 namespace dunedaq {
-DUNE_DAQ_TYPESTRING(dunedaq::trigger::TCWrapper, "TriggerCandidate")
 
 namespace trigger {
 
@@ -64,7 +63,7 @@ CustomTCMaker::init(std::shared_ptr<appfwk::ModuleConfiguration> mcfg)
   try {
     // Get the outputs
     for(auto con: mtrg->get_outputs()){
-        m_trigger_candidate_sink = get_iom_sender<trigger::TCWrapper>(con->UID());
+        m_trigger_candidate_sink = get_iom_sender<triggeralgs::TriggerCandidate>(con->UID());
     }
   } catch (const ers::Issue& excpt) {
     throw dunedaq::trigger::InvalidQueueFatalError(ERS_HERE, get_name(), "input/output", excpt);
@@ -242,9 +241,8 @@ CustomTCMaker::send_trigger_candidates()
     TLOG_DEBUG(1) << get_name() << " at timestamp " << m_timestamp_estimator->get_timestamp_estimate()
                   << ", pushing a candidate with timestamp " << candidate.time_candidate;
 
-    TCWrapper tcw(candidate);
     try {
-      m_trigger_candidate_sink->send(std::move(tcw), std::chrono::milliseconds(10));
+      m_trigger_candidate_sink->send(std::move(candidate), std::chrono::milliseconds(10));
       m_tc_sent_count++;
       m_tc_sent_count_type[m_tc_timestamps.front().first] += 1;
     } catch (const ers::Issue& e) {

--- a/plugins/CustomTCMaker.hpp
+++ b/plugins/CustomTCMaker.hpp
@@ -25,7 +25,6 @@
 #include "iomanager/Sender.hpp"
 #include "utilities/TimestampEstimator.hpp"
 #include "triggeralgs/TriggerCandidate.hpp"
-#include "trigger/TCWrapper.hpp"
 #include "trigger/opmon/customtcmaker_info.pb.h"
 
 #include <memory>
@@ -80,7 +79,7 @@ private:
 
   // Queue sources and sinks
   std::shared_ptr<iomanager::ReceiverConcept<dfmessages::TimeSync>> m_time_sync_source;
-  std::shared_ptr<iomanager::SenderConcept<trigger::TCWrapper>> m_trigger_candidate_sink;
+  std::shared_ptr<iomanager::SenderConcept<triggeralgs::TriggerCandidate>> m_trigger_candidate_sink;
 
   // Config parameters
   const appmodel::CustomTCMakerConf* m_conf;

--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -33,8 +33,6 @@
 
 namespace dunedaq {
 
-DUNE_DAQ_TYPESTRING(dunedaq::trigger::TCWrapper, "TriggerCandidate")
-
 namespace trigger {
 
 RandomTCMakerModule::RandomTCMakerModule(const std::string& name)
@@ -57,7 +55,7 @@ RandomTCMakerModule::init(std::shared_ptr<appfwk::ModuleConfiguration> mcfg)
   for(auto con: mtrg->get_outputs()){
     TLOG() << "TC sink is " << con->class_name() << "@" << con->UID();
     m_trigger_candidate_sink =
-        get_iom_sender<trigger::TCWrapper>(con->UID());
+        get_iom_sender<triggeralgs::TriggerCandidate>(con->UID());
   }
   for(auto con: mtrg->get_inputs()) {
   // Get the time sync source
@@ -214,9 +212,9 @@ RandomTCMakerModule::send_trigger_candidates()
 
     TLOG_DEBUG(1) << get_name() << " at timestamp " << m_timestamp_estimator->get_timestamp_estimate()
                   << ", pushing a candidate with timestamp " << candidate.time_candidate;
-    TCWrapper tcw(candidate);
+
     try{
-      m_trigger_candidate_sink->send(std::move(tcw), std::chrono::milliseconds(10));
+      m_trigger_candidate_sink->send(std::move(candidate), std::chrono::milliseconds(10));
       m_tc_sent_count++;
     } catch (const ers::Issue& e) {
       ers::error(e);

--- a/plugins/RandomTCMakerModule.hpp
+++ b/plugins/RandomTCMakerModule.hpp
@@ -26,7 +26,6 @@
 #include "iomanager/Sender.hpp"
 #include "utilities/TimestampEstimator.hpp"
 #include "triggeralgs/TriggerCandidate.hpp"
-#include "trigger/TCWrapper.hpp"
 #include "trigger/opmon/randomtcmaker_info.pb.h"
 
 #include <memory>
@@ -82,7 +81,7 @@ private:
 
   // Queue sources and sinks
   std::shared_ptr<iomanager::ReceiverConcept<dfmessages::TimeSync>> m_time_sync_source;
-  std::shared_ptr<iomanager::SenderConcept<trigger::TCWrapper>> m_trigger_candidate_sink;
+  std::shared_ptr<iomanager::SenderConcept<triggeralgs::TriggerCandidate>> m_trigger_candidate_sink;
 
   //randomtriggercandidatemaker::Conf m_conf;
   const appmodel::RandomTCMakerConf* m_conf;


### PR DESCRIPTION
through the DataSubscriberModule data path.