### PR TITLE
Small fix for replay app python script

### DIFF
--- a/python/trigger/tpreplay_application/__main__.py
+++ b/python/trigger/tpreplay_application/__main__.py
@@ -207,6 +207,14 @@ def extract_rous_and_planes(files: list[str], channel_map: 'detchannelmaps._daq_
                     continue
 
                 plane = channel_map.get_plane_from_offline_channel(tp.channel)
+
+                # Hack for APA1 :/ 
+                if plane in (1, 2):
+                    rou = channel_map.get_element_name_from_offline_channel(tp.channel)
+                    if rou == "APA_P02SU":
+                        # Remap the plane
+                        plane = 2 if plane == 1 else 1
+
                 if plane not in planes_to_filter:
                     rou = channel_map.get_element_name_from_offline_channel(tp.channel)
                     rou_plane_data.add_value(rou, plane)


### PR DESCRIPTION
There is a 'hack' in c++ tpreplay code that switches planes for APA1.
This hack also needs to be present in the python script preparing the configuration, so that the source ID numbers and plane numbers are matched up. 