### PR TITLE
Updated uses of the string_to_fragment_type_value() method to use its…

### DIFF
--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -68,7 +68,7 @@ RandomTCMakerModule::init(std::shared_ptr<appfwk::ModuleConfiguration> mcfg)
   m_tcout_time_before = tc_readout->get_time_before();
   m_tcout_time_after = tc_readout->get_time_after();
   m_tcout_type = static_cast<TCType>(
-      dunedaq::trgdataformats::string_to_fragment_type_value(tc_readout->get_tc_type_name()));
+      dunedaq::trgdataformats::string_to_trigger_candidate_type(tc_readout->get_tc_type_name()));
 
   // Throw error if unknown TC type
   if (m_tcout_type == TCType::kUnknown) {

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -607,7 +607,7 @@ TCProcessor::parse_readout_map(const std::vector<const appmodel::TCReadoutMap*>&
 {
   for (auto readout_type : data) {
     TCType tc_type = static_cast<TCType>(
-      dunedaq::trgdataformats::string_to_fragment_type_value(readout_type->get_tc_type_name()));
+      dunedaq::trgdataformats::string_to_trigger_candidate_type(readout_type->get_tc_type_name()));
 
       // Throw error if unknown TC type
       if (tc_type == TCType::kUnknown) {

--- a/src/trigger/HSISourceModel.hpp
+++ b/src/trigger/HSISourceModel.hpp
@@ -77,7 +77,7 @@ public:
     for (auto win : hsi_conf->get_signals()) {
       triggeralgs::TriggerCandidate::Type tc_type;
       tc_type = static_cast<triggeralgs::TriggerCandidate::Type>(
-          dunedaq::trgdataformats::string_to_fragment_type_value(win->get_tc_type_name()));
+          dunedaq::trgdataformats::string_to_trigger_candidate_type(win->get_tc_type_name()));
 
       // Throw error if unknown TC type
       if (tc_type == triggeralgs::TriggerCandidate::Type::kUnknown) {


### PR DESCRIPTION
… new name, string_to_trigger_candidate_type(), which seems much more appropriate.

These changes need to be tested and merged along with corresponding changes in the [trgdataformats](https://github.com/DUNE-DAQ/trgdataformats/pull/47) and [triggeralgs](https://github.com/DUNE-DAQ/triggeralgs/pull/88) repos.