### PR TITLE
TPReplay changes to fix patch->dev merge

### DIFF
--- a/plugins/TPReplayModule.cpp
+++ b/plugins/TPReplayModule.cpp
@@ -60,8 +60,6 @@ void
 TPReplayModule::do_configure(const nlohmann::json& /*obj*/)
 {
 
-#if 0
-  
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering conf() method";
 
   m_conf = m_mtrg->get_configuration();
@@ -84,7 +82,7 @@ TPReplayModule::do_configure(const nlohmann::json& /*obj*/)
   TLOG() << "### REPLAY CONFIGURATION ###";
   TLOG() << "Will use channel map: " << m_channel_map_name;
   try {
-    m_channel_map = dunedaq::detchannelmaps::make_map(m_channel_map_name);
+    m_channel_map = dunedaq::detchannelmaps::make_tpc_map(m_channel_map_name);
   } catch (const detchannelmaps::ChannelMapCreationFailed& e) {
     ers::error(dunedaq::trigger::ReplayChannelMapProblem(ERS_HERE, get_name(), m_channel_map_name));
   }
@@ -169,9 +167,6 @@ TPReplayModule::do_configure(const nlohmann::json& /*obj*/)
   TLOG() << "Total of " << m_tp_streams.size() << " TP streams.";
 
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting conf() method";
-
-#endif // Of #if 0
-
 }
 
 void
@@ -281,7 +276,6 @@ std::map<std::string, std::map<int, std::deque<std::vector<TriggerPrimitiveTypeA
 TPReplayModule::read_tps(std::map<int, std::string> m_tpstream_files)
 {
 
-#if 0
   std::map<std::string, std::map<int, std::deque<std::vector<TriggerPrimitiveTypeAdapter>>>> all_data;
 
   // Loop over each file
@@ -349,7 +343,7 @@ TPReplayModule::read_tps(std::map<int, std::string> m_tpstream_files)
       // Get ROU and plane
       std::string ROU;
       try {
-        ROU = m_channel_map->get_tpc_element_from_offline_channel(tp.channel);
+        ROU = m_channel_map->get_element_name_from_offline_channel(tp.channel);
         local_rous.insert(ROU);
       } catch (...) {
         ers::error(dunedaq::trigger::ReplayROUError(ERS_HERE, get_name(), filename));
@@ -444,9 +438,6 @@ TPReplayModule::read_tps(std::map<int, std::string> m_tpstream_files)
   }
 
   return all_data;
-#else  // closes #if 0 above
-  return std::map<std::string, std::map<int, std::deque<std::vector<TriggerPrimitiveTypeAdapter>>>>{};
-#endif
 }
 
 void

--- a/python/trigger/tpreplay_application/README.md
+++ b/python/trigger/tpreplay_application/README.md
@@ -57,7 +57,7 @@ One can use this script that will modify the OKS data with parameters obtained f
 |----------------------|--------------|----------------|--------------|
 | `--files`            | `str`        | **Required**   | Text file with full paths to HDF5 TPStream file locations. |
 | `--filter-planes`    | `list[int]`  | `[]` (empty)   | List of planes to filter out. Accepts combinations of: <br> `0` (U), `1` (V), `2` (X). Example: `0 1` to filter out both induction planes. |
-| `--channel-map`      | `str`        | `PD2HDChannelMap` | Specify channel map. For example: `PD2HDChannelMap`, `PD2VDBottomTPCChannelMap`, etc. For the full list, see: [Channel Maps Documentation](https://github.com/DUNE-DAQ/detchannelmaps/blob/develop/docs/channel-maps-table.md). |
+| `--channel-map`      | `str`        | `PD2HDTPCChannelMap` | Specify channel map. For example: `PD2HDTPCChannelMap`, `PD2VDBottomTPCChannelMap`, etc. For the full list, see: [Channel Maps Documentation](https://github.com/DUNE-DAQ/detchannelmaps/blob/develop/docs/channel-maps-table.md). |
 | `--n-loops`          | `int`        | -1             | Number of times to loop over the provided data. The default is `-1` and this results in "infinite" replay. For multiple loops, the time of TPs is modified (shifted). |
 | `--config`           | `str`        | `config/daqsystemtest/example-configs.data.xml` | Path to the base OKS configuration file with `tpreplay` session. |
 | `--path`             | `str`        | `tpreplay-run` | Path for local output for configuration files. This directory will be created by this script and modified configurations stored there. |
@@ -80,7 +80,7 @@ An example input text file:
 ```
 --filter-planes 0 1
 ```
-- *channel-map*: valid channel map is needed to extract readout units and planes from TP data. Defaults to `PD2HDChannelMap`. Make sure you are using the correct channel map for your data!
+- *channel-map*: valid channel map is needed to extract readout units and planes from TP data. Defaults to `PD2HDTPCChannelMap`. Make sure you are using the correct channel map for your data!
 - *n-loops*: the application allows to replay the data multiple times by shifting the TP times. If `-1` is used, the replay will continue indefinitely (until the user stops the run).
 - *config*: this is a path to OKS (.data.xml) file that containts default `tpreplay` session. Can be left to use the default.
 - *path*: this is a path that will be created locally to store the modified configurations. By default set to `tpreplay-run`.
@@ -184,7 +184,7 @@ Few notes on what happens in this script:
   <attribute name="template_for" type="class" init-value="TPReplayModule"/>
   <attribute name="number_of_loops" type="u32" init-value="1" is-not-null="yes"/>
   <attribute name="maximum_wait_time_us" type="u32" init-value="1000" is-not-null="yes"/>
-  <attribute name="channel_map" type="string" init-value="PD2HDChannelMap" is-not-null="yes"/>
+  <attribute name="channel_map" type="string" init-value="PD2HDTPCChannelMap" is-not-null="yes"/>
   <attribute name="total_planes" type="u32" init-value="0" is-not-null="yes"/>
   <attribute name="filter_out_plane" type="u32" range="0..2" init-value="0" is-multi-value="yes"/>
   <relationship name="tp_streams" class-type="TPStreamConf" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
@@ -274,7 +274,7 @@ Verbose logging is available in the `TPReplayModule`:
 - Configuration:
 ```
 ### REPLAY CONFIGURATION ###
-Will use channel map: PD2HDChannelMap
+Will use channel map: PD2HDTPCChannelMap
 Plane filtering: 1
 Planes to filter:
 0

--- a/python/trigger/tpreplay_application/__main__.py
+++ b/python/trigger/tpreplay_application/__main__.py
@@ -109,7 +109,7 @@ def load_channel_map(channel_map_string: str) -> detchannelmaps._daq_detchannelm
     If it fails, prints the error and exits.
     """
     try: 
-        channel_map = detchannelmaps.make_map(channel_map_string)
+        channel_map = detchannelmaps.make_tpc_map(channel_map_string)
         logging.debug(f"Channel map '{channel_map_string}' successfully created.")
         return channel_map
     except Exception as e:
@@ -208,7 +208,7 @@ def extract_rous_and_planes(files: list[str], channel_map: 'detchannelmaps._daq_
 
                 plane = channel_map.get_plane_from_offline_channel(tp.channel)
                 if plane not in planes_to_filter:
-                    rou = channel_map.get_tpc_element_from_offline_channel(tp.channel)
+                    rou = channel_map.get_element_name_from_offline_channel(tp.channel)
                     rou_plane_data.add_value(rou, plane)
                     logging.debug("Extracted rou: %s for plane: %s", rou, plane)
                 else:
@@ -354,8 +354,8 @@ def main():
             formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("--files", type=str, required=True, help="Text file with (full) paths to HDF5 TPStream file location. One per line.")
     parser.add_argument("--filter-planes", type=int, nargs='*', choices=[0, 1, 2], default=[], help="list of planes to filter out. Can be empty or contain any combination of 0 (U), 1 (V), and 2 (X).")
-    parser.add_argument("--channel-map", type=str, default='PD2HDChannelMap', 
-                        help="Specify the channel map to use. Available examples include: PD2HDChannelMap, PD2VDBottomTPCChannelMap, VDColdboxChannelMap, HDColdboxChannelMap.\n"
+    parser.add_argument("--channel-map", type=str, default='PD2HDTPCChannelMap', 
+                        help="Specify the channel map to use. Available examples include: PD2HDTPCChannelMap, PD2VDBottomTPCChannelMap, VDColdboxTPCChannelMap, HDColdboxTPCChannelMap.\n"
                              "For more details, visit: https://github.com/DUNE-DAQ/detchannelmaps/blob/develop/docs/channel-maps-table.md")
     parser.add_argument("--n-loops", type=int, default=-1, help="Number of times to loop over the provided data.")
     parser.add_argument("--config", type=str, default="config/daqsystemtest/example-configs.data.xml", help="Path to OKS configuration file.")


### PR DESCRIPTION
This PR addresses changes needed to bring patch branches into develop after v5.3.2-rc2 release, mentioned in:
- https://github.com/DUNE-DAQ/trigger/issues/400
- https://github.com/DUNE-DAQ/appmodel/issues/210

Changes that were addressed:
- generate_modules changes
- detchannelmaps changes
- few minor checks and const-correctness improvements
- rerunning clang formatter

Linked PRs are:
- https://github.com/DUNE-DAQ/appmodel/pull/211
- https://github.com/DUNE-DAQ/daqsystemtest/pull/211
