### PR TITLE
Add "tc_time_outside_window_test", which is just

### DIFF
--- a/integtest/README.md
+++ b/integtest/README.md
@@ -10,3 +10,4 @@ pytest -s change_rate_test.py [--nanorc-option log-level debug]  # this nanorc o
 For reference, here are the ideas behind the existing tests:
 * `change_rate_test.py` - Tests whether the change-rate command properly changes the rate of the RTCM and not the FakeHSI
 * `td_leakage_between_runs_test.py` - [Currently Broken] tests whether TriggerDecision messages received by the DFO have the correct run number in certain special conditions
+* `td_time_outside_window_test.py` - [Currently Broken] tests whether TriggerCandidate fragments with a start time outside the configured readout window get correctly included in the TriggerRecord

--- a/integtest/README.md
+++ b/integtest/README.md
@@ -10,4 +10,4 @@ pytest -s change_rate_test.py [--nanorc-option log-level debug]  # this nanorc o
 For reference, here are the ideas behind the existing tests:
 * `change_rate_test.py` - Tests whether the change-rate command properly changes the rate of the RTCM and not the FakeHSI
 * `td_leakage_between_runs_test.py` - [Currently Broken] tests whether TriggerDecision messages received by the DFO have the correct run number in certain special conditions
-* `td_time_outside_window_test.py` - [Currently Broken] tests whether TriggerCandidate fragments with a start time outside the configured readout window get correctly included in the TriggerRecord
+* `tc_time_outside_window_test.py` - [Currently Broken] tests whether TriggerCandidate fragments with a start time outside the configured readout window get correctly included in the TriggerRecord

--- a/integtest/tc_time_outside_window_test.py
+++ b/integtest/tc_time_outside_window_test.py
@@ -84,7 +84,7 @@ object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 conf_dict = data_classes.drunc_config()
 conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.op_env = "integtest"
-conf_dict.session = "tdoutsidewindow"
+conf_dict.session = "tcoutsidewindow"
 conf_dict.tpg_enabled = False
 conf_dict.fake_hsi_enabled = True
 

--- a/integtest/td_time_outside_window_test.py
+++ b/integtest/td_time_outside_window_test.py
@@ -1,0 +1,165 @@
+import pytest
+import urllib.request
+
+import integrationtest.data_file_checks as data_file_checks
+import integrationtest.log_file_checks as log_file_checks
+import integrationtest.data_classes as data_classes
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
+
+# Values that help determine the running conditions
+number_of_data_producers = 1
+data_rate_slowdown_factor = 1  # 10 for ProtoWIB/DuneWIB
+run_duration = 20  # seconds
+readout_window_time_before = 1000
+readout_window_time_after = 1001
+
+# Default values for validation parameters
+expected_number_of_data_files = 1
+check_for_logfile_errors = True
+expected_event_count = run_duration
+expected_event_count_tolerance = 2
+wib1_frag_hsi_trig_params = {
+    "fragment_type_description": "WIB",
+    "fragment_type": "ProtoWIB",
+    "hdf5_source_subsystem": "Detector_Readout",
+    "expected_fragment_count": number_of_data_producers,
+    "min_size_bytes": 37656,
+    "max_size_bytes": 37656,
+}
+wib2_frag_params = {
+    "fragment_type_description": "WIB2",
+    "fragment_type": "WIB",
+    "hdf5_source_subsystem": "Detector_Readout",
+    "expected_fragment_count": number_of_data_producers,
+    "min_size_bytes": 29808,
+    "max_size_bytes": 30280,
+}
+wibeth_frag_params = {
+    "fragment_type_description": "WIBEth",
+    "fragment_type": "WIBEth",
+    "hdf5_source_subsystem": "Detector_Readout",
+    "expected_fragment_count": number_of_data_producers,
+    "min_size_bytes": 7272,
+    "max_size_bytes": 14472,
+}
+triggercandidate_frag_params = {
+    "fragment_type_description": "Trigger Candidate",
+    "fragment_type": "Trigger_Candidate",
+    "hdf5_source_subsystem": "Trigger",
+    "expected_fragment_count": 1,
+    "min_size_bytes": 128,
+    "max_size_bytes": 216,
+}
+hsi_frag_params = {
+    "fragment_type_description": "HSI",
+    "fragment_type": "Hardware_Signal",
+    "hdf5_source_subsystem": "HW_Signals_Interface",
+    "expected_fragment_count": 1,
+    "min_size_bytes": 72,
+    "max_size_bytes": 100,
+}
+ignored_logfile_problems = {
+    "connectionservice": [
+        "Searching for connections matching uid_regex<errored_frames_q> and data_type Unknown"
+    ],
+    "-controller": [
+        "Worker with pid \\d+ was terminated due to signal 1",
+        "Connection '.*' not found on the application registry",
+    ],
+    "connectivity-service": [
+        "errorlog: -",
+    ],
+}
+
+# The next three variable declarations *must* be present as globals in the test
+# file. They're read by the "fixtures" in conftest.py to determine how
+# to run the config generation and nanorc
+
+# The arguments to pass to the config generator, excluding the json
+# output directory (the test framework handles that)
+
+object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
+
+conf_dict = data_classes.drunc_config()
+conf_dict.dro_map_config.n_streams = number_of_data_producers
+conf_dict.op_env = "integtest"
+conf_dict.session = "tdoutsidewindow"
+conf_dict.tpg_enabled = False
+conf_dict.fake_hsi_enabled = True
+
+conf_dict.config_substitutions.append(
+    data_classes.config_substitution(
+        obj_id=conf_dict.session,
+        obj_class="Session",
+        updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
+    )
+)
+conf_dict.config_substitutions.append(
+    data_classes.config_substitution(obj_class="LatencyBuffer", updates={"size": 50000})
+)
+
+conf_dict.config_substitutions.append(
+    data_classes.config_substitution(
+        obj_class="FakeHSIEventGeneratorConf",
+        updates={"trigger_rate": 1.0},
+    )
+)
+
+conf_dict.config_substitutions.append(
+    data_classes.config_substitution(
+        obj_class="TCReadoutMap",
+        updates={
+            "time_before": readout_window_time_before,
+            "time_after": readout_window_time_after,
+        },
+    )
+)
+
+confgen_arguments = {"MinimalSystem": conf_dict}
+# The commands to run in nanorc, as a list
+nanorc_command_list = (
+    "boot conf start --run-number 101 wait 1 enable-triggers wait ".split()
+    + [str(run_duration)]
+    + "disable-triggers wait 2 drain-dataflow stop-trigger-sources stop wait 2 scrap terminate".split()
+)
+
+# The tests themselves
+
+
+def test_nanorc_success(run_nanorc):
+    # Check that nanorc completed correctly
+    assert run_nanorc.completed_process.returncode == 0
+
+
+def test_log_files(run_nanorc):
+    if check_for_logfile_errors:
+        # Check that there are no warnings or errors in the log files
+        assert log_file_checks.logs_are_error_free(
+            run_nanorc.log_files, True, True, ignored_logfile_problems
+        )
+
+
+def test_data_files(run_nanorc):
+    # Run some tests on the output data file
+    assert len(run_nanorc.data_files) == expected_number_of_data_files
+
+    fragment_check_list = [triggercandidate_frag_params, hsi_frag_params]
+    # fragment_check_list.append(wib1_frag_hsi_trig_params) # ProtoWIB
+    # fragment_check_list.append(wib2_frag_params) # DuneWIB
+    fragment_check_list.append(wibeth_frag_params)  # WIBEth
+
+    for idx in range(len(run_nanorc.data_files)):
+        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+        assert data_file_checks.sanity_check(data_file)
+        assert data_file_checks.check_file_attributes(data_file)
+        assert data_file_checks.check_event_count(
+            data_file, expected_event_count, expected_event_count_tolerance
+        )
+        for jdx in range(len(fragment_check_list)):
+            assert data_file_checks.check_fragment_count(
+                data_file, fragment_check_list[jdx]
+            )
+            assert data_file_checks.check_fragment_sizes(
+                data_file, fragment_check_list[jdx]
+            )


### PR DESCRIPTION
small_footprint_quick_test from daqsystemtest with readout window specified in trigger such that the td time is outside the window for the TC fragment.

(See https://github.com/DUNE-DAQ/daqsystemtest/pull/183 for update to small_footprint_quick_test now that the issue demonstration has been moved here)