### PR TITLE
Fixing TCProcessor's high mlt-dec thread occupancy

### DIFF
--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -113,7 +113,6 @@ TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
         link->get_sid()});
   }
 
-
     // TODO: Group links!
   //m_group_links_data = conf->get_groups_links();
   parse_group_links(m_group_links_data);
@@ -304,6 +303,12 @@ void
 TCProcessor::send_trigger_decisions() {
 
  while (m_running_flag) {
+    // Free the thread for a bit if there's nothing to do...
+    if (!m_pending_tds.size()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      continue;
+    }
+
     std::lock_guard<std::mutex> lock(m_td_vector_mutex);
     auto ready_tds = get_ready_tds(m_pending_tds);
     TLOG_DEBUG(10) << "ready tds: " << ready_tds.size() << ", updated pending tds: " << m_pending_tds.size();

--- a/src/trigger/TCProcessor.hpp
+++ b/src/trigger/TCProcessor.hpp
@@ -119,6 +119,7 @@ protected:
   };
   std::vector<PendingTD> m_pending_tds;
   std::mutex m_td_vector_mutex;
+  std::condition_variable m_cv;
 
   void add_tc(const triggeralgs::TriggerCandidate tc);
   void add_tc_ignored(const triggeralgs::TriggerCandidate tc);


### PR DESCRIPTION
`mlt-dec` thread had 100% occupancy. This is reminiscent of the v4 mlt, that also always had 100% thread occupancy. 
In both cases it's because of a while loop without any `sleep_for`, so it runs at 100% non-stop. 

This fix adds a check to the TD-sending function inside the while loop, that makes the thread `sleep_for` 10ms (and therefore releasing this thread to other tasks) if there's no TDs pending.

Tested by running through drunc, checking if the data is still being saved, and `mlt-dec` now has orders of magnitude lower occupancy.

Potentially adds up to 10ms latency to the TDs being sent. Can reduce if considered too high.