### PR TITLE
Reworking TC-type configs

### DIFF
--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -28,7 +28,7 @@
 
 namespace dunedaq {
 
-ERS_DECLARE_ISSUE(trigger, InvalidConfiguration, "An invalid configuration object was received", ERS_EMPTY)
+ERS_DECLARE_ISSUE(trigger, InvalidConfiguration, "Invalid configuration error:" << conferror, ((std::string)conferror))
 ERS_DECLARE_ISSUE(trigger, TriggerActive, "Trigger is active now", ERS_EMPTY)
 ERS_DECLARE_ISSUE(trigger, TriggerPaused, "Trigger is paused", ERS_EMPTY)
 ERS_DECLARE_ISSUE(trigger, TriggerInhibited, "Trigger is inhibited in run " << runno, ((int64_t)runno))

--- a/integtest/td_leakage_between_runs_test.py
+++ b/integtest/td_leakage_between_runs_test.py
@@ -53,20 +53,19 @@ conf_dict["trigger"]["ctcm_timestamp_method"] = "kTimeSync"
 conf_dict["trigger"]["mlt_merge_overlapping_tcs"] = True
 conf_dict["trigger"]["mlt_send_timed_out_tds"] = True
 conf_dict["trigger"]["mlt_buffer_timeout"] = 1000
-conf_dict["trigger"]["mlt_use_readout_map"] = True
 conf_dict["trigger"]["mlt_td_readout_map"] = []
 rmap_conf = {}
-rmap_conf["candidate_type"] = 1
+rmap_conf["tc_type_name"] = "kTiming"
 rmap_conf["time_before"] = readout_window_time_before
 rmap_conf["time_after"] = readout_window_time_after
 conf_dict["trigger"]["mlt_td_readout_map"].append(rmap_conf)
 rmap_conf = {}
-rmap_conf["candidate_type"] = 2
+rmap_conf["tc_type_name"] = "kTPCLowE"
 rmap_conf["time_before"] = readout_window_time_before
 rmap_conf["time_after"] = readout_window_time_after
 conf_dict["trigger"]["mlt_td_readout_map"].append(rmap_conf)
 rmap_conf = {}
-rmap_conf["candidate_type"] = 3
+rmap_conf["tc_type_name"] = "kSupernova"
 rmap_conf["time_before"] = readout_window_time_before
 rmap_conf["time_after"] = readout_window_time_after
 conf_dict["trigger"]["mlt_td_readout_map"].append(rmap_conf)

--- a/plugins/RandomTCMakerModule.hpp
+++ b/plugins/RandomTCMakerModule.hpp
@@ -72,6 +72,7 @@ public:
   void generate_opmon_data() override;
 
 private:
+  using TCType = triggeralgs::TriggerCandidate::Type;
   // Commands
   void do_configure(const nlohmann::json& obj);
   void do_start(const nlohmann::json& obj);
@@ -97,9 +98,17 @@ private:
   std::shared_ptr<iomanager::ReceiverConcept<dfmessages::TimeSync>> m_time_sync_source;
   std::shared_ptr<iomanager::SenderConcept<triggeralgs::TriggerCandidate>> m_trigger_candidate_sink;
 
-  //randomtriggercandidatemaker::Conf m_conf;
   const appmodel::RandomTCMakerConf* m_conf;
-  const appmodel::TCReadoutMap* m_tc_readout;
+
+  /// @brief Output TC type
+  TCType m_tcout_type;
+  /// @brief Output window start time, based off trigger timestamp
+  dfmessages::timestamp_t m_tcout_time_before;
+  /// @brief Output window end time, based off trigger timestamp
+  dfmessages::timestamp_t m_tcout_time_after;
+
+
+
 
   /// @brief Clock speed in hz, taken from detector configuration
   uint64_t m_clock_speed_hz;

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -134,31 +134,31 @@ TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
   m_send_timed_out_tds = (m_ignore_tc_pileup) ? false : proc_conf->get_td_out_of_timeout();
   m_td_readout_limit  = proc_conf->get_td_readout_limit();
   m_ignored_tc_types = proc_conf->get_ignore_tc();
-  m_ignoring_tc_types = (m_ignored_tc_types.size() > 0) ? true : false;
-  m_use_readout_map   = proc_conf->get_use_readout_map();
-  m_use_roi_readout   = proc_conf->get_use_roi_readout();
+  m_ignoring_tc_types = !m_ignored_tc_types.empty();
   m_use_bitwords      = proc_conf->get_use_bitwords();
   TLOG_DEBUG(3) << "Allow merging: " << m_tc_merging;
   TLOG_DEBUG(3) << "Ignore pileup: " << m_ignore_tc_pileup;
   TLOG_DEBUG(3) << "Buffer timeout: " << m_buffer_timeout;
   TLOG_DEBUG(3) << "Should send timed out TDs: " << m_send_timed_out_tds;
   TLOG_DEBUG(3) << "TD readout limit: " << m_td_readout_limit;
-  TLOG_DEBUG(3) << "Use ROI readout?: " << m_use_roi_readout;
 
   // ROI map
-  if(m_use_roi_readout){
-    m_roi_conf_data = proc_conf->get_roi_group_conf();
+  m_roi_conf_data = proc_conf->get_roi_group_conf();
+  m_use_roi_readout = !m_roi_conf_data.empty();
+  if (m_use_roi_readout) {
     parse_roi_conf(m_roi_conf_data);
     print_roi_conf(m_roi_conf);
   }
+  TLOG_DEBUG(3) << "Use ROI readout?: " << m_use_roi_readout;
 
   // Custom readout map
-  TLOG_DEBUG(3) << "Use readout map: " << m_use_readout_map;
-  if(m_use_readout_map){
-    m_readout_window_map_data = proc_conf->get_tc_readout_map();
+  m_readout_window_map_data = proc_conf->get_tc_readout_map();
+  m_use_readout_map = !m_readout_window_map_data.empty();
+  if (m_use_readout_map) {
     parse_readout_map(m_readout_window_map_data);
     print_readout_map(m_readout_window_map);
   }
+  TLOG_DEBUG(3) << "Use readout map: " << m_use_readout_map;
 
   // Ignoring TC types
   TLOG_DEBUG(3) << "Ignoring TC types: " << m_ignoring_tc_types;

--- a/src/trigger/TCProcessor.hpp
+++ b/src/trigger/TCProcessor.hpp
@@ -59,7 +59,8 @@ protected:
 
   void make_td(const TCWrapper* tc);
 
-  private:
+private:
+  using TCType = triggeralgs::TriggerCandidate::Type;
   void send_trigger_decisions();
   std::thread m_send_trigger_decisions_thread;
 
@@ -156,10 +157,10 @@ protected:
   // Readout map config
   bool m_use_readout_map;
   std::vector<const appmodel::TCReadoutMap*>  m_readout_window_map_data;
-  std::map<trgdataformats::TriggerCandidateData::Type, std::pair<triggeralgs::timestamp_t, triggeralgs::timestamp_t>>
+  std::map<TCType, std::pair<triggeralgs::timestamp_t, triggeralgs::timestamp_t>>
     m_readout_window_map;
   void parse_readout_map(const std::vector<const appmodel::TCReadoutMap*>& data);
-  void print_readout_map(std::map<trgdataformats::TriggerCandidateData::Type,
+  void print_readout_map(std::map<TCType,
                                   std::pair<triggeralgs::timestamp_t, triggeralgs::timestamp_t>> map);
 
   // Create the next trigger decision


### PR DESCRIPTION
This PR has to go together with:
1. https://github.com/DUNE-DAQ/appmodel/pull/150
2. https://github.com/DUNE-DAQ/daqsystemtest/pull/136

Done:
1. Reworked `TCProcessor` and `RandomTCMaker` configurations to use string-based TC-type inputs, rather than integer-based.
2. Removed `use_readout_map` and `use_roi_readout` from configuration inputs: now assumed to be `True` if readout map or roi map is provided.
3. Changed Trigger configuration error message.

Tests:
1. Compiles.
2. `pytest -s ${DAQSYSTEMTEST_SHARE}/integtest/3ru_3df_multirun_test.py` runs
3. Changed TC-types in the configurations, ran a test session, and confirmed correct outputs with `HDF5LIBS_TestDumpRecord`.