### PR TITLE
Fix TCProcessor busy-spin preventing TC merging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(trigger VERSION 2.5.0)
+project(trigger VERSION 2.5.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -351,6 +351,7 @@ TCProcessor::send_trigger_decisions() {
  std::unique_lock<std::mutex> lock(m_td_vector_mutex);
 
  while (m_running_flag) {
+    // TODO: think about better implementation (notify?, something event driven)
     m_cv.wait_for(lock, std::chrono::microseconds(100));
     auto ready_tds = get_ready_tds(m_pending_tds);
     TLOG_DEBUG(10) << "ready tds: " << ready_tds.size() << ", updated pending tds: " << m_pending_tds.size();

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -351,10 +351,7 @@ TCProcessor::send_trigger_decisions() {
  std::unique_lock<std::mutex> lock(m_td_vector_mutex);
 
  while (m_running_flag) {
-    // Either there are pending TDs, or wait for a bit
-    m_cv.wait(lock, [this] {
-        return !m_pending_tds.empty() || !m_running_flag;
-    });
+    m_cv.wait_for(lock, std::chrono::microseconds(100));
     auto ready_tds = get_ready_tds(m_pending_tds);
     TLOG_DEBUG(10) << "ready tds: " << ready_tds.size() << ", updated pending tds: " << m_pending_tds.size();
 


### PR DESCRIPTION
Problem Description
The core logic for accumulating and merging Trigger Candidates (TCs) was broken due to a concurrency bug. The consumer thread would enter a high-frequency busy-spin when a TC was buffered but not yet timed-out. This busy-spin created high mutex contention, effectively blocking the producer thread from adding new TCs to the queue.

As a result, the queue size never exceeded 1, and the intended merging of multiple TCs into a single Trigger Decision (TD) could not occur. The system was fundamentally not working as designed.

Description of the Fix
The fix resolves the busy-spin by replacing std::condition_variable::wait with std::condition_variable::wait_for.

This change implements an efficient polling wait, forcing the consumer to sleep briefly instead of consuming 100% of a CPU core. This eliminates the mutex contention, allowing the producer to correctly add multiple TCs to the queue.

While this polling mechanism introduces a negligible latency (on the order of the wait_for duration), it fixes a critical bug that previously made TC accumulation and merging impossible. The processor now functions correctly.

Some details in slides: https://indico.fnal.gov/event/71105/contributions/323330/attachments/191568/264974/merging.pdf

