### PR TITLE
Asztuc/mlt v4 to v5

### DIFF
--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -205,6 +205,13 @@ ERS_DECLARE_ISSUE(trigger,
                   "TD trigger number " << tn << " time stamp  " << ts,
                   ((uint64_t)tn) ((uint64_t)ts))
 
+ERS_DECLARE_ISSUE_BASE(trigger,
+                       MLTConfigurationProblem,
+                       appfwk::GeneralDAQModuleIssue,
+                       "Configuration error: " << item,
+                       ((std::string)name),
+                       ((std::string)item))
+
 } // namespace dunedaq
 
 #endif // TRIGGER_INCLUDE_TRIGGER_ISSUES_HPP_

--- a/plugins/MLTModule.cpp
+++ b/plugins/MLTModule.cpp
@@ -294,8 +294,16 @@ MLTModule::trigger_decisions_callback(dfmessages::TriggerDecision& decision )
 
     // Overwrite the component's readout window if we have custom
     // subdetector--readout window map
-    for ( const auto& [sourceid, window] : m_subdetector_readout_window_map ) {
+    for ( const auto& [subdetectorid, window] : m_subdetector_readout_window_map ) {
       for (auto& request: decision.components) {
+        if (request.component.subsystem != daqdataformats::SourceID::Subsystem::kDetectorReadout) {
+          continue;
+        }
+
+        if (subdetectorid != m_srcid_detid_map[request.component]) {
+          continue;
+        }
+
         request.window_begin = decision.trigger_timestamp - window.first;
         request.window_end = decision.trigger_timestamp + window.second;
       }

--- a/plugins/MLTModule.hpp
+++ b/plugins/MLTModule.hpp
@@ -26,10 +26,13 @@
 #include "appmodel/TCReadoutMap.hpp"
 #include "appmodel/ROIGroupConf.hpp"
 #include "appmodel/SourceIDConf.hpp"
+#include "appmodel/SubdetectorReadoutWindowMap.hpp"
 
 #include "confmodel/Connection.hpp"
+#include "confmodel/GeoId.hpp"
 
 #include "daqdataformats/SourceID.hpp"
+#include "hdf5libs/HDF5RawDataFile.hpp"
 #include "dfmessages/TriggerDecision.hpp"
 #include "dfmessages/TriggerDecisionToken.hpp"
 #include "dfmessages/TriggerInhibit.hpp"
@@ -57,6 +60,7 @@ namespace trigger {
 class MLTModule : public dunedaq::appfwk::DAQModule
 {
 public:
+  typedef dunedaq::detdataformats::DetID::Subdetector SubdetectorID;
   /**
    * @brief MLTModule Constructor
    * @param name Instance name for this MLTModule instance
@@ -80,6 +84,8 @@ private:
 
   void trigger_decisions_callback(dfmessages::TriggerDecision& decision);
   void dfo_busy_callback(dfmessages::TriggerInhibit& inhibit);
+
+  std::map<std::string, int> decode_geoid(uint64_t _geoid_int);
 
   // Queue sources and sinks
   std::shared_ptr<iomanager::ReceiverConcept<dfmessages::TriggerDecision>> m_decision_input;
@@ -206,6 +212,14 @@ private:
   bool m_ignoring_tc_types;
   bool check_trigger_type_ignore(unsigned int tc_type);
   */
+
+  /// @brief SourceID -- SubdetectorID map
+  std::map<dfmessages::SourceID, SubdetectorID> m_srcid_detid_map;
+
+  /// @brief Subdetector--readout-window map config
+  std::map<SubdetectorID, std::pair<triggeralgs::timestamp_t, triggeralgs::timestamp_t>>
+    m_subdetector_readout_window_map;
+
   // Opmon variables
   using metric_counter_type = uint64_t ; //decltype(moduleleveltriggerinfo::Info::tc_received_count);
   std::atomic<metric_counter_type> m_td_msg_received_count{ 0 };

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -130,8 +130,9 @@ TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
 
   m_hsi_passthrough = proc_conf->get_hsi_trigger_type_passthrough();
   m_tc_merging        = proc_conf->get_merge_overlapping_tcs();
+  m_ignore_tc_pileup = proc_conf->get_ignore_overlapping_tcs();
   m_buffer_timeout    = proc_conf->get_buffer_timeout();
-  m_send_timed_out_tds = proc_conf->get_td_out_of_timeout();
+  m_send_timed_out_tds = (m_ignore_tc_pileup) ? false : proc_conf->get_td_out_of_timeout();
   m_td_readout_limit  = proc_conf->get_td_readout_limit();
   m_ignored_tc_types = proc_conf->get_ignore_tc();
   m_ignoring_tc_types = (m_ignored_tc_types.size() > 0) ? true : false;
@@ -139,6 +140,7 @@ TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
   m_use_roi_readout   = proc_conf->get_use_roi_readout();
   m_use_bitwords      = proc_conf->get_use_bitwords();
   TLOG_DEBUG(3) << "Allow merging: " << m_tc_merging;
+  TLOG_DEBUG(3) << "Ignore pileup: " << m_ignore_tc_pileup;
   TLOG_DEBUG(3) << "Buffer timeout: " << m_buffer_timeout;
   TLOG_DEBUG(3) << "Should send timed out TDs: " << m_send_timed_out_tds;
   TLOG_DEBUG(3) << "TD readout limit: " << m_td_readout_limit;
@@ -365,55 +367,71 @@ TCProcessor::call_tc_decision(const TCProcessor::PendingTD& pending_td)
 void
 TCProcessor::add_tc(const triggeralgs::TriggerCandidate tc)
 {
-  bool added_to_existing = false;
+  bool tc_dealt = false;
   int64_t tc_wallclock_arrived =
     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
 
-  if (m_tc_merging) {
+  if (m_tc_merging || m_ignore_tc_pileup) {
 
     for (std::vector<PendingTD>::iterator it = m_pending_tds.begin(); it != m_pending_tds.end();) {
-      if (check_overlap(tc, *it)) {
-        it->contributing_tcs.push_back(tc);
-        if ( (m_use_readout_map) && (m_readout_window_map.count(tc.type)) ){
-          TLOG_DEBUG(3) << "TC with start/end times " << tc.time_candidate - m_readout_window_map[tc.type].first << "/"
-                        << tc.time_candidate + m_readout_window_map[tc.type].second
-                        << " overlaps with pending TD with start/end times " << it->readout_start << "/"
-                        << it->readout_end;
-          it->readout_start = ((tc.time_candidate - m_readout_window_map[tc.type].first) >= it->readout_start)
-                                ? it->readout_start
-                                : (tc.time_candidate - m_readout_window_map[tc.type].first);
-          it->readout_end = ((tc.time_candidate + m_readout_window_map[tc.type].second) >= it->readout_end)
-                              ? (tc.time_candidate + m_readout_window_map[tc.type].second)
-                              : it->readout_end;
-        } else {
-          TLOG_DEBUG(3) << "TC with start/end times " << tc.time_start << "/" << tc.time_end
-                        << " overlaps with pending TD with start/end times " << it->readout_start << "/"
-                        << it->readout_end;
-          it->readout_start = (tc.time_start >= it->readout_start) ? it->readout_start : tc.time_start;
-          it->readout_end = (tc.time_end >= it->readout_end) ? tc.time_end : it->readout_end;
-        }
-        it->walltime_expiration = tc_wallclock_arrived + m_buffer_timeout;
-        added_to_existing = true;
+      // Don't deal with TC here if there's no overlap
+      if (!check_overlap(tc, *it)) {
+        it++;
+        continue;
+      }
+
+      // If overlap and ignoring, we drop the TC and flag it as dealt with.
+      if (m_ignore_tc_pileup) {
+        m_tds_dropped_tc_count++;
+        tc_dealt = true;
+        TLOG_DEBUG(3) << "TC overlapping with a previous TD, dropping!";
         break;
       }
-      ++it;
+
+      // If we're here, TC merging must be on, in which case we're actually
+      // going to merge the TC into the TD.    
+      it->contributing_tcs.push_back(tc);
+      if ( (m_use_readout_map) && (m_readout_window_map.count(tc.type)) ){
+        TLOG_DEBUG(3) << "TC with start/end times " << tc.time_candidate - m_readout_window_map[tc.type].first << "/"
+                      << tc.time_candidate + m_readout_window_map[tc.type].second
+                      << " overlaps with pending TD with start/end times " << it->readout_start << "/"
+                      << it->readout_end;
+        it->readout_start = ((tc.time_candidate - m_readout_window_map[tc.type].first) >= it->readout_start)
+                              ? it->readout_start
+                              : (tc.time_candidate - m_readout_window_map[tc.type].first);
+        it->readout_end = ((tc.time_candidate + m_readout_window_map[tc.type].second) >= it->readout_end)
+                            ? (tc.time_candidate + m_readout_window_map[tc.type].second)
+                            : it->readout_end;
+      } else {
+        TLOG_DEBUG(3) << "TC with start/end times " << tc.time_start << "/" << tc.time_end
+                      << " overlaps with pending TD with start/end times " << it->readout_start << "/"
+                      << it->readout_end;
+        it->readout_start = (tc.time_start >= it->readout_start) ? it->readout_start : tc.time_start;
+        it->readout_end = (tc.time_end >= it->readout_end) ? tc.time_end : it->readout_end;
+      }
+      it->walltime_expiration = tc_wallclock_arrived + m_buffer_timeout;
+      tc_dealt = true;
+      break;
     }
   }
 
-  if (!added_to_existing) {
-    PendingTD td_candidate;
-    td_candidate.contributing_tcs.push_back(tc);
-    if ( (m_use_readout_map) && (m_readout_window_map.count(tc.type)) ){
-      td_candidate.readout_start = tc.time_candidate - m_readout_window_map[tc.type].first;
-      td_candidate.readout_end = tc.time_candidate + m_readout_window_map[tc.type].second;
-    } else {
-      td_candidate.readout_start = tc.time_start;
-      td_candidate.readout_end = tc.time_end;
-    }
-    td_candidate.walltime_expiration = tc_wallclock_arrived + m_buffer_timeout;
-    m_pending_tds.push_back(td_candidate);
+  // Don't do anything else if we've already dealt with the TC
+  if (tc_dealt) {
+    return;
   }
-  return;
+
+  // Create a new TD out of the TC
+  PendingTD td_candidate;
+  td_candidate.contributing_tcs.push_back(tc);
+  if ( (m_use_readout_map) && (m_readout_window_map.count(tc.type)) ){
+    td_candidate.readout_start = tc.time_candidate - m_readout_window_map[tc.type].first;
+    td_candidate.readout_end = tc.time_candidate + m_readout_window_map[tc.type].second;
+  } else {
+    td_candidate.readout_start = tc.time_start;
+    td_candidate.readout_end = tc.time_end;
+  }
+  td_candidate.walltime_expiration = tc_wallclock_arrived + m_buffer_timeout;
+  m_pending_tds.push_back(td_candidate);
 }
 
 void

--- a/src/trigger/TCProcessor.hpp
+++ b/src/trigger/TCProcessor.hpp
@@ -103,6 +103,9 @@ protected:
   std::atomic<bool> m_hsi_passthrough;
   std::atomic<bool> m_tc_merging;
 
+  /// @brief Ignore TCs that overlap with already made TD
+  bool m_ignore_tc_pileup;
+
   dfmessages::trigger_number_t m_last_trigger_number;
 
   dfmessages::run_number_t m_run_number;


### PR DESCRIPTION
This PR has to go together with https://github.com/DUNE-DAQ/appmodel/pull/143

Porting MLT changes from v4 to v5:
* Ignoring overlaps between TCs, to deal with pileups in PD2
* Configurable readout windows for different sub-detectors, enabling wider readout window for the PDS than TPC

Tested by running offline with custom readout map expanding TPC (but not TA/TP/Trigger data), and with high rates but ignoring overlaps.