### PR TITLE
Bugfixing RTCM for v5.2

### DIFF
--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -198,19 +198,19 @@ RandomTCMakerModule::create_candidate(dfmessages::timestamp_t timestamp)
   return candidate;
 }
 
-int
+uint64_t
 RandomTCMakerModule::get_interval(std::mt19937& gen)
 {
   std::string time_distribution = m_conf->get_time_distribution();
 
-  int interval = m_clock_speed_hz / m_trigger_rate_hz.load();
+  uint64_t interval = m_clock_speed_hz / m_trigger_rate_hz.load();
 
   if( time_distribution == "kUniform"){
     return interval;
   }
   else if(time_distribution == "kPoisson"){
     std::exponential_distribution<double> d(1.0 / interval);
-    return static_cast<int>(0.5 + d(gen));
+    return static_cast<uint64_t>(0.5 + d(gen));
   }
   else{
     TLOG_DEBUG(1) << get_name() << " unknown distribution! Using kUniform.";

--- a/plugins/RandomTCMakerModule.hpp
+++ b/plugins/RandomTCMakerModule.hpp
@@ -116,7 +116,7 @@ private:
   /// @brief Output trigger rate in hz
   std::atomic<float> m_trigger_rate_hz{ 0 };
 
-  int get_interval(std::mt19937& gen);
+  uint64_t get_interval(std::mt19937& gen);
 
   dfmessages::run_number_t m_run_number;
 


### PR DESCRIPTION
Bugfixing `RandomTCMaker` after v5.2 performance tests. 

**Bug**: when running with trigger rate of 0.01Hz or lower, RTCM would spit out TCs at much higher rate.
**Fix**: The issue was with using `int` for time intervals rather than `uint64_t`s. Changed from `int` to `uint64_t`
**Test**: Ran test configuration with low trigger rate (0.01Hz) on code before and after the fix for 300s, comparing raw file before and after. Changed from 1000s of triggers to 3, as expected.