### PR TITLE
RandomTCMaker overhaul

### DIFF
--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -44,6 +44,7 @@ RandomTCMakerModule::RandomTCMakerModule(const std::string& name)
   register_command("start", &RandomTCMakerModule::do_start);
   register_command("stop_trigger_sources", &RandomTCMakerModule::do_stop);
   register_command("scrap", &RandomTCMakerModule::do_scrap);
+  register_command("change_rate", &RandomTCMakerModule::do_change_trigger_rate);
 }
 
 void
@@ -61,7 +62,17 @@ RandomTCMakerModule::init(std::shared_ptr<appfwk::ModuleConfiguration> mcfg)
      m_time_sync_source = get_iom_receiver<dfmessages::TimeSync>(con->UID());
   }
   m_conf = mtrg->get_configuration();
+
+  // Get the TC out configuration
+  m_tc_readout = m_conf->get_tc_readout();
+
   m_latency_monitoring.store( m_conf->get_latency_monitoring() );
+
+  // Get the clock speed from detector configuration
+  m_clock_speed_hz = mcfg->configuration_manager()->session()->get_detector_configuration()->get_clock_speed_hz();
+  m_trigger_rate_hz = m_conf->get_trigger_rate_hz();
+  TLOG() << "Clock speed is: " << m_clock_speed_hz;
+  TLOG() << "Output trigger rate is: " << m_trigger_rate_hz;
 }
 
 void
@@ -105,31 +116,26 @@ RandomTCMakerModule::do_start(const nlohmann::json& obj)
   std::string timestamp_method = m_conf->get_timestamp_method();
   if (timestamp_method == "kTimeSync") {
     TLOG_DEBUG(0) << "Creating TimestampEstimator";
-    m_timestamp_estimator.reset(new utilities::TimestampEstimator(m_run_number, m_conf->get_clock_frequency_hz()));
+    m_timestamp_estimator.reset(new utilities::TimestampEstimator(m_run_number, m_clock_speed_hz));
     m_time_sync_source->add_callback(std::bind(&utilities::TimestampEstimator::timesync_callback<dfmessages::TimeSync>,
           reinterpret_cast<utilities::TimestampEstimator*>(m_timestamp_estimator.get()),
           std::placeholders::_1));
   }
   else if(timestamp_method == "kSystemClock"){
     TLOG_DEBUG(0) << "Creating TimestampEstimatorSystem";
-    m_timestamp_estimator.reset(new utilities::TimestampEstimatorSystem(m_conf->get_clock_frequency_hz()));
+    m_timestamp_estimator.reset(new utilities::TimestampEstimatorSystem(m_clock_speed_hz));
   }
   else{
     // TODO: write some error message
   }
-  //switch (m_conf->get_timestamp_method()) {
-  //  case randomtriggercandidatemaker::timestamp_estimation::kTimeSync:
-  //    TLOG_DEBUG(0) << "Creating TimestampEstimator";
-  //    m_timestamp_estimator.reset(new utilities::TimestampEstimator(m_run_number, m_conf->get_clock_frequency_hz()));
-  //    m_time_sync_source->add_callback(std::bind(&utilities::TimestampEstimator::timesync_callback<dfmessages::TimeSync>,
-  //                                               reinterpret_cast<utilities::TimestampEstimator*>(m_timestamp_estimator.get()),
-  //                                               std::placeholders::_1));
-  //    break;
-  //  case randomtriggercandidatemaker::timestamp_estimation::kSystemClock:
-  //    TLOG_DEBUG(0) << "Creating TimestampEstimatorSystem";
-  //    m_timestamp_estimator.reset(new utilities::TimestampEstimatorSystem(m_conf->get_clock_frequency_hz()));
-  //    break;
-  //}
+
+  // Check if the trigger rate was changed in the starting parameters, and set it if so
+  auto start_params = obj.get<rcif::cmd::StartParams>();
+  if (start_params.trigger_rate > 0) {
+    TLOG() << " Changing rate: trigger_rate "
+      << start_params.trigger_rate;
+    m_trigger_rate_hz = start_params.trigger_rate;
+  }
 
   m_send_trigger_candidates_thread = std::thread(&RandomTCMakerModule::send_trigger_candidates, this);
   pthread_setname_np(m_send_trigger_candidates_thread.native_handle(), "random-tc-maker");
@@ -154,15 +160,32 @@ RandomTCMakerModule::do_scrap(const nlohmann::json& /*obj*/)
   m_configured_flag.store(false);
 }
 
+
+void
+RandomTCMakerModule::do_change_trigger_rate(const nlohmann::json& obj)
+{
+  auto change_rate_params = obj.get<rcif::cmd::ChangeRateParams>();
+
+  TLOG() << "Changing trigger rate from " << m_trigger_rate_hz << " to " << change_rate_params.trigger_rate;
+
+  m_trigger_rate_hz = change_rate_params.trigger_rate;
+}
+
 triggeralgs::TriggerCandidate
 RandomTCMakerModule::create_candidate(dfmessages::timestamp_t timestamp)
 {
   triggeralgs::TriggerCandidate candidate;
-  candidate.time_start = (timestamp - 1000);
-  candidate.time_end = (timestamp + 1000);
+  candidate.time_start = (timestamp - m_tc_readout->get_time_before());
+  candidate.time_end = (timestamp + m_tc_readout->get_time_after());
   candidate.time_candidate = timestamp;
   candidate.detid = { 0 };
-  candidate.type = triggeralgs::TriggerCandidate::Type::kRandom;
+  candidate.type = static_cast<triggeralgs::TriggerCandidate::Type>(m_tc_readout->get_candidate_type());
+
+  // Throw error if unknown TC type
+  if (candidate.type == triggeralgs::TriggerCandidate::Type::kUnknown) {
+            throw InvalidConfiguration(ERS_HERE);
+  }
+
   // TODO: Originally kHSIEventToTriggerCandidate
   candidate.algorithm = triggeralgs::TriggerCandidate::Algorithm::kCustom;
 
@@ -174,27 +197,19 @@ RandomTCMakerModule::get_interval(std::mt19937& gen)
 {
   std::string time_distribution = m_conf->get_time_distribution();
 
+  int interval = m_trigger_rate_hz * m_clock_speed_hz;
+
   if( time_distribution == "kUniform"){
-    return m_conf->get_trigger_interval_ticks();
+    return interval;
   }
   else if(time_distribution == "kPoisson"){
-    std::exponential_distribution<double> d(1.0 / m_conf->get_trigger_interval_ticks());
+    std::exponential_distribution<double> d(1.0 / interval);
     return static_cast<int>(0.5 + d(gen));
   }
   else{
     TLOG_DEBUG(1) << get_name() << " unknown distribution! Using kUniform.";
   }
-  return m_conf->get_trigger_interval_ticks();
-  //switch (m_conf->get_time_distribution()) {
-  //  default: // Treat an unknown distribution as kUniform, but warn
-  //    TLOG_DEBUG(1) << get_name() << " unknown distribution! Using kUniform.";
-  //    // fall through
-  //  case randomtriggercandidatemaker::distribution_type::kUniform:
-  //    return m_conf->get_trigger_interval_ticks();
-  //  case randomtriggercandidatemaker::distribution_type::kPoisson:
-  //    std::exponential_distribution<double> d(1.0 / m_conf->get_trigger_interval_ticks());
-  //    return static_cast<int>(0.5 + d(gen));
-  //}
+  return interval;
 }
 
 void

--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -229,6 +229,14 @@ RandomTCMakerModule::send_trigger_candidates()
   TLOG_DEBUG(1) << get_name() << " initial timestamp estimate is " << initial_timestamp;
 
   while (m_running_flag.load()) {
+    // If trigger rate is 0, just sleep. Need to use small number here because
+    // of floating point precision...
+    constexpr float epsilon = 1e-9;
+    if ( m_trigger_rate_hz.load() <= epsilon) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      continue;
+    }
+
     if (m_timestamp_estimator->wait_for_timestamp(next_trigger_timestamp, m_running_flag) ==
         utilities::TimestampEstimatorBase::kInterrupted) {
       break;

--- a/plugins/RandomTCMakerModule.hpp
+++ b/plugins/RandomTCMakerModule.hpp
@@ -12,9 +12,12 @@
 #include "appfwk/DAQModule.hpp"
 #include "appfwk/ModuleConfiguration.hpp"
 #include "confmodel/Connection.hpp"
+#include "confmodel/Session.hpp"
+#include "confmodel/DetectorConfig.hpp"
 
 #include "appmodel/RandomTCMakerConf.hpp"
 #include "appmodel/RandomTCMakerModule.hpp"
+#include "appmodel/TCReadoutMap.hpp"
 
 #include "daqdataformats/SourceID.hpp"
 #include "dfmessages/TimeSync.hpp"
@@ -29,6 +32,8 @@
 #include "trigger/Latency.hpp"
 #include "trigger/opmon/randomtcmaker_info.pb.h"
 #include "trigger/opmon/latency_info.pb.h"
+
+#include "rcif/cmd/Nljs.hpp"
 
 #include <memory>
 #include <random>
@@ -73,6 +78,13 @@ private:
   void do_stop(const nlohmann::json& obj);
   void do_scrap(const nlohmann::json& obj);
 
+  /**
+   * @brief Command function to change the output trigger rate
+   *
+   * @param obj descriprice json object with the ChangeRateParams
+   */
+  void do_change_trigger_rate(const nlohmann::json& obj);
+
   void send_trigger_candidates();
   std::thread m_send_trigger_candidates_thread;
 
@@ -87,6 +99,13 @@ private:
 
   //randomtriggercandidatemaker::Conf m_conf;
   const appmodel::RandomTCMakerConf* m_conf;
+  const appmodel::TCReadoutMap* m_tc_readout;
+
+  /// @brief Clock speed in hz, taken from detector configuration
+  uint64_t m_clock_speed_hz;
+
+  /// @brief Output trigger rate in hz
+  std::atomic<float> m_trigger_rate_hz{ 0 };
 
   int get_interval(std::mt19937& gen);
 


### PR DESCRIPTION
This PR needs to be merged together with:
1. https://github.com/DUNE-DAQ/appmodel/pull/146
2. https://github.com/DUNE-DAQ/daqsystemtest/pull/132
3. https://github.com/DUNE-DAQ/drunc/pull/261

A small overhaul of `RandomTCMaker`:
1. The maker now accepts `trigger_rate_hz` rather than `trigger_interval_ticks`
5. New function `do_change_trigger_rate` that will be triggered when user enters `change-rate` in `drunc` live session to change the trigger rate live.
6. More configurable: the TC maker now accepts `TCReadoutMap` configuration object, where user can specify the TC window (time before and time after) as well as the output TC type (in integer for now, will be in string later, e.g. kRandom, kTiming, kSupernova etc).
7. The clock speed is now pulled directly from the "session", rather than having to be manually added in the configuration.

Tested by:
1. Running with current `drunc` automatically sets the trigger rate to 1 as expected given the current drunc dev.
2. Running with https://github.com/DUNE-DAQ/drunc/pull/261 doesn't override the trigger rate at `do_start`.
3. Can change trigger rate live with https://github.com/DUNE-DAQ/drunc/pull/261 and https://github.com/DUNE-DAQ/daqsystemtest/pull/127
4. Checked the output raw data file to make sure the trigger rates were as expected for all the runs above.
8. Changed the output TC type to `kSupernova` to see if the new config works.