### PR TITLE
Modified DataSubscriberModule so that it connects its do_stop() metho…

### DIFF
--- a/plugins/DataSubscriberModule.cpp
+++ b/plugins/DataSubscriberModule.cpp
@@ -41,7 +41,7 @@ DataSubscriberModule::DataSubscriberModule(const std::string& name)
 {
 
   inherited_mod::register_command("start", &DataSubscriberModule::do_start);
-  inherited_mod::register_command("drain_dataflow", &DataSubscriberModule::do_stop);
+  inherited_mod::register_command("stop_trigger_sources", &DataSubscriberModule::do_stop);
 }
 
 void


### PR DESCRIPTION
…d to the `stop_trigger_sources` FSM transition instead of `drain_dataflow`.  This is to (A) better match what is done in other modules and (B) avoid the situation in which a backlog of data packets builds up in the queue/socket between modules when stopping one run and starting another one in the same DAQ session.

The background is the following:

I/we have been occasionally noticing an error message like the following in the logfiles when we run the automated regression tests in the `daqsystemtest` repo.:

```
ta_input_: Unable to push within timeout period (timeout period was 0 milliseconds)
```

This message happens rather rarely.    I believe that two issues can cause this problem to happen.  The first is addressed in [daqsystemtest PR 181](https://github.com/DUNE-DAQ/daqsystemtest/pull/181).  The second is addressed here.

The problem that is addressed here is a backlog of TAs at the input of the DataSubscriberModule at the start of a run (leftover from the previous run).  (I can provide information about what I've found during debugging.)

Stopping the senders and receivers of TAs at the same time helps avoid the situation in which a bunch of data packets are sent between modules after the receiver has stopped listening.

![19Jan_local-1x1-config_tc-maker-1}](https://github.com/user-attachments/assets/725b77d9-9a9d-4d66-bd89-70a53d2ca99f)
