### PR TITLE
Proper conf and scrap implementation for trigger modules

### DIFF
--- a/plugins/MLTModule.cpp
+++ b/plugins/MLTModule.cpp
@@ -106,7 +106,7 @@ MLTModule::do_configure(const nlohmann::json& /*obj*/)
       SubdetectorID detid = static_cast<SubdetectorID>(gidmap["detector_id"]);
       if (m_srcid_detid_map.contains(sourceid) && !(m_srcid_detid_map[sourceid] == detid)) {
         throw MLTConfigurationProblem(
-          ERS_HERE, get_name(), "Multiple subdetector types for ine SourceID not suported in trigger system!");
+          ERS_HERE, get_name(), "Multiple subdetector types for one SourceID not supported in trigger system!");
       }
       m_srcid_detid_map[sourceid] = detid;
     }

--- a/plugins/MLTModule.cpp
+++ b/plugins/MLTModule.cpp
@@ -34,12 +34,12 @@ MLTModule::MLTModule(const std::string& name)
   , m_run_number(0)
 {
   // clang-format off
-  //register_command("conf",   &MLTModule::do_configure);
+  register_command("conf",   &MLTModule::do_configure);
   register_command("start",  &MLTModule::do_start);
   register_command("stop",   &MLTModule::do_stop);
   register_command("disable_triggers",  &MLTModule::do_pause);
   register_command("enable_triggers", &MLTModule::do_resume);
-//  register_command("scrap",  &MLTModule::do_scrap);
+  register_command("scrap",  &MLTModule::do_scrap);
   // clang-format on
 }
 
@@ -50,7 +50,7 @@ MLTModule::decode_geoid(uint64_t _geoid_int)
 
   std::map<std::string, int> geoid;
 
-      // Extract stream_id (stored in the top 16 bits)
+  // Extract stream_id (stored in the top 16 bits)
   geoid["stream_id"] = (_geoid_int >> 48) & 0xFFFF;
 
   // Extract slot_id (stored in the next 16 bits)
@@ -68,30 +68,38 @@ MLTModule::decode_geoid(uint64_t _geoid_int)
 void
 MLTModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
 {
-  auto mtrg = mcfg->get_dal<appmodel::MLTModule>(get_name());
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering init() method";
+
+  m_mtrg = mcfg->get_dal<appmodel::MLTModule>(get_name());
+  // Get the session to access the detector configuration
+  m_session = mcfg->session();
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting init() method";
+}
+
+void
+MLTModule::do_configure(const nlohmann::json& /*obj*/)
+{
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering conf() method";
 
   // Get the inputs
-  std::string candidate_input;
-  std::string inhibit_input;
-  for(auto con : mtrg->get_inputs()){
+  for(auto con : m_mtrg->get_inputs()){
     if(con->get_data_type() == datatype_to_string<dfmessages::TriggerDecision>()) {
-      m_decision_input = get_iom_receiver<dfmessages::TriggerDecision>(con->UID());
+      if (!m_decision_input) {
+        m_decision_input = get_iom_receiver<dfmessages::TriggerDecision>(con->UID());
+      }
     } else if(con->get_data_type() == datatype_to_string<dfmessages::TriggerInhibit>()) {
       m_inhibit_input = get_iom_receiver<dfmessages::TriggerInhibit>(con->UID());
     }
   }
 
   // Get the outputs
-  for(auto con : mtrg->get_outputs()){
+  for(auto con : m_mtrg->get_outputs()){
     if(con->get_data_type() == datatype_to_string<dfmessages::TriggerDecision>())
       m_decision_output = get_iom_sender<dfmessages::TriggerDecision>(con->UID());
   }
 
-  // Get the session to access the detector configuration
-  auto session = mcfg->session();
-
-  hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t geoidmap = hdf5libs::HDF5SourceIDHandler::make_source_id_geo_id_map(session);
-
+  hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t geoidmap = hdf5libs::HDF5SourceIDHandler::make_source_id_geo_id_map(m_session);
   // Fill the SourceID -- Subdetector map
   for (auto const& [sourceid, geoids] : geoidmap) {
     TLOG() << "SourceID: " << sourceid;
@@ -108,7 +116,7 @@ MLTModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
     TLOG() << " * Subdetector type: " << m_srcid_detid_map[sourceid];
   }
 
-  for (auto subdet_readout_window : mtrg->get_configuration()->get_subdetector_readout_map()) {
+  for (auto subdet_readout_window : m_mtrg->get_configuration()->get_subdetector_readout_map()) {
     std::string subdetector_name = subdet_readout_window->get_subdetector();
     SubdetectorID detid = dunedaq::detdataformats::DetID::string_to_subdetector(subdetector_name);
     if (detid == detdataformats::DetID::Subdetector::kUnknown) {
@@ -129,10 +137,28 @@ MLTModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
   }
 
   // Latency related
-  m_latency_monitoring.store( mtrg->get_configuration()->get_latency_monitoring() );
+  m_latency_monitoring.store( m_mtrg->get_configuration()->get_latency_monitoring() );
 
   // Now do the configuration: dummy for now
   m_configured_flag.store(true);
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting conf() method";
+}
+
+void
+MLTModule::do_scrap(const nlohmann::json& /*obj*/)
+{
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering scrap() method";
+
+  //m_decision_input.reset();
+  m_decision_output.reset();
+  m_inhibit_input.reset();
+
+  m_srcid_detid_map.clear();
+  m_subdetector_readout_window_map.clear();
+  m_trigger_counters.clear();
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting scrap() method";
 }
 
 void
@@ -191,6 +217,8 @@ MLTModule::generate_opmon_data()
 void
 MLTModule::do_start(const nlohmann::json& startobj)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering start() method";
+
   m_run_number = startobj.value<dunedaq::daqdataformats::run_number_t>("run", 0);
   // We get here at start of run, so reset the trigger number
   m_last_trigger_number = 1;
@@ -219,11 +247,15 @@ MLTModule::do_start(const nlohmann::json& startobj)
   m_decision_input->add_callback(std::bind(&MLTModule::trigger_decisions_callback, this, std::placeholders::_1));
 
   ers::info(TriggerStartOfRun(ERS_HERE, m_run_number));
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting start() method";
 }
 
 void
 MLTModule::do_stop(const nlohmann::json& /*stopobj*/)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering stop() method";
+
   m_running_flag.store(false);
   m_decision_input->remove_callback();
   m_inhibit_input->remove_callback();
@@ -245,11 +277,14 @@ MLTModule::do_stop(const nlohmann::json& /*stopobj*/)
   print_opmon_stats();
 
   ers::info(TriggerEndOfRun(ERS_HERE, m_run_number));
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting stop() method";
 }
 
 void
 MLTModule::do_pause(const nlohmann::json& /*pauseobj*/)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering pause() method";
 
   m_paused.store(true);
   m_livetime_counter->set_state(LivetimeCounter::State::kPaused);
@@ -259,11 +294,15 @@ MLTModule::do_pause(const nlohmann::json& /*pauseobj*/)
                 << std::chrono::duration_cast<std::chrono::microseconds>(
                      std::chrono::system_clock::now().time_since_epoch())
                      .count();
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting pause() method";
 }
 
 void
 MLTModule::do_resume(const nlohmann::json& /*resumeobj*/)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering resume() method";
+
   ers::info(TriggerActive(ERS_HERE));
   TLOG() << "******* Triggers RESUMED! in run " << m_run_number << " *********";
   m_livetime_counter->set_state(LivetimeCounter::State::kLive);
@@ -273,6 +312,8 @@ MLTModule::do_resume(const nlohmann::json& /*resumeobj*/)
                 << std::chrono::duration_cast<std::chrono::microseconds>(
                      std::chrono::system_clock::now().time_since_epoch())
                      .count();
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting resume() method";
 }
 
 void

--- a/plugins/MLTModule.cpp
+++ b/plugins/MLTModule.cpp
@@ -84,9 +84,7 @@ MLTModule::do_configure(const nlohmann::json& /*obj*/)
   // Get the inputs
   for (auto con : m_mtrg->get_inputs()) {
     if (con->get_data_type() == datatype_to_string<dfmessages::TriggerDecision>()) {
-      if (!m_decision_input) {
         m_decision_input = get_iom_receiver<dfmessages::TriggerDecision>(con->UID());
-      }
     } else if (con->get_data_type() == datatype_to_string<dfmessages::TriggerInhibit>()) {
       m_inhibit_input = get_iom_receiver<dfmessages::TriggerInhibit>(con->UID());
     }
@@ -152,7 +150,7 @@ MLTModule::do_scrap(const nlohmann::json& /*obj*/)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering scrap() method";
 
-  // m_decision_input.reset();
+  m_decision_input.reset();
   m_decision_output.reset();
   m_inhibit_input.reset();
 

--- a/plugins/MLTModule.cpp
+++ b/plugins/MLTModule.cpp
@@ -350,7 +350,7 @@ MLTModule::trigger_decisions_callback(dfmessages::TriggerDecision& decision)
     }
   }
 
-  TLOG() << "Received decision with timestamp " << decision.trigger_timestamp;
+  TLOG_DEBUG(2) << "Received decision with timestamp " << decision.trigger_timestamp;
 
   if ((!m_paused.load() && !m_dfo_is_busy.load())) {
     TLOG_DEBUG(1) << "Sending a decision with triggernumber " << decision.trigger_number << " timestamp "

--- a/plugins/MLTModule.cpp
+++ b/plugins/MLTModule.cpp
@@ -73,7 +73,7 @@ MLTModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
   // Get the session to access the detector configuration
   m_session = mcfg->session();
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting init() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
 }
 
 void
@@ -142,7 +142,7 @@ MLTModule::do_configure(const nlohmann::json& /*obj*/)
   // Now do the configuration: dummy for now
   m_configured_flag.store(true);
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting conf() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting conf() method";
 }
 
 void
@@ -158,7 +158,7 @@ MLTModule::do_scrap(const nlohmann::json& /*obj*/)
   m_subdetector_readout_window_map.clear();
   m_trigger_counters.clear();
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting scrap() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting scrap() method";
 }
 
 void
@@ -248,7 +248,7 @@ MLTModule::do_start(const nlohmann::json& startobj)
 
   ers::info(TriggerStartOfRun(ERS_HERE, m_run_number));
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting start() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting start() method";
 }
 
 void
@@ -278,7 +278,7 @@ MLTModule::do_stop(const nlohmann::json& /*stopobj*/)
 
   ers::info(TriggerEndOfRun(ERS_HERE, m_run_number));
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting stop() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting stop() method";
 }
 
 void
@@ -295,7 +295,7 @@ MLTModule::do_pause(const nlohmann::json& /*pauseobj*/)
                      std::chrono::system_clock::now().time_since_epoch())
                      .count();
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting pause() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting pause() method";
 }
 
 void
@@ -313,7 +313,7 @@ MLTModule::do_resume(const nlohmann::json& /*resumeobj*/)
                      std::chrono::system_clock::now().time_since_epoch())
                      .count();
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting resume() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting resume() method";
 }
 
 void

--- a/plugins/MLTModule.cpp
+++ b/plugins/MLTModule.cpp
@@ -373,7 +373,7 @@ MLTModule::trigger_decisions_callback(dfmessages::TriggerDecision& decision)
       }
 
       m_last_trigger_number++;
-      //        add_td(pending_td);
+      // add_td(pending_td);
     } catch (const ers::Issue& e) {
       ers::error(e);
       TLOG_DEBUG(1) << "The network is misbehaving: TD send failed for " << m_last_trigger_number;

--- a/plugins/MLTModule.cpp
+++ b/plugins/MLTModule.cpp
@@ -424,7 +424,7 @@ MLTModule::print_opmon_stats()
 {
   TLOG() << "MLT opmon counters summary:";
   TLOG() << "------------------------------";
-  TLOG() << "Received TD messages: \t" << m_td_msg_received_count;
+  TLOG() << "Received TD messages: \t\t" << m_td_msg_received_count;
   TLOG() << "Sent TDs: \t\t\t" << m_td_sent_count;
   TLOG() << "Inhibited TDs: \t\t" << m_td_inhibited_count;
   TLOG() << "Paused TDs: \t\t\t" << m_td_paused_count;

--- a/plugins/MLTModule.cpp
+++ b/plugins/MLTModule.cpp
@@ -43,7 +43,6 @@ MLTModule::MLTModule(const std::string& name)
   // clang-format on
 }
 
-
 std::map<std::string, int>
 MLTModule::decode_geoid(uint64_t _geoid_int)
 {
@@ -83,33 +82,33 @@ MLTModule::do_configure(const nlohmann::json& /*obj*/)
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering conf() method";
 
   // Get the inputs
-  for(auto con : m_mtrg->get_inputs()){
-    if(con->get_data_type() == datatype_to_string<dfmessages::TriggerDecision>()) {
+  for (auto con : m_mtrg->get_inputs()) {
+    if (con->get_data_type() == datatype_to_string<dfmessages::TriggerDecision>()) {
       if (!m_decision_input) {
         m_decision_input = get_iom_receiver<dfmessages::TriggerDecision>(con->UID());
       }
-    } else if(con->get_data_type() == datatype_to_string<dfmessages::TriggerInhibit>()) {
+    } else if (con->get_data_type() == datatype_to_string<dfmessages::TriggerInhibit>()) {
       m_inhibit_input = get_iom_receiver<dfmessages::TriggerInhibit>(con->UID());
     }
   }
 
   // Get the outputs
-  for(auto con : m_mtrg->get_outputs()){
-    if(con->get_data_type() == datatype_to_string<dfmessages::TriggerDecision>())
+  for (auto con : m_mtrg->get_outputs()) {
+    if (con->get_data_type() == datatype_to_string<dfmessages::TriggerDecision>())
       m_decision_output = get_iom_sender<dfmessages::TriggerDecision>(con->UID());
   }
 
-  hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t geoidmap = hdf5libs::HDF5SourceIDHandler::make_source_id_geo_id_map(m_session);
+  hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t geoidmap =
+    hdf5libs::HDF5SourceIDHandler::make_source_id_geo_id_map(m_session);
   // Fill the SourceID -- Subdetector map
   for (auto const& [sourceid, geoids] : geoidmap) {
     TLOG() << "SourceID: " << sourceid;
     for (auto const& geoid : geoids) {
       std::map<std::string, int> gidmap = decode_geoid(geoid);
       SubdetectorID detid = static_cast<SubdetectorID>(gidmap["detector_id"]);
-      if (m_srcid_detid_map.contains(sourceid) &&
-          !(m_srcid_detid_map[sourceid]  == detid)) {
-        throw MLTConfigurationProblem(ERS_HERE, get_name(),
-            "Multiple subdetector types for ine SourceID not suported in trigger system!");
+      if (m_srcid_detid_map.contains(sourceid) && !(m_srcid_detid_map[sourceid] == detid)) {
+        throw MLTConfigurationProblem(
+          ERS_HERE, get_name(), "Multiple subdetector types for ine SourceID not suported in trigger system!");
       }
       m_srcid_detid_map[sourceid] = detid;
     }
@@ -120,24 +119,27 @@ MLTModule::do_configure(const nlohmann::json& /*obj*/)
     std::string subdetector_name = subdet_readout_window->get_subdetector();
     SubdetectorID detid = dunedaq::detdataformats::DetID::string_to_subdetector(subdetector_name);
     if (detid == detdataformats::DetID::Subdetector::kUnknown) {
-      throw MLTConfigurationProblem(ERS_HERE, get_name(),
-          "Unknown Subdetector supplied to MLT subdetector-readout window map");
+      throw MLTConfigurationProblem(
+        ERS_HERE, get_name(), "Unknown Subdetector supplied to MLT subdetector-readout window map");
     }
 
     if (m_subdetector_readout_window_map.count(detid)) {
-      throw MLTConfigurationProblem(ERS_HERE, get_name(),
-          "Supplied more than one of the same Subdetector name to MLT subdetector-readout window map");
+      throw MLTConfigurationProblem(
+        ERS_HERE,
+        get_name(),
+        "Supplied more than one of the same Subdetector name to MLT subdetector-readout window map");
     }
 
-    m_subdetector_readout_window_map[detid] = std::make_pair(subdet_readout_window->get_time_before(),
-                                                             subdet_readout_window->get_time_after());
+    m_subdetector_readout_window_map[detid] =
+      std::make_pair(subdet_readout_window->get_time_before(), subdet_readout_window->get_time_after());
 
     TLOG() << "[MLT] Custom readout map for subdetector: " << detid
-      << " time_start: " << subdet_readout_window->get_time_before() << " time_after: " << subdet_readout_window->get_time_after();
+           << " time_start: " << subdet_readout_window->get_time_before()
+           << " time_after: " << subdet_readout_window->get_time_after();
   }
 
   // Latency related
-  m_latency_monitoring.store( m_mtrg->get_configuration()->get_latency_monitoring() );
+  m_latency_monitoring.store(m_mtrg->get_configuration()->get_latency_monitoring());
 
   // Now do the configuration: dummy for now
   m_configured_flag.store(true);
@@ -150,7 +152,7 @@ MLTModule::do_scrap(const nlohmann::json& /*obj*/)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering scrap() method";
 
-  //m_decision_input.reset();
+  // m_decision_input.reset();
   m_decision_output.reset();
   m_inhibit_input.reset();
 
@@ -166,28 +168,28 @@ MLTModule::generate_opmon_data()
 {
   opmon::ModuleLevelTriggerInfo info;
 
-  info.set_td_msg_received_count( m_td_msg_received_count.load() );
-  info.set_td_sent_count( m_td_sent_count.load() );
-  info.set_td_inhibited_count( m_td_inhibited_count.load() );
-  info.set_td_paused_count( m_td_paused_count.load() );
-  info.set_td_queue_timeout_expired_err_count( m_td_queue_timeout_expired_err_count.load() );
-  info.set_td_total_count( m_td_total_count.load() );
+  info.set_td_msg_received_count(m_td_msg_received_count.load());
+  info.set_td_sent_count(m_td_sent_count.load());
+  info.set_td_inhibited_count(m_td_inhibited_count.load());
+  info.set_td_paused_count(m_td_paused_count.load());
+  info.set_td_queue_timeout_expired_err_count(m_td_queue_timeout_expired_err_count.load());
+  info.set_td_total_count(m_td_total_count.load());
 
   if (m_lc_started) {
-    info.set_lc_klive( m_livetime_counter->get_time(LivetimeCounter::State::kLive) );
-    info.set_lc_kpaused( m_livetime_counter->get_time(LivetimeCounter::State::kPaused) );
-    info.set_lc_kdead( m_livetime_counter->get_time(LivetimeCounter::State::kDead) );
+    info.set_lc_klive(m_livetime_counter->get_time(LivetimeCounter::State::kLive));
+    info.set_lc_kpaused(m_livetime_counter->get_time(LivetimeCounter::State::kPaused));
+    info.set_lc_kdead(m_livetime_counter->get_time(LivetimeCounter::State::kDead));
   } else {
-    info.set_lc_klive( m_lc_kLive);
-    info.set_lc_kpaused( m_lc_kPaused );
-    info.set_lc_kdead( m_lc_kDead );
+    info.set_lc_klive(m_lc_kLive);
+    info.set_lc_kpaused(m_lc_kPaused);
+    info.set_lc_kdead(m_lc_kDead);
   }
 
   this->publish(std::move(info));
 
   // per TC type
-  std::lock_guard<std::mutex>   guard(m_trigger_mutex);
-  for ( auto & [type, counts] : m_trigger_counters ) {
+  std::lock_guard<std::mutex> guard(m_trigger_mutex);
+  for (auto& [type, counts] : m_trigger_counters) {
     auto name = dunedaq::trgdataformats::get_trigger_candidate_type_names()[type];
     opmon::TriggerDecisionInfo td_info;
     td_info.set_received(counts.received.exchange(0));
@@ -195,21 +197,21 @@ MLTModule::generate_opmon_data()
     td_info.set_failed_send(counts.failed_send.exchange(0));
     td_info.set_paused(counts.paused.exchange(0));
     td_info.set_inhibited(counts.inhibited.exchange(0));
-    this->publish( std::move(td_info), {{"type", name}} );
+    this->publish(std::move(td_info), { { "type", name } });
   }
 
   // latency
-  if ( m_latency_monitoring.load() && m_running_flag.load() ) {
+  if (m_latency_monitoring.load() && m_running_flag.load()) {
     // TC in, TD out
     opmon::TriggerLatency lat_info;
-    lat_info.set_latency_in( m_latency_instance.get_latency_in() );
-    lat_info.set_latency_out( m_latency_instance.get_latency_out() );
+    lat_info.set_latency_in(m_latency_instance.get_latency_in());
+    lat_info.set_latency_out(m_latency_instance.get_latency_out());
     this->publish(std::move(lat_info));
 
     // vs readout window requests
     opmon::ModuleLevelTriggerRequestLatency lat_request_info;
-    lat_request_info.set_latency_window_start( m_latency_requests_instance.get_latency_in() );
-    lat_request_info.set_latency_window_end( m_latency_requests_instance.get_latency_out() );
+    lat_request_info.set_latency_window_start(m_latency_requests_instance.get_latency_in());
+    lat_request_info.set_latency_window_end(m_latency_requests_instance.get_latency_out());
     this->publish(std::move(lat_request_info));
   }
 }
@@ -259,7 +261,7 @@ MLTModule::do_stop(const nlohmann::json& /*stopobj*/)
   m_running_flag.store(false);
   m_decision_input->remove_callback();
   m_inhibit_input->remove_callback();
-  //m_send_trigger_decisions_thread.join();
+  // m_send_trigger_decisions_thread.join();
   m_lc_kLive_count = m_livetime_counter->get_time(LivetimeCounter::State::kLive);
   m_lc_kPaused_count = m_livetime_counter->get_time(LivetimeCounter::State::kPaused);
   m_lc_kDead_count = m_livetime_counter->get_time(LivetimeCounter::State::kDead);
@@ -272,7 +274,7 @@ MLTModule::do_stop(const nlohmann::json& /*stopobj*/)
 
   TLOG(3) << "LivetimeCounter - total deadtime+paused: " << m_lc_deadtime << std::endl;
   m_livetime_counter.reset(); // Calls LivetimeCounter dtor?
-  m_lc_started = false; 
+  m_lc_started = false;
 
   print_opmon_stats();
 
@@ -317,94 +319,92 @@ MLTModule::do_resume(const nlohmann::json& /*resumeobj*/)
 }
 
 void
-MLTModule::trigger_decisions_callback(dfmessages::TriggerDecision& decision )
+MLTModule::trigger_decisions_callback(dfmessages::TriggerDecision& decision)
 {
-    m_td_msg_received_count++;
-    if (m_latency_monitoring.load()) m_latency_instance.update_latency_in( decision.trigger_timestamp );
+  m_td_msg_received_count++;
+  if (m_latency_monitoring.load())
+    m_latency_instance.update_latency_in(decision.trigger_timestamp);
 
-    auto trigger_types = unpack_types(decision.trigger_type);
-    for ( const auto t : trigger_types ) {
-      ++get_trigger_counter(t).received;
+  auto trigger_types = unpack_types(decision.trigger_type);
+  for (const auto t : trigger_types) {
+    ++get_trigger_counter(t).received;
+  }
+
+  auto ts = decision.trigger_timestamp;
+  auto tt = decision.trigger_type;
+  decision.run_number = m_run_number;
+  decision.trigger_number = m_last_trigger_number;
+
+  // Overwrite the component's readout window if we have custom
+  // subdetector--readout window map
+  for (const auto& [subdetectorid, window] : m_subdetector_readout_window_map) {
+    for (auto& request : decision.components) {
+      if (request.component.subsystem != daqdataformats::SourceID::Subsystem::kDetectorReadout) {
+        continue;
+      }
+
+      if (subdetectorid != m_srcid_detid_map[request.component]) {
+        continue;
+      }
+
+      request.window_begin = decision.trigger_timestamp - window.first;
+      request.window_end = decision.trigger_timestamp + window.second;
+    }
+  }
+
+  TLOG() << "Received decision with timestamp " << decision.trigger_timestamp;
+
+  if ((!m_paused.load() && !m_dfo_is_busy.load())) {
+    TLOG_DEBUG(1) << "Sending a decision with triggernumber " << decision.trigger_number << " timestamp "
+                  << decision.trigger_timestamp << " start " << decision.components.front().window_begin << " end "
+                  << decision.components.front().window_end << " number of links " << decision.components.size();
+
+    // readout window latency update
+    // TODO: The latency will be different for different components, since they might have different readout windows
+    if (m_latency_monitoring.load()) {
+      m_latency_requests_instance.update_latency_in(decision.components.front().window_begin);
+      m_latency_requests_instance.update_latency_out(decision.components.front().window_end);
     }
 
-    auto ts = decision.trigger_timestamp;
-    auto tt = decision.trigger_type;
-    decision.run_number = m_run_number;
-    decision.trigger_number = m_last_trigger_number;
+    try {
+      m_decision_output->send(std::move(decision), std::chrono::milliseconds(1));
+      m_td_sent_count++;
 
-    // Overwrite the component's readout window if we have custom
-    // subdetector--readout window map
-    for ( const auto& [subdetectorid, window] : m_subdetector_readout_window_map ) {
-      for (auto& request: decision.components) {
-        if (request.component.subsystem != daqdataformats::SourceID::Subsystem::kDetectorReadout) {
-          continue;
-        }
+      for (const auto t : trigger_types) {
+        ++get_trigger_counter(t).sent;
+      }
 
-        if (subdetectorid != m_srcid_detid_map[request.component]) {
-          continue;
-        }
+      m_last_trigger_number++;
+      //        add_td(pending_td);
+    } catch (const ers::Issue& e) {
+      ers::error(e);
+      TLOG_DEBUG(1) << "The network is misbehaving: TD send failed for " << m_last_trigger_number;
+      m_td_queue_timeout_expired_err_count++;
 
-        request.window_begin = decision.trigger_timestamp - window.first;
-        request.window_end = decision.trigger_timestamp + window.second;
+      for (const auto t : trigger_types) {
+        ++get_trigger_counter(t).failed_send;
       }
     }
 
-    TLOG() << "Received decision with timestamp "
-             << decision.trigger_timestamp ;
-    
-    if ((!m_paused.load() && !m_dfo_is_busy.load())) {
-      TLOG_DEBUG(1) << "Sending a decision with triggernumber " << decision.trigger_number << " timestamp "
-             << decision.trigger_timestamp << " start " << decision.components.front().window_begin << " end " << decision.components.front().window_end
- 	     << " number of links " << decision.components.size();
-
-      // readout window latency update
-      // TODO: The latency will be different for different components, since they might have different readout windows
-      if (m_latency_monitoring.load()) {
-        m_latency_requests_instance.update_latency_in( decision.components.front().window_begin );
-        m_latency_requests_instance.update_latency_out( decision.components.front().window_end );
-      }
-
-      try {
-        m_decision_output->send(std::move(decision), std::chrono::milliseconds(1));
-        m_td_sent_count++;
-
-        for ( const auto t : trigger_types ) {
-          ++get_trigger_counter(t).sent;
-        }
-
-        m_last_trigger_number++;
-//        add_td(pending_td);
-      } catch (const ers::Issue& e) {
-        ers::error(e);
-        TLOG_DEBUG(1) << "The network is misbehaving: TD send failed for "
-                      << m_last_trigger_number;
-        m_td_queue_timeout_expired_err_count++;
-
-        for ( const auto t : trigger_types ) {
-          ++get_trigger_counter(t).failed_send;
-        }
-      }
-
-    } else if (m_paused.load()) {
-      ++m_td_paused_count;
-      for ( const auto t : trigger_types ) {
-        ++get_trigger_counter(t).paused;
-      }
-
-      TLOG_DEBUG(1) << "Triggers are paused. Not sending a TriggerDecision for TD with timestamp and type "
-                    << ts << "/" << tt;
-    } else {
-      ers::warning(TriggerInhibited(ERS_HERE, m_run_number));
-      TLOG_DEBUG(1) << "The DFO is busy. Not sending a TriggerDecision with timestamp and type "
-                    << ts << "/" << tt;
-      m_td_inhibited_count++;
-      for ( const auto t : trigger_types ) {
-        ++get_trigger_counter(t).inhibited;
-      }
-
+  } else if (m_paused.load()) {
+    ++m_td_paused_count;
+    for (const auto t : trigger_types) {
+      ++get_trigger_counter(t).paused;
     }
-    if (m_latency_monitoring.load()) m_latency_instance.update_latency_out( decision.trigger_timestamp );
-    m_td_total_count++;
+
+    TLOG_DEBUG(1) << "Triggers are paused. Not sending a TriggerDecision for TD with timestamp and type " << ts << "/"
+                  << tt;
+  } else {
+    ers::warning(TriggerInhibited(ERS_HERE, m_run_number));
+    TLOG_DEBUG(1) << "The DFO is busy. Not sending a TriggerDecision with timestamp and type " << ts << "/" << tt;
+    m_td_inhibited_count++;
+    for (const auto t : trigger_types) {
+      ++get_trigger_counter(t).inhibited;
+    }
+  }
+  if (m_latency_monitoring.load())
+    m_latency_instance.update_latency_out(decision.trigger_timestamp);
+  m_td_total_count++;
 }
 
 void

--- a/plugins/MLTModule.hpp
+++ b/plugins/MLTModule.hpp
@@ -83,11 +83,16 @@ private:
   void do_stop(const nlohmann::json& obj);
   void do_pause(const nlohmann::json& obj);
   void do_resume(const nlohmann::json& obj);
+  void do_configure(const nlohmann::json& /*obj*/);
+  void do_scrap(const nlohmann::json& /*obj*/);
 
   void trigger_decisions_callback(dfmessages::TriggerDecision& decision);
   void dfo_busy_callback(dfmessages::TriggerInhibit& inhibit);
 
   std::map<std::string, int> decode_geoid(uint64_t _geoid_int);
+
+  const dunedaq::appmodel::MLTModule* m_mtrg;
+  const dunedaq::confmodel::Session* m_session;
 
   // Queue sources and sinks
   std::shared_ptr<iomanager::ReceiverConcept<dfmessages::TriggerDecision>> m_decision_input;

--- a/plugins/MLTModule.hpp
+++ b/plugins/MLTModule.hpp
@@ -15,30 +15,30 @@
 #define TRIGGER_PLUGINS_MODULELEVELTRIGGER_HPP_
 
 #include "trigger/Issues.hpp"
+#include "trigger/Latency.hpp"
 #include "trigger/LivetimeCounter.hpp"
 #include "trigger/TokenManager.hpp"
-#include "trigger/Latency.hpp"
-#include "trigger/opmon/moduleleveltrigger_info.pb.h"
 #include "trigger/opmon/latency_info.pb.h"
+#include "trigger/opmon/moduleleveltrigger_info.pb.h"
 
 #include "appfwk/DAQModule.hpp"
 
-#include "appmodel/MLTModule.hpp"
 #include "appmodel/MLTConf.hpp"
-#include "appmodel/TCReadoutMap.hpp"
+#include "appmodel/MLTModule.hpp"
 #include "appmodel/ROIGroupConf.hpp"
 #include "appmodel/SourceIDConf.hpp"
 #include "appmodel/SubdetectorReadoutWindowMap.hpp"
+#include "appmodel/TCReadoutMap.hpp"
 
 #include "confmodel/Connection.hpp"
 #include "confmodel/GeoId.hpp"
 
 #include "daqdataformats/SourceID.hpp"
-#include "hdf5libs/HDF5RawDataFile.hpp"
 #include "dfmessages/TriggerDecision.hpp"
 #include "dfmessages/TriggerDecisionToken.hpp"
 #include "dfmessages/TriggerInhibit.hpp"
 #include "dfmessages/Types.hpp"
+#include "hdf5libs/HDF5RawDataFile.hpp"
 #include "iomanager/Receiver.hpp"
 #include "trgdataformats/TriggerCandidateData.hpp"
 #include "trgdataformats/Types.hpp"
@@ -141,8 +141,8 @@ private:
   // paused state, in which we don't send triggers
   std::atomic<bool> m_paused;
   std::atomic<bool> m_dfo_is_busy;
-  //std::atomic<bool> m_hsi_passthrough;
-  //std::atomic<bool> m_tc_merging;
+  // std::atomic<bool> m_hsi_passthrough;
+  // std::atomic<bool> m_tc_merging;
 
   dfmessages::trigger_number_t m_last_trigger_number;
 
@@ -228,7 +228,7 @@ private:
     m_subdetector_readout_window_map;
 
   // Opmon variables
-  using metric_counter_type = uint64_t ; //decltype(moduleleveltriggerinfo::Info::tc_received_count);
+  using metric_counter_type = uint64_t; // decltype(moduleleveltriggerinfo::Info::tc_received_count);
   std::atomic<metric_counter_type> m_td_msg_received_count{ 0 };
   std::atomic<metric_counter_type> m_td_sent_count{ 0 };
   std::atomic<metric_counter_type> m_td_total_count{ 0 };
@@ -243,20 +243,23 @@ private:
   bool m_lc_started = false;
 
   // Struct for per TC stats
-  struct TDData {
+  struct TDData
+  {
     std::atomic<metric_counter_type> received{ 0 };
     std::atomic<metric_counter_type> sent{ 0 };
     std::atomic<metric_counter_type> failed_send{ 0 };
     std::atomic<metric_counter_type> paused{ 0 };
     std::atomic<metric_counter_type> inhibited{ 0 };
   };
-  static std::set<trgdataformats::TriggerCandidateData::Type> unpack_types( const dfmessages::trigger_type_t& t) {
+  static std::set<trgdataformats::TriggerCandidateData::Type> unpack_types(const dfmessages::trigger_type_t& t)
+  {
     std::set<trgdataformats::TriggerCandidateData::Type> results;
     if (t == dfmessages::TypeDefaults::s_invalid_trigger_type)
       return results;
     const std::bitset<64> bits(t);
-    for( size_t i = 0; i < bits.size(); ++i ) {
-      if ( bits[i] ) results.insert((trgdataformats::TriggerCandidateData::Type)i);
+    for (size_t i = 0; i < bits.size(); ++i) {
+      if (bits[i])
+        results.insert((trgdataformats::TriggerCandidateData::Type)i);
     }
     return results;
   }
@@ -264,10 +267,12 @@ private:
   std::map<dunedaq::trgdataformats::TriggerCandidateData::Type, TDData> m_trigger_counters;
 
   std::mutex m_trigger_mutex;
-  TDData & get_trigger_counter(trgdataformats::TriggerCandidateData::Type type) {
+  TDData& get_trigger_counter(trgdataformats::TriggerCandidateData::Type type)
+  {
     auto it = m_trigger_counters.find(type);
-    if (it != m_trigger_counters.end()) return it->second;
-    
+    if (it != m_trigger_counters.end())
+      return it->second;
+
     std::lock_guard<std::mutex> guard(m_trigger_mutex);
     return m_trigger_counters[type];
   }

--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -12,16 +12,16 @@
 #include "trigger/Issues.hpp"
 
 #include "daqdataformats/ComponentRequest.hpp"
-#include "trgdataformats/Types.hpp"
 #include "dfmessages/TimeSync.hpp"
 #include "dfmessages/TriggerDecision.hpp"
 #include "dfmessages/TriggerInhibit.hpp"
 #include "dfmessages/Types.hpp"
 #include "iomanager/IOManager.hpp"
 #include "logging/Logging.hpp"
+#include "trgdataformats/Types.hpp"
+#include "triggeralgs/TriggerCandidate.hpp"
 #include "utilities/TimestampEstimator.hpp"
 #include "utilities/TimestampEstimatorSystem.hpp"
-#include "triggeralgs/TriggerCandidate.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -65,16 +65,16 @@ RandomTCMakerModule::generate_opmon_data()
 {
   opmon::RandomTCMakerInfo info;
 
-  info.set_tc_made_count( m_tc_made_count.load() );
-  info.set_tc_sent_count( m_tc_sent_count.load() );
-  info.set_tc_failed_sent_count( m_tc_failed_sent_count.load() );
+  info.set_tc_made_count(m_tc_made_count.load());
+  info.set_tc_sent_count(m_tc_sent_count.load());
+  info.set_tc_failed_sent_count(m_tc_failed_sent_count.load());
 
   this->publish(std::move(info));
 
-  if ( m_latency_monitoring.load() && m_running_flag.load() ) {
+  if (m_latency_monitoring.load() && m_running_flag.load()) {
     opmon::TriggerLatencyStandalone lat_info;
 
-    lat_info.set_latency_out( m_latency_instance.get_latency_out() );
+    lat_info.set_latency_out(m_latency_instance.get_latency_out());
 
     this->publish(std::move(lat_info));
   }
@@ -86,19 +86,17 @@ RandomTCMakerModule::do_configure(const nlohmann::json& /*obj*/)
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering conf() method";
 
   // Get the output connections
-  for(auto con: m_mtrg->get_outputs()){
+  for (auto con : m_mtrg->get_outputs()) {
     TLOG() << "TC sink is " << con->class_name() << "@" << con->UID();
-    m_trigger_candidate_sink =
-        get_iom_sender<triggeralgs::TriggerCandidate>(con->UID());
+    m_trigger_candidate_sink = get_iom_sender<triggeralgs::TriggerCandidate>(con->UID());
   }
 
   // Get the input connections
-  for(auto con: m_mtrg->get_inputs()) {
+  for (auto con : m_mtrg->get_inputs()) {
     // Get the time sync source
-    TLOG() << "TimeSync receiver connection is " << con->class_name() << "@"
-           << con->UID() << " with tag " << get_name();
-    m_time_sync_source =
-      get_iomanager()->get_receiver<dfmessages::TimeSync>(con->UID(), get_name());
+    TLOG() << "TimeSync receiver connection is " << con->class_name() << "@" << con->UID() << " with tag "
+           << get_name();
+    m_time_sync_source = get_iomanager()->get_receiver<dfmessages::TimeSync>(con->UID(), get_name());
   }
   m_conf = m_mtrg->get_configuration();
 
@@ -106,24 +104,23 @@ RandomTCMakerModule::do_configure(const nlohmann::json& /*obj*/)
   const appmodel::TCReadoutMap* tc_readout = m_conf->get_tc_readout();
   m_tcout_time_before = tc_readout->get_time_before();
   m_tcout_time_after = tc_readout->get_time_after();
-  m_tcout_type = static_cast<TCType>(
-      dunedaq::trgdataformats::string_to_trigger_candidate_type(tc_readout->get_tc_type_name()));
+  m_tcout_type =
+    static_cast<TCType>(dunedaq::trgdataformats::string_to_trigger_candidate_type(tc_readout->get_tc_type_name()));
 
   // Throw error if unknown TC type
   if (m_tcout_type == TCType::kUnknown) {
     throw(InvalidConfiguration(ERS_HERE, "Provided an unknown TC type output to RandomTCMakerModule!"));
   }
 
-  m_latency_monitoring.store( m_conf->get_latency_monitoring() );
+  m_latency_monitoring.store(m_conf->get_latency_monitoring());
   m_trigger_rate_hz.store(m_conf->get_trigger_rate_hz());
 
   TLOG() << "RandomTCMaker will output TC of type: " << tc_readout->get_tc_type_name();
-  TLOG() << "TC window time before: " << m_tcout_time_before
-         << " time after: " << m_tcout_time_after;
+  TLOG() << "TC window time before: " << m_tcout_time_before << " time after: " << m_tcout_time_after;
   TLOG() << "Clock speed is: " << m_clock_speed_hz;
   TLOG() << "Output trigger rate is: " << m_trigger_rate_hz.load();
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) <<  ": Exiting conf() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting conf() method";
 }
 
 void
@@ -143,15 +140,14 @@ RandomTCMakerModule::do_start(const nlohmann::json& obj)
   if (timestamp_method == "kTimeSync") {
     TLOG_DEBUG(0) << "Creating TimestampEstimator";
     m_timestamp_estimator.reset(new utilities::TimestampEstimator(m_run_number, m_clock_speed_hz));
-    m_time_sync_source->add_callback(std::bind(&utilities::TimestampEstimator::timesync_callback<dfmessages::TimeSync>,
-          reinterpret_cast<utilities::TimestampEstimator*>(m_timestamp_estimator.get()),
-          std::placeholders::_1));
-  }
-  else if(timestamp_method == "kSystemClock"){
+    m_time_sync_source->add_callback(
+      std::bind(&utilities::TimestampEstimator::timesync_callback<dfmessages::TimeSync>,
+                reinterpret_cast<utilities::TimestampEstimator*>(m_timestamp_estimator.get()),
+                std::placeholders::_1));
+  } else if (timestamp_method == "kSystemClock") {
     TLOG_DEBUG(0) << "Creating TimestampEstimatorSystem";
     m_timestamp_estimator.reset(new utilities::TimestampEstimatorSystem(m_clock_speed_hz));
-  }
-  else{
+  } else {
     // TODO: write some error message
   }
 
@@ -164,7 +160,7 @@ RandomTCMakerModule::do_start(const nlohmann::json& obj)
 
   m_send_trigger_candidates_thread = std::thread(&RandomTCMakerModule::send_trigger_candidates, this);
   pthread_setname_np(m_send_trigger_candidates_thread.native_handle(), "random-tc-maker");
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) <<  ": Exiting start() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting start() method";
 }
 
 void
@@ -182,7 +178,7 @@ RandomTCMakerModule::do_stop(const nlohmann::json& /*obj*/)
   m_timestamp_estimator.reset(nullptr); // Calls TimestampEstimator dtor
 
   print_opmon_stats();
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) <<  ": Exiting stop() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting stop() method";
 }
 
 void
@@ -191,7 +187,7 @@ RandomTCMakerModule::do_scrap(const nlohmann::json& /*obj*/)
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering scrap() method";
   m_time_sync_source.reset();
   m_trigger_candidate_sink.reset();
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) <<  ": Exiting scrap() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting scrap() method";
 }
 
 void
@@ -203,7 +199,7 @@ RandomTCMakerModule::do_change_trigger_rate(const nlohmann::json& obj)
   TLOG() << "Changing trigger rate from " << m_trigger_rate_hz.load() << " to " << change_rate_params.trigger_rate;
 
   m_trigger_rate_hz.store(change_rate_params.trigger_rate);
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) <<  ": Exiting change-rate() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting change-rate() method";
 }
 
 triggeralgs::TriggerCandidate
@@ -229,14 +225,12 @@ RandomTCMakerModule::get_interval(std::mt19937& gen)
 
   uint64_t interval = m_clock_speed_hz / m_trigger_rate_hz.load();
 
-  if( time_distribution == "kUniform"){
+  if (time_distribution == "kUniform") {
     return interval;
-  }
-  else if(time_distribution == "kPoisson"){
+  } else if (time_distribution == "kPoisson") {
     std::exponential_distribution<double> d(1.0 / interval);
     return static_cast<uint64_t>(0.5 + d(gen));
-  }
-  else{
+  } else {
     TLOG_DEBUG(1) << get_name() << " unknown distribution! Using kUniform.";
   }
   return interval;
@@ -263,7 +257,7 @@ RandomTCMakerModule::send_trigger_candidates()
     // If trigger rate is 0, just sleep. Need to use small number here because
     // of floating point precision...
     constexpr float epsilon = 1e-9;
-    if ( m_trigger_rate_hz.load() <= epsilon) {
+    if (m_trigger_rate_hz.load() <= epsilon) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
       continue;
     }
@@ -280,8 +274,9 @@ RandomTCMakerModule::send_trigger_candidates()
     TLOG_DEBUG(1) << get_name() << " at timestamp " << m_timestamp_estimator->get_timestamp_estimate()
                   << ", pushing a candidate with timestamp " << candidate.time_candidate;
 
-    if (m_latency_monitoring.load()) m_latency_instance.update_latency_out( candidate.time_candidate );
-    try{
+    if (m_latency_monitoring.load())
+      m_latency_instance.update_latency_out(candidate.time_candidate);
+    try {
       m_trigger_candidate_sink->send(std::move(candidate), std::chrono::milliseconds(10));
       m_tc_sent_count++;
     } catch (const ers::Issue& e) {

--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -50,6 +50,31 @@ RandomTCMakerModule::RandomTCMakerModule(const std::string& name)
 void
 RandomTCMakerModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
 {
+}
+
+void
+RandomTCMakerModule::generate_opmon_data()
+{
+  opmon::RandomTCMakerInfo info;
+
+  info.set_tc_made_count( m_tc_made_count.load() );
+  info.set_tc_sent_count( m_tc_sent_count.load() );
+  info.set_tc_failed_sent_count( m_tc_failed_sent_count.load() );
+
+  this->publish(std::move(info));
+
+  if ( m_latency_monitoring.load() && m_running_flag.load() ) {
+    opmon::TriggerLatencyStandalone lat_info;
+
+    lat_info.set_latency_out( m_latency_instance.get_latency_out() );
+
+    this->publish(std::move(lat_info));
+  }
+}
+
+void
+RandomTCMakerModule::do_configure(const nlohmann::json& /*obj*/)
+{
   auto mtrg = mcfg->get_dal<appmodel::RandomTCMakerModule>(get_name());
 
   // Get the output connections
@@ -91,32 +116,6 @@ RandomTCMakerModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
          << " time after: " << m_tcout_time_after;
   TLOG() << "Clock speed is: " << m_clock_speed_hz;
   TLOG() << "Output trigger rate is: " << m_trigger_rate_hz.load();
-}
-
-void
-RandomTCMakerModule::generate_opmon_data()
-{
-  opmon::RandomTCMakerInfo info;
-
-  info.set_tc_made_count( m_tc_made_count.load() );
-  info.set_tc_sent_count( m_tc_sent_count.load() );
-  info.set_tc_failed_sent_count( m_tc_failed_sent_count.load() );
-
-  this->publish(std::move(info));
-
-  if ( m_latency_monitoring.load() && m_running_flag.load() ) {
-    opmon::TriggerLatencyStandalone lat_info;
-
-    lat_info.set_latency_out( m_latency_instance.get_latency_out() );
-
-    this->publish(std::move(lat_info));
-  }
-}
-
-void
-RandomTCMakerModule::do_configure(const nlohmann::json& /*obj*/)
-{
-  //m_conf = obj.get<randomtriggercandidatemaker::Conf>();
 }
 
 void
@@ -176,8 +175,10 @@ RandomTCMakerModule::do_stop(const nlohmann::json& /*obj*/)
 
 void
 RandomTCMakerModule::do_scrap(const nlohmann::json& /*obj*/)
-{}
-
+{
+  m_time_sync_source.reset(nullptr);
+  m_trigger_candidate_sink.reset(nullptr);
+}
 
 void
 RandomTCMakerModule::do_change_trigger_rate(const nlohmann::json& obj)

--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -293,8 +293,8 @@ RandomTCMakerModule::print_opmon_stats()
 {
   TLOG() << "RandomTCMaker opmon counters summary:";
   TLOG() << "------------------------------";
-  TLOG() << "Made TCs: \t\t" << m_tc_made_count;
-  TLOG() << "Sent TCs: \t\t" << m_tc_sent_count;
+  TLOG() << "Made TCs: \t\t\t" << m_tc_made_count;
+  TLOG() << "Sent TCs: \t\t\t" << m_tc_sent_count;
   TLOG() << "Failed to send TCs: \t" << m_tc_failed_sent_count;
   TLOG();
 }

--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -50,6 +50,14 @@ RandomTCMakerModule::RandomTCMakerModule(const std::string& name)
 void
 RandomTCMakerModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering init() method";
+
+  m_mtrg = mcfg->get_dal<appmodel::RandomTCMakerModule>(get_name());
+
+  // Get the clock speed from detector configuration
+  m_clock_speed_hz = mcfg->session()->get_detector_configuration()->get_clock_speed_hz();
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
 }
 
 void
@@ -75,24 +83,24 @@ RandomTCMakerModule::generate_opmon_data()
 void
 RandomTCMakerModule::do_configure(const nlohmann::json& /*obj*/)
 {
-  auto mtrg = mcfg->get_dal<appmodel::RandomTCMakerModule>(get_name());
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering conf() method";
 
   // Get the output connections
-  for(auto con: mtrg->get_outputs()){
+  for(auto con: m_mtrg->get_outputs()){
     TLOG() << "TC sink is " << con->class_name() << "@" << con->UID();
     m_trigger_candidate_sink =
         get_iom_sender<triggeralgs::TriggerCandidate>(con->UID());
   }
 
   // Get the input connections
-  for(auto con: mtrg->get_inputs()) {
+  for(auto con: m_mtrg->get_inputs()) {
     // Get the time sync source
     TLOG() << "TimeSync receiver connection is " << con->class_name() << "@"
            << con->UID() << " with tag " << get_name();
     m_time_sync_source =
       get_iomanager()->get_receiver<dfmessages::TimeSync>(con->UID(), get_name());
   }
-  m_conf = mtrg->get_configuration();
+  m_conf = m_mtrg->get_configuration();
 
   // Get the TC out configuration
   const appmodel::TCReadoutMap* tc_readout = m_conf->get_tc_readout();
@@ -107,20 +115,21 @@ RandomTCMakerModule::do_configure(const nlohmann::json& /*obj*/)
   }
 
   m_latency_monitoring.store( m_conf->get_latency_monitoring() );
-
-  // Get the clock speed from detector configuration
-  m_clock_speed_hz = mcfg->session()->get_detector_configuration()->get_clock_speed_hz();
   m_trigger_rate_hz.store(m_conf->get_trigger_rate_hz());
+
   TLOG() << "RandomTCMaker will output TC of type: " << tc_readout->get_tc_type_name();
   TLOG() << "TC window time before: " << m_tcout_time_before
          << " time after: " << m_tcout_time_after;
   TLOG() << "Clock speed is: " << m_clock_speed_hz;
   TLOG() << "Output trigger rate is: " << m_trigger_rate_hz.load();
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) <<  ": Exiting conf() method";
 }
 
 void
 RandomTCMakerModule::do_start(const nlohmann::json& obj)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering start() method";
   m_run_number = obj.value<dunedaq::daqdataformats::run_number_t>("run", 0);
 
   m_running_flag.store(true);
@@ -155,11 +164,13 @@ RandomTCMakerModule::do_start(const nlohmann::json& obj)
 
   m_send_trigger_candidates_thread = std::thread(&RandomTCMakerModule::send_trigger_candidates, this);
   pthread_setname_np(m_send_trigger_candidates_thread.native_handle(), "random-tc-maker");
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) <<  ": Exiting start() method";
 }
 
 void
 RandomTCMakerModule::do_stop(const nlohmann::json& /*obj*/)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering stop() method";
   m_running_flag.store(false);
 
   m_send_trigger_candidates_thread.join();
@@ -171,23 +182,28 @@ RandomTCMakerModule::do_stop(const nlohmann::json& /*obj*/)
   m_timestamp_estimator.reset(nullptr); // Calls TimestampEstimator dtor
 
   print_opmon_stats();
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) <<  ": Exiting stop() method";
 }
 
 void
 RandomTCMakerModule::do_scrap(const nlohmann::json& /*obj*/)
 {
-  m_time_sync_source.reset(nullptr);
-  m_trigger_candidate_sink.reset(nullptr);
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering scrap() method";
+  m_time_sync_source.reset();
+  m_trigger_candidate_sink.reset();
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) <<  ": Exiting scrap() method";
 }
 
 void
 RandomTCMakerModule::do_change_trigger_rate(const nlohmann::json& obj)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering change-rate() method";
   auto change_rate_params = obj.get<rcif::cmd::ChangeRateParams>();
 
   TLOG() << "Changing trigger rate from " << m_trigger_rate_hz.load() << " to " << change_rate_params.trigger_rate;
 
   m_trigger_rate_hz.store(change_rate_params.trigger_rate);
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) <<  ": Exiting change-rate() method";
 }
 
 triggeralgs::TriggerCandidate

--- a/plugins/RandomTCMakerModule.hpp
+++ b/plugins/RandomTCMakerModule.hpp
@@ -9,11 +9,11 @@
 
 #include "trigger/TokenManager.hpp"
 
-#include "appfwk/DAQModule.hpp"
 #include "appfwk/ConfigurationManager.hpp"
+#include "appfwk/DAQModule.hpp"
 #include "confmodel/Connection.hpp"
-#include "confmodel/Session.hpp"
 #include "confmodel/DetectorConfig.hpp"
+#include "confmodel/Session.hpp"
 
 #include "appmodel/RandomTCMakerConf.hpp"
 #include "appmodel/RandomTCMakerModule.hpp"
@@ -27,11 +27,11 @@
 #include "dfmessages/Types.hpp"
 #include "iomanager/Receiver.hpp"
 #include "iomanager/Sender.hpp"
-#include "utilities/TimestampEstimator.hpp"
-#include "triggeralgs/TriggerCandidate.hpp"
 #include "trigger/Latency.hpp"
-#include "trigger/opmon/randomtcmaker_info.pb.h"
 #include "trigger/opmon/latency_info.pb.h"
+#include "trigger/opmon/randomtcmaker_info.pb.h"
+#include "triggeralgs/TriggerCandidate.hpp"
+#include "utilities/TimestampEstimator.hpp"
 
 #include "rcif/cmd/Nljs.hpp"
 
@@ -59,14 +59,10 @@ public:
    */
   explicit RandomTCMakerModule(const std::string& name);
 
-  RandomTCMakerModule(const RandomTCMakerModule&) =
-    delete; ///< RandomTCMakerModule is not copy-constructible
-  RandomTCMakerModule& operator=(const RandomTCMakerModule&) =
-    delete; ///< RandomTCMakerModule is not copy-assignable
-  RandomTCMakerModule(RandomTCMakerModule&&) =
-    delete; ///< RandomTCMakerModule is not move-constructible
-  RandomTCMakerModule& operator=(RandomTCMakerModule&&) =
-    delete; ///< RandomTCMakerModule is not move-assignable
+  RandomTCMakerModule(const RandomTCMakerModule&) = delete; ///< RandomTCMakerModule is not copy-constructible
+  RandomTCMakerModule& operator=(const RandomTCMakerModule&) = delete; ///< RandomTCMakerModule is not copy-assignable
+  RandomTCMakerModule(RandomTCMakerModule&&) = delete;            ///< RandomTCMakerModule is not move-constructible
+  RandomTCMakerModule& operator=(RandomTCMakerModule&&) = delete; ///< RandomTCMakerModule is not move-assignable
 
   void init(std::shared_ptr<appfwk::ConfigurationManager> mcfg) override;
   void generate_opmon_data() override;
@@ -123,7 +119,7 @@ private:
   std::atomic<bool> m_running_flag{ false };
 
   // OpMon variables
-  using metric_counter_type = uint64_t; //decltype(randomtriggercandidatemakerinfo::Info::tc_sent_count);
+  using metric_counter_type = uint64_t; // decltype(randomtriggercandidatemakerinfo::Info::tc_sent_count);
   std::atomic<metric_counter_type> m_tc_made_count{ 0 };
   std::atomic<metric_counter_type> m_tc_sent_count{ 0 };
   std::atomic<metric_counter_type> m_tc_failed_sent_count{ 0 };

--- a/plugins/RandomTCMakerModule.hpp
+++ b/plugins/RandomTCMakerModule.hpp
@@ -98,6 +98,8 @@ private:
   std::shared_ptr<iomanager::ReceiverConcept<dfmessages::TimeSync>> m_time_sync_source;
   std::shared_ptr<iomanager::SenderConcept<triggeralgs::TriggerCandidate>> m_trigger_candidate_sink;
 
+  // confs
+  const dunedaq::appmodel::RandomTCMakerModule* m_mtrg;
   const appmodel::RandomTCMakerConf* m_conf;
 
   /// @brief Output TC type

--- a/src/TAProcessor.cpp
+++ b/src/TAProcessor.cpp
@@ -174,8 +174,8 @@ TAProcessor::print_opmon_stats()
   TLOG() << "TAProcessor opmon counters summary:";
   TLOG() << "------------------------------";
   TLOG() << "TAs received: \t\t" << m_ta_received_count;
-  TLOG() << "TCs made: \t\t\t" << m_tc_made_count;
-  TLOG() << "TCs sent: \t\t\t" << m_tc_sent_count;
+  TLOG() << "TCs made: \t\t" << m_tc_made_count;
+  TLOG() << "TCs sent: \t\t" << m_tc_sent_count;
   TLOG() << "TCs failed to send: \t" << m_tc_failed_sent_count;
   TLOG();
 }

--- a/src/TAProcessor.cpp
+++ b/src/TAProcessor.cpp
@@ -47,6 +47,7 @@ TAProcessor::~TAProcessor()
 void
 TAProcessor::start(const nlohmann::json& args)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TAProcessor: Entering start() method";
 
   // Reset stats
   m_ta_received_count.store(0);
@@ -57,19 +58,27 @@ TAProcessor::start(const nlohmann::json& args)
   m_running_flag.store(true);
 
   inherited::start(args);
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TAProcessor: Exiting start() method";
 }
 
 void
 TAProcessor::stop(const nlohmann::json& args)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TAProcessor: Entering stop() method";
+
   inherited::stop(args);
   m_running_flag.store(false);
   print_opmon_stats();
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TAProcessor: Exiting stop() method";
 }
 
 void
 TAProcessor::conf(const appmodel::DataHandlerModule* conf)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TAProcessor: Entering conf() method";
+
   for (auto output : conf->get_outputs()) {
    try {
       if (output->get_data_type() == "TriggerCandidate") {
@@ -99,6 +108,18 @@ TAProcessor::conf(const appmodel::DataHandlerModule* conf)
   }
   m_latency_monitoring.store( dp->get_latency_monitoring() );
   inherited::conf(conf);
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TAProcessor: Exiting conf() method";
+}
+
+void
+TAProcessor::scrap(const nlohmann::json& args)
+{
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TAProcessor: Entering scrap() method";
+  m_tcms.clear();
+  m_tc_sink.reset();
+  inherited::scrap(args);
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TAProcessor: Exiting scrap() method";
 }
 
 void

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -40,7 +40,7 @@ TCProcessor::~TCProcessor()
 void
 TCProcessor::start(const nlohmann::json& args)
 {
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering start() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TCProcessor: Entering start() method";
 
   m_running_flag.store(true);
   m_send_trigger_decisions_thread = std::thread(&TCProcessor::send_trigger_decisions, this);
@@ -62,13 +62,13 @@ TCProcessor::start(const nlohmann::json& args)
   m_tc_ignored_count.store(0);
   inherited::start(args);
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting start() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TCProcessor: Exiting start() method";
 }
 
 void
 TCProcessor::stop(const nlohmann::json& args)
 {
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering stop() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TCProcessor: Entering stop() method";
 
   inherited::stop(args);
   m_running_flag.store(false);
@@ -89,13 +89,13 @@ TCProcessor::stop(const nlohmann::json& args)
 
   print_opmon_stats();
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting stop() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TCProcessor: Exiting stop() method";
 }
 
 void
 TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
 {
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering conf() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TCProcessor: Entering conf() method";
 
   auto m_mtrg = cfg->cast<appmodel::TriggerDataHandlerModule>();	
   if (m_mtrg == nullptr) {
@@ -190,13 +190,13 @@ TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
 
   inherited::conf(m_mtrg);
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting conf() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TCProcessor: Exiting conf() method";
 }
 
 void
 TCProcessor::scrap(const nlohmann::json& args)
 {
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering scrap() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TCProcessor: Entering scrap() method";
 
   m_mandatory_links.clear();
   m_group_links.clear();
@@ -217,7 +217,7 @@ TCProcessor::scrap(const nlohmann::json& args)
   
   inherited::scrap(args);
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting scrap() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TCProcessor: Exiting scrap() method";
 }
 
 void

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -97,11 +97,11 @@ TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TCProcessor: Entering conf() method";
 
-  auto m_mtrg = cfg->cast<appmodel::TriggerDataHandlerModule>();	
-  if (m_mtrg == nullptr) {
+  auto mtrg = cfg->cast<appmodel::TriggerDataHandlerModule>();	
+  if (mtrg == nullptr) {
     throw(InvalidConfiguration(ERS_HERE, "Provided null TriggerDataHandlerModule configuration!"));
   }
-  for (auto output : m_mtrg->get_outputs()) {
+  for (auto output : mtrg->get_outputs()) {
    try {
       if (output->get_data_type() == "TriggerDecision") {
          m_td_sink = get_iom_sender<dfmessages::TriggerDecision>(output->UID());
@@ -111,17 +111,17 @@ TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
     }
   }
 
-  auto dp = m_mtrg->get_module_configuration()->get_data_processor();
+  auto dp = mtrg->get_module_configuration()->get_data_processor();
   auto proc_conf = dp->cast<appmodel::TCDataProcessor>();
 
   // Add all Source IDs to mandatoy links for now...
-  for(auto const& link : m_mtrg->get_mandatory_source_ids()){
+  for(auto const& link : mtrg->get_mandatory_source_ids()){
     m_mandatory_links.push_back(
         dfmessages::SourceID{
         daqdataformats::SourceID::string_to_subsystem(link->get_subsystem()),
         link->get_sid()});
   }  
-  for(auto const& link : m_mtrg->get_enabled_source_ids()){
+  for(auto const& link : mtrg->get_enabled_source_ids()){
     m_mandatory_links.push_back(
         dfmessages::SourceID{
         daqdataformats::SourceID::string_to_subsystem(link->get_subsystem()),
@@ -188,7 +188,7 @@ TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
   m_latency_monitoring.store( dp->get_latency_monitoring() );
   inherited::add_postprocess_task(std::bind(&TCProcessor::make_td, this, std::placeholders::_1));
 
-  inherited::conf(m_mtrg);
+  inherited::conf(mtrg);
 
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TCProcessor: Exiting conf() method";
 }

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -860,11 +860,11 @@ TCProcessor::print_opmon_stats()
 {
   TLOG() << "TCProcessor opmon counters summary:";
   TLOG() << "------------------------------";
-  TLOG() << "TDs created: \t\t" << m_tds_created_count << " \t(" << m_tds_created_tc_count << " TCs)";
+  TLOG() << "TDs created: \t\t\t" << m_tds_created_count << " \t(" << m_tds_created_tc_count << " TCs)";
   TLOG() << "TDs sent: \t\t\t" << m_tds_sent_count << " \t(" << m_tds_sent_tc_count << " TCs)";
-  TLOG() << "TDs dropped: \t\t" << m_tds_dropped_count << " \t(" << m_tds_dropped_tc_count << " TCs)";
+  TLOG() << "TDs dropped: \t\t\t" << m_tds_dropped_count << " \t(" << m_tds_dropped_tc_count << " TCs)";
   TLOG() << "TDs failed bitword check: \t" << m_tds_failed_bitword_count << " \t(" << m_tds_failed_bitword_tc_count << " TCs)";
-  TLOG() << "TDs cleared: \t\t" << m_tds_cleared_count << " \t(" << m_tds_cleared_tc_count << " TCs)";
+  TLOG() << "TDs cleared: \t\t\t" << m_tds_cleared_count << " \t(" << m_tds_cleared_tc_count << " TCs)";
   TLOG() << "------------------------------";
   TLOG() << "TCs received: \t" << m_tc_received_count;
   TLOG() << "TCs ignored: \t" << m_tc_ignored_count;

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -40,6 +40,8 @@ TCProcessor::~TCProcessor()
 void
 TCProcessor::start(const nlohmann::json& args)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering start() method";
+
   m_running_flag.store(true);
   m_send_trigger_decisions_thread = std::thread(&TCProcessor::send_trigger_decisions, this);
   pthread_setname_np(m_send_trigger_decisions_thread.native_handle(), "mlt-dec"); // TODO: originally mlt-trig-dec
@@ -59,11 +61,15 @@ TCProcessor::start(const nlohmann::json& args)
   m_tds_cleared_tc_count.store(0);
   m_tc_ignored_count.store(0);
   inherited::start(args);
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting start() method";
 }
 
 void
 TCProcessor::stop(const nlohmann::json& args)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering stop() method";
+
   inherited::stop(args);
   m_running_flag.store(false);
 
@@ -83,16 +89,19 @@ TCProcessor::stop(const nlohmann::json& args)
 
   print_opmon_stats();
 
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting stop() method";
 }
 
 void
 TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
 {
-  auto mtrg = cfg->cast<appmodel::TriggerDataHandlerModule>();	
-  if (mtrg == nullptr) {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering conf() method";
+
+  auto m_mtrg = cfg->cast<appmodel::TriggerDataHandlerModule>();	
+  if (m_mtrg == nullptr) {
     throw(InvalidConfiguration(ERS_HERE, "Provided null TriggerDataHandlerModule configuration!"));
   }
-  for (auto output : mtrg->get_outputs()) {
+  for (auto output : m_mtrg->get_outputs()) {
    try {
       if (output->get_data_type() == "TriggerDecision") {
          m_td_sink = get_iom_sender<dfmessages::TriggerDecision>(output->UID());
@@ -102,17 +111,17 @@ TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
     }
   }
 
-  auto dp = mtrg->get_module_configuration()->get_data_processor();
+  auto dp = m_mtrg->get_module_configuration()->get_data_processor();
   auto proc_conf = dp->cast<appmodel::TCDataProcessor>();
 
   // Add all Source IDs to mandatoy links for now...
-  for(auto const& link : mtrg->get_mandatory_source_ids()){
+  for(auto const& link : m_mtrg->get_mandatory_source_ids()){
     m_mandatory_links.push_back(
         dfmessages::SourceID{
         daqdataformats::SourceID::string_to_subsystem(link->get_subsystem()),
         link->get_sid()});
   }  
-  for(auto const& link : mtrg->get_enabled_source_ids()){
+  for(auto const& link : m_mtrg->get_enabled_source_ids()){
     m_mandatory_links.push_back(
         dfmessages::SourceID{
         daqdataformats::SourceID::string_to_subsystem(link->get_subsystem()),
@@ -179,7 +188,36 @@ TCProcessor::conf(const appmodel::DataHandlerModule* cfg)
   m_latency_monitoring.store( dp->get_latency_monitoring() );
   inherited::add_postprocess_task(std::bind(&TCProcessor::make_td, this, std::placeholders::_1));
 
-  inherited::conf(mtrg);
+  inherited::conf(m_mtrg);
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting conf() method";
+}
+
+void
+TCProcessor::scrap(const nlohmann::json& args)
+{
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering scrap() method";
+
+  m_mandatory_links.clear();
+  m_group_links.clear();
+  m_roi_conf.clear();
+  m_roi_conf_data.clear();
+  m_roi_conf_ids.clear();
+  m_roi_conf_probs.clear();
+  m_roi_conf_probs_c.clear();
+  m_pending_tds.clear();
+  m_readout_window_map_data.clear();
+  m_readout_window_map.clear();
+  m_ignored_tc_types.clear();
+  
+  m_td_sink.reset();
+  
+  m_group_links_data.clear();
+  m_pending_tds.clear();
+  
+  inherited::scrap(args);
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << ": Exiting scrap() method";
 }
 
 void

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -213,7 +213,6 @@ TCProcessor::scrap(const nlohmann::json& args)
   m_td_sink.reset();
   
   m_group_links_data.clear();
-  m_pending_tds.clear();
   
   inherited::scrap(args);
 

--- a/src/TPProcessor.cpp
+++ b/src/TPProcessor.cpp
@@ -45,6 +45,7 @@ TPProcessor::~TPProcessor()
 void
 TPProcessor::start(const nlohmann::json& args)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TPProcessor: Entering start() method";
 
   // Reset stats
   m_tp_received_count.store(0);
@@ -55,19 +56,27 @@ TPProcessor::start(const nlohmann::json& args)
   m_running_flag.store(true);
 
   inherited::start(args);
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TPProcessor: Exiting start() method";
 }
 
 void
 TPProcessor::stop(const nlohmann::json& args)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TPProcessor: Entering stop() method";
+  
   inherited::stop(args);
   m_running_flag.store(false);
   print_opmon_stats();
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TPProcessor: Exiting stop() method";
 }
 
 void
 TPProcessor::conf(const appmodel::DataHandlerModule* conf)
 {
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TPProcessor: Entering conf() method";
+
   for (auto output : conf->get_outputs()) {
    try {
       if (output->get_data_type() == "TriggerActivity") {
@@ -102,6 +111,17 @@ TPProcessor::conf(const appmodel::DataHandlerModule* conf)
   m_latency_monitoring.store( dp->get_latency_monitoring() );
   inherited::conf(conf);
 
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TPProcessor: Exiting conf() method";
+}
+
+void
+TPProcessor::scrap(const nlohmann::json& args)
+{
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TPProcessor: Entering scrap() method";
+  m_tams.clear();
+  m_ta_sink.reset();
+  inherited::scrap(args);
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "TPProcessor: Exiting scrap() method";
 }
 
 void

--- a/src/TPProcessor.cpp
+++ b/src/TPProcessor.cpp
@@ -177,8 +177,8 @@ TPProcessor::print_opmon_stats()
   TLOG() << "TPProcessor opmon counters summary:";
   TLOG() << "------------------------------";
   TLOG() << "TPs received: \t\t" << m_tp_received_count;
-  TLOG() << "TAs made: \t\t\t" << m_ta_made_count;
-  TLOG() << "TAs sent: \t\t\t" << m_ta_sent_count;
+  TLOG() << "TAs made: \t\t" << m_ta_made_count;
+  TLOG() << "TAs sent: \t\t" << m_ta_sent_count;
   TLOG() << "TAs failed to send: \t" << m_ta_failed_sent_count;
   TLOG();
 }

--- a/src/TPRequestHandler.cpp
+++ b/src/TPRequestHandler.cpp
@@ -25,6 +25,7 @@ TPRequestHandler::conf(const appmodel::DataHandlerModule* conf) {
 void
 TPRequestHandler::scrap(const nlohmann::json& args) {
   m_tpset_sink.reset();
+  inherited2::scrap(args);
 }
 
 void 

--- a/src/TPRequestHandler.cpp
+++ b/src/TPRequestHandler.cpp
@@ -22,6 +22,11 @@ TPRequestHandler::conf(const appmodel::DataHandlerModule* conf) {
    inherited2::conf(conf);
 }
 
+void
+TPRequestHandler::scrap(const nlohmann::json& args) {
+  m_tpset_sink.reset();
+}
+
 void 
 TPRequestHandler::start(const nlohmann::json& args) {
 

--- a/src/trigger/HSISourceModel.hpp
+++ b/src/trigger/HSISourceModel.hpp
@@ -51,7 +51,12 @@ public:
    * @param name Instance name for this SourceModel instance
    */
   HSISourceModel(): datahandlinglibs::SourceConcept() {}
-  ~HSISourceModel() {}
+  ~HSISourceModel()
+  {
+    m_data_receiver.reset();
+    m_data_sender.reset();
+    m_signals.clear();
+  }
 
   void init(const confmodel::DaqModule* cfg) override
   {

--- a/src/trigger/HSISourceModel.hpp
+++ b/src/trigger/HSISourceModel.hpp
@@ -51,7 +51,7 @@ public:
    * @param name Instance name for this SourceModel instance
    */
   HSISourceModel(): datahandlinglibs::SourceConcept() {}
-  ~HSISourceModel()
+  ~HSISourceModel() override
   {
     m_data_receiver.reset();
     m_data_sender.reset();

--- a/src/trigger/TAProcessor.hpp
+++ b/src/trigger/TAProcessor.hpp
@@ -48,6 +48,8 @@ public:
 
   void conf(const appmodel::DataHandlerModule* conf) override;
 
+  void scrap(const nlohmann::json& args) override;
+
   void generate_opmon_data() override;
 
 protected:

--- a/src/trigger/TCProcessor.hpp
+++ b/src/trigger/TCProcessor.hpp
@@ -84,8 +84,6 @@ private:
   void add_requests_to_decision(dfmessages::TriggerDecision& decision,
                                 std::vector<dfmessages::ComponentRequest> requests);
 
-  const appmodel::TriggerDataHandlerModule* m_mtrg;
-
   // ROI
   bool m_use_roi_readout;
   struct roi_group

--- a/src/trigger/TCProcessor.hpp
+++ b/src/trigger/TCProcessor.hpp
@@ -16,6 +16,7 @@
 #include "appmodel/TCReadoutMap.hpp"
 #include "appmodel/ROIGroupConf.hpp"
 #include "appmodel/SourceIDConf.hpp"
+#include "appmodel/TriggerDataHandlerModule.hpp"
 
 #include "datahandlinglibs/models/TaskRawDataProcessorModel.hpp"
 
@@ -53,6 +54,8 @@ public:
 
   void conf(const appmodel::DataHandlerModule* conf) override;
 
+  void scrap(const nlohmann::json& args) override;
+
   void generate_opmon_data() override;
 
 protected:
@@ -80,6 +83,8 @@ private:
                                                                          triggeralgs::timestamp_t end);
   void add_requests_to_decision(dfmessages::TriggerDecision& decision,
                                 std::vector<dfmessages::ComponentRequest> requests);
+
+  const appmodel::TriggerDataHandlerModule* m_mtrg;
 
   // ROI
   bool m_use_roi_readout;

--- a/src/trigger/TPProcessor.hpp
+++ b/src/trigger/TPProcessor.hpp
@@ -48,6 +48,8 @@ public:
 
   void conf(const appmodel::DataHandlerModule* conf) override;
 
+  void scrap(const nlohmann::json& args) override;
+
   void generate_opmon_data() override;
 
 protected:

--- a/src/trigger/TPRequestHandler.hpp
+++ b/src/trigger/TPRequestHandler.hpp
@@ -63,6 +63,7 @@ public:
  
   void conf(const appmodel::DataHandlerModule* conf) override;
   void start(const nlohmann::json& args) override;
+  void scrap(const nlohmann::json& args) override;
   void periodic_data_transmission() override;
   
 private:

--- a/src/trigger/TriggerGenericMaker.hpp
+++ b/src/trigger/TriggerGenericMaker.hpp
@@ -65,6 +65,7 @@ public:
     register_command("start", &TriggerGenericMaker::do_start);
     register_command("stop", &TriggerGenericMaker::do_stop);
     register_command("conf", &TriggerGenericMaker::do_configure);
+    register_command("scrap", &TriggerGenericMaker::do_scrap);
   }
 
   virtual ~TriggerGenericMaker() {}
@@ -167,6 +168,14 @@ private:
    
     // worker should be notified that configuration potentially changed
     worker.reconfigure();
+  }
+
+  void do_scrap(const nlohmann::json& obj)
+  {
+    m_input_queue.reset();
+    m_output_queue.reset();
+    m_maker.reset();
+    m_maker_conf.clear();
   }
 
   void do_work(std::atomic<bool>& m_running_flag)


### PR DESCRIPTION
There was an issue discovered where destructors of makers (triggeralgs modules) were not being reached. There were multiple reasons for this (the base classes in datahandlinglibs not reaching destructors ?) but another one is that the scrap methods were not (fully) implemented in some trigger modules.
Another reason this is important is the potential `stop -> scrap -> conf` fsm transition which is expected to work (currently doesn't due to issues in df). 

Here is the implementation of more appropriate conf and scrap methods for the trigger modules.
There are no logical / functional changes, the code changes are just splitting already present functionality to relevant init,conf,scrap blocks; additional cleanup in the scrap blocks, and some improved logging. 

Tested locally (one can use https://github.com/DUNE-DAQ/triggeralgs/compare/develop...mrigan/ta_makers_debug for testing only) and passed the usual suite of integration tests. 