### PR TITLE
Unit Tests for trigger object behavior in buffers/requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ daq_add_application( generate_tpset_from_hdf5 generate_tpset_from_hdf5.cxx TEST 
 #daq_add_unit_test(TriggerZipper_test             LINK_LIBRARIES trigger)
 #daq_add_unit_test(TriggerObjectOverlay_test      LINK_LIBRARIES trigger)
 #daq_add_unit_test(AlgorithmPlugins_test          LINK_LIBRARIES trigger)
+daq_add_unit_test(TriggerTypeAdapters_test        LINK_LIBRARIES trigger)
 
 ##############################################################################
 

--- a/include/trigger/TAWrapper.hpp
+++ b/include/trigger/TAWrapper.hpp
@@ -14,19 +14,21 @@
 #include "triggeralgs/TriggerObjectOverlay.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
 #include "triggeralgs/TriggerActivity.hpp"
-#include "trigger/Issues.hpp"
 
 namespace dunedaq {
 namespace trigger {
   struct TAWrapper
   {
+
+    using FrameType = TAWrapper;
+
     triggeralgs::TriggerActivity activity;
     std::vector<uint8_t> activity_overlay_buffer;
     
     // Don't really want this default ctor, but IterableQueueModel requires it
-    TAWrapper() {}
+    //TAWrapper() {}
     
-    TAWrapper(triggeralgs::TriggerActivity a)
+    TAWrapper(triggeralgs::TriggerActivity a = triggeralgs::TriggerActivity())
       : activity(a)
     {
       populate_buffer();
@@ -52,6 +54,12 @@ namespace trigger {
     void set_timestamp(uint64_t ts) // NOLINT(build/unsigned)
     {
       activity.time_start = ts;
+    }
+
+    void fake_timestamps(uint64_t first_timestamp, uint64_t /*offset */ = 0) // NOLINT(build/unsigned)
+    {
+      activity.time_start = first_timestamp;
+      populate_buffer();
     }
 
     size_t get_payload_size() { return activity_overlay_buffer.size(); }

--- a/include/trigger/TCWrapper.hpp
+++ b/include/trigger/TCWrapper.hpp
@@ -14,18 +14,18 @@
 #include "triggeralgs/TriggerObjectOverlay.hpp"
 #include "triggeralgs/TriggerActivity.hpp"
 #include "triggeralgs/TriggerCandidate.hpp"
-#include "trigger/Issues.hpp"
 
 namespace dunedaq {
 namespace trigger {
     struct TCWrapper
   {
+    using FrameType = TCWrapper;
     triggeralgs::TriggerCandidate candidate;
     std::vector<uint8_t> candidate_overlay_buffer;
     // Don't really want this default ctor, but IterableQueueModel requires it
-    TCWrapper() {}
+    //TCWrapper() {}
     
-    TCWrapper(triggeralgs::TriggerCandidate c)
+    TCWrapper(triggeralgs::TriggerCandidate c = triggeralgs::TriggerCandidate())
       : candidate(c)
     {
       populate_buffer();
@@ -51,6 +51,12 @@ namespace trigger {
     void set_timestamp(uint64_t ts) // NOLINT(build/unsigned)
     {
       candidate.time_start = ts;
+    }
+
+    void fake_timestamps(uint64_t first_timestamp, uint64_t /*offset */ = 0) // NOLINT(build/unsigned)
+    {
+      candidate.time_start = first_timestamp;
+      populate_buffer();
     }
 
     size_t get_payload_size() { return candidate_overlay_buffer.size(); }

--- a/include/trigger/TriggerPrimitiveTypeAdapter.hpp
+++ b/include/trigger/TriggerPrimitiveTypeAdapter.hpp
@@ -38,7 +38,7 @@ struct TriggerPrimitiveTypeAdapter
     tp.time_start = ts;
   }
 
-  void fake_timestamps(uint64_t first_timestamp, uint64_t /*offset = 25*/) // NOLINT(build/unsigned)
+  void fake_timestamps(uint64_t first_timestamp, uint64_t /*offset */ = 0) // NOLINT(build/unsigned)
   {
     tp.time_start = first_timestamp;
   }

--- a/unittest/TriggerTypeAdapters_test.cxx
+++ b/unittest/TriggerTypeAdapters_test.cxx
@@ -1,0 +1,64 @@
+/**
+ * @file TriggerTypeAdapters_test.cxx
+ *
+ * Unittest for testing lower bound and request handling on trigger type adapters/wrappers.
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2022.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#define BOOST_TEST_MODULE TriggerTypeAdapters_test // NOLINT
+
+#include "trigger/TriggerPrimitiveTypeAdapter.hpp"
+#include "trigger/TAWrapper.hpp"
+#include "trigger/TCWrapper.hpp"
+
+#include "datahandlinglibs/testutils/TestUtilities.hpp"
+#include "datahandlinglibs/models/SkipListLatencyBufferModel.hpp"
+
+#include "boost/test/unit_test.hpp"
+
+BOOST_AUTO_TEST_SUITE(TriggerTypeAdapters_test)
+
+BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_TriggerPrimitiveTypeAdapter_TestQueue)
+{
+    dunedaq::datahandlinglibs::test::test_queue_model<
+            dunedaq::datahandlinglibs::SkipListLatencyBufferModel,
+            dunedaq::trigger::TriggerPrimitiveTypeAdapter>();
+}
+BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_TriggerPrimitiveTypeAdapter_TestRequest)
+{
+    dunedaq::datahandlinglibs::test::test_request_model<
+            dunedaq::datahandlinglibs::SkipListLatencyBufferModel,
+            dunedaq::trigger::TriggerPrimitiveTypeAdapter>();
+}
+
+BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_TAWrapper_TestQueue)
+{
+    dunedaq::datahandlinglibs::test::test_queue_model<
+            dunedaq::datahandlinglibs::SkipListLatencyBufferModel,
+            dunedaq::trigger::TAWrapper>();
+}
+BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_TAWrapper_TestRequest)
+{
+    dunedaq::datahandlinglibs::test::test_request_model<
+            dunedaq::datahandlinglibs::SkipListLatencyBufferModel,
+            dunedaq::trigger::TAWrapper>();
+}
+
+BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_TCWrapper_TestQueue)
+{
+    dunedaq::datahandlinglibs::test::test_queue_model<
+            dunedaq::datahandlinglibs::SkipListLatencyBufferModel,
+            dunedaq::trigger::TCWrapper>();
+}
+BOOST_AUTO_TEST_CASE(SkipListLatencyBufferModel_TCWrapper_TestRequest)
+{
+    dunedaq::datahandlinglibs::test::test_request_model<
+            dunedaq::datahandlinglibs::SkipListLatencyBufferModel,
+            dunedaq::trigger::TCWrapper>();
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+


### PR DESCRIPTION
This PR implements unit tests using the common datahandlinglibs test functions that check the SkipListLatencyBuffer with enclosed trigger types (TriggerPrimitiveTypeAdapter, TAWrapper, TCWrapper), with respect to returning the correct lower_bound behavior and to responding to requests to form fragments properly.

Note that the TAWrapper and TCWrappers need a bit more care in making sure the underling data is populated on the construction of the test objects. There should (hopefully...) be no change in the behavior of the code that isn't intended.

This PR needs https://github.com/DUNE-DAQ/datahandlinglibs/pull/27. With that pulled down, to run the unit tests, do

dbt-build --unittest trigger

We should wait to merge this PR in until the datahandlinglibs PR has been approved and merged as well.