### PR TITLE
Modified integtests to use the attribute_substitution data class instead of config_substitution. 

### DIFF
--- a/integtest/change_rate_test.py
+++ b/integtest/change_rate_test.py
@@ -90,25 +90,25 @@ conf_dict.session = "changerate"
 conf_dict.tpg_enabled = False
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id=conf_dict.session,
         obj_class="Session",
         updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(obj_class="LatencyBuffer", updates={"size": 50000})
+    data_classes.attribute_substitution(obj_class="LatencyBuffer", updates={"size": 50000})
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",
         updates={"trigger_rate_hz": 1.0},
     )
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCReadoutMap",
         updates={
             "time_before": readout_window_time_before,

--- a/integtest/tc_time_outside_window_test.py
+++ b/integtest/tc_time_outside_window_test.py
@@ -89,25 +89,25 @@ conf_dict.tpg_enabled = False
 conf_dict.fake_hsi_enabled = True
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id=conf_dict.session,
         obj_class="Session",
         updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(obj_class="LatencyBuffer", updates={"size": 50000})
+    data_classes.attribute_substitution(obj_class="LatencyBuffer", updates={"size": 50000})
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="FakeHSIEventGeneratorConf",
         updates={"trigger_rate": 1.0},
     )
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCReadoutMap",
         updates={
             "time_before": readout_window_time_before,


### PR DESCRIPTION
This is part of providing more configuration substitution options in integtests.

## Description

The changes in this PR make use of the new way of specifying configuration substitutions in integration tests, as described in DUNE-DAQ/daq-deliverables#181.

## Testing Suggestions

Please see the suggestions in the parent Issue, DUNE-DAQ/daq-deliverables#181.