### PR TITLE
Adding scrap for TXProcessor

### DIFF
--- a/src/TAProcessor.cpp
+++ b/src/TAProcessor.cpp
@@ -102,6 +102,14 @@ TAProcessor::conf(const appmodel::DataHandlerModule* conf)
 }
 
 void
+TAProcessor::scrap(const nlohmann::json& args)
+{
+  inherited::scrap(args);
+  m_tcms.clear();
+  m_tc_sink.reset();
+}
+
+void
 TAProcessor::generate_opmon_data()
 {
   opmon::TAProcessorInfo info;

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -183,6 +183,26 @@ TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
 }
 
 void
+TCProcessor::scrap(const nlohmann::json& args)
+{
+  m_mandatory_links.clear();
+  m_group_links.clear();
+  m_roi_conf.clear();
+  m_roi_conf_data.clear();
+  m_roi_conf_ids.clear();
+  m_roi_conf_probs.clear();
+  m_roi_conf_probs_c.clear();
+  m_pending_tds.clear();
+  m_trigger_bitwords.clear();
+  m_readout_window_map_data.clear();
+  m_readout_window_map.clear();
+  m_ignored_tc_types.clear();
+  m_td_sink.reset();
+
+  inherited::scrap(args);
+}
+
+void
 TCProcessor::generate_opmon_data()
 {
   opmon::TCProcessorInfo info;

--- a/src/TPProcessor.cpp
+++ b/src/TPProcessor.cpp
@@ -105,6 +105,15 @@ TPProcessor::conf(const appmodel::DataHandlerModule* conf)
 }
 
 void
+TPProcessor::scrap(const nlohmann::json& args)
+{
+  inherited::scrap(args);
+  m_tams.clear();
+  m_ta_sink.reset();
+}
+
+
+void
 TPProcessor::generate_opmon_data()
 {
   opmon::TPProcessorInfo info;

--- a/src/trigger/TAProcessor.hpp
+++ b/src/trigger/TAProcessor.hpp
@@ -48,6 +48,8 @@ public:
 
   void conf(const appmodel::DataHandlerModule* conf) override;
 
+  void scrap(const nlohmann::json& args) override;
+
   void generate_opmon_data() override;
 
 protected:

--- a/src/trigger/TCProcessor.hpp
+++ b/src/trigger/TCProcessor.hpp
@@ -53,6 +53,8 @@ public:
 
   void conf(const appmodel::DataHandlerModule* conf) override;
 
+  void scrap(const nlohmann::json& args) override;
+
   void generate_opmon_data() override;
 
 protected:

--- a/src/trigger/TPProcessor.hpp
+++ b/src/trigger/TPProcessor.hpp
@@ -48,6 +48,8 @@ public:
 
   void conf(const appmodel::DataHandlerModule* conf) override;
 
+  void scrap(const nlohmann::json& args) override;
+
   void generate_opmon_data() override;
 
 protected:


### PR DESCRIPTION
An issue was reported where the triggeralgs processors were not reaching their destructors. 
The issue is that the TXProcessors are not set up to clear their vectors (often of pointers). This is especially problematic for sequences of multiple runs in the same session where terminate is not reached at run change (ie -> stop -> scrap -> conf -> start (new run)). 

There are no logic changes, but the scrap method is made available for each TXProcessor.

Tested with local sessions and suit of integration tests. 

Can be tested with https://github.com/DUNE-DAQ/triggeralgs/compare/develop...mrigan/ta_makers_debug (that is not to be merged, just for testing). 