### PR TITLE
TPRequestHandler: check whether sink queue is set

### DIFF
--- a/src/TPRequestHandler.cpp
+++ b/src/TPRequestHandler.cpp
@@ -39,6 +39,9 @@ TPRequestHandler::start(const nlohmann::json& args) {
 
 void
 TPRequestHandler::periodic_data_transmission() {
+   
+   if (m_tpset_sink == nullptr) return;
+
    dunedaq::dfmessages::DataRequest dr;
 
    {


### PR DESCRIPTION
Added small check that a sink queue is set before proceeding with periodic data transmission.