### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -15,7 +15,7 @@
 #include "ers/Issue.hpp"
 #include "triggeralgs/Types.hpp"
 #include "trigger/serialize.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 #include <bitset>

--- a/include/trigger/Issues.hpp
+++ b/include/trigger/Issues.hpp
@@ -15,6 +15,7 @@
 #include "ers/Issue.hpp"
 #include "triggeralgs/Types.hpp"
 #include "trigger/serialize.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 #include <bitset>

--- a/src/trigger/TPRequestHandler.hpp
+++ b/src/trigger/TPRequestHandler.hpp
@@ -23,7 +23,7 @@
 #include "trigger/TriggerPrimitiveTypeAdapter.hpp"
 #include "trigger/TPSet.hpp"
 
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
  
 #include <atomic>
 #include <memory>

--- a/src/trigger/TPRequestHandler.hpp
+++ b/src/trigger/TPRequestHandler.hpp
@@ -22,6 +22,8 @@
 
 #include "trigger/TriggerPrimitiveTypeAdapter.hpp"
 #include "trigger/TPSet.hpp"
+
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
  
 #include <atomic>
 #include <memory>


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)