### PR TITLE
Patch/fddaq v5.4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(trigger VERSION 2.5.0)
+project(trigger VERSION 2.5.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -351,6 +351,7 @@ TCProcessor::send_trigger_decisions() {
  std::unique_lock<std::mutex> lock(m_td_vector_mutex);
 
  while (m_running_flag) {
+    // TODO: think about better implementation (notify?, something event driven)
     m_cv.wait_for(lock, std::chrono::microseconds(100));
     auto ready_tds = get_ready_tds(m_pending_tds);
     TLOG_DEBUG(10) << "ready tds: " << ready_tds.size() << ", updated pending tds: " << m_pending_tds.size();

--- a/src/TCProcessor.cpp
+++ b/src/TCProcessor.cpp
@@ -351,10 +351,7 @@ TCProcessor::send_trigger_decisions() {
  std::unique_lock<std::mutex> lock(m_td_vector_mutex);
 
  while (m_running_flag) {
-    // Either there are pending TDs, or wait for a bit
-    m_cv.wait(lock, [this] {
-        return !m_pending_tds.empty() || !m_running_flag;
-    });
+    m_cv.wait_for(lock, std::chrono::microseconds(100));
     auto ready_tds = get_ready_tds(m_pending_tds);
     TLOG_DEBUG(10) << "ready tds: " << ready_tds.size() << ", updated pending tds: " << m_pending_tds.size();
 


### PR DESCRIPTION
This will bring the busy-spin fix (https://github.com/DUNE-DAQ/trigger/pull/410) which necessitated `fddaq-v5.4.2` into `develop`. 

This can also be thought of as a fairly specific framing of "merge the patch branches for `fddaq-v4.4.2` into `develop`, since `fddaq-v4.4.2` only involved a change to this package. 