### PR TITLE
Added setting of m_last_processed_daq_ts in TxProcessor classes to ge…

### DIFF
--- a/src/TAProcessor.cpp
+++ b/src/TAProcessor.cpp
@@ -165,6 +165,7 @@ TAProcessor::find_tc(const TAWrapper* ta,  std::shared_ptr<triggeralgs::TriggerC
       m_tc_sent_count++;
     }
   }
+  m_last_processed_daq_ts = ta->activity.time_start;
   return;
 }
 

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -289,6 +289,7 @@ TCProcessor::make_td(const TCWrapper* tcw)
     m_cv.notify_one();
     TLOG_DEBUG(10) << "pending tds size: " << m_pending_tds.size();
   }
+  m_last_processed_daq_ts = tc.time_start;
   return;
 }
 

--- a/src/TPProcessor.cpp
+++ b/src/TPProcessor.cpp
@@ -168,6 +168,7 @@ TPProcessor::find_ta(const TriggerPrimitiveTypeAdapter* tp,  std::shared_ptr<tri
       }
       tas.pop_back();
   }
+  m_last_processed_daq_ts = tp->tp.time_start;
   return;
 }
 


### PR DESCRIPTION
…t the last_daq_timestamp OpMon metric to work for Trigger data processor classes.

I noticed that the values for the `last_daq_timestamp` metric in OpMon reporting  were zero for Trigger-related DAQModules.  

To address this apparent omission, I added the setting of the appropriate value in the `trigger/src/TxProcessor.cpp` classes.  Readout and Trigger experts should comment on whether this change is appropriate or not.

Here are sample instructions for demonstrating the zero value, and for validating the changes that I am proposing:
```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_250605_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/appmodel.git -b develop
git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/dfmodules.git -b develop
git clone https://github.com/DUNE-DAQ/trigger.git -b develop
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

daqconf_set_connectivity_service_port local-1x1-config config/daqsystemtest/example-configs.data.xml

daqsystemtest_integtest_bundle.sh -k tps

cd /tmp/pytest-of-${USER}/pytest-current/runcurrent
info_file_collator info*.json
grep -B 2 -A 8 last_daq_timestamp opmon_collated.json

echo "----------------"
echo "Pausing for 10 seconds so the zero values can be seen"
echo "----------------"
sleep 10

cd $DBT_AREA_ROOT
cd sourcecode/trigger
git checkout kbiery/last_daq_timestamp_addition
cd ../..

dbt-build -j 12
dbt-workarea-env

daqsystemtest_integtest_bundle.sh -k tps

cd /tmp/pytest-of-${USER}/pytest-current/runcurrent
info_file_collator info*.json
grep -B 2 -A 8 last_daq_timestamp opmon_collated.json

cd $DBT_AREA_ROOT
```
