### PR TITLE
Delayed postprocessing timeout logic

### DIFF
--- a/include/trigger/TriggerDataHandlingModel.hpp
+++ b/include/trigger/TriggerDataHandlingModel.hpp
@@ -36,6 +36,9 @@ public:
 
   // Transform input data type to readout
   std::vector<ReadoutType> transform_payload(IDT& original) const override;
+
+  // Actions postprocess scheduler takes if no data arrives in a configured time
+  void invoke_postprocess_schedule_timeout_policy() const override;
 };
 
 } // namespace dunedaq::trigger

--- a/include/trigger/detail/TriggerDataHandlingModel.hxx
+++ b/include/trigger/detail/TriggerDataHandlingModel.hxx
@@ -38,4 +38,11 @@ TriggerDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::transform_payload(IDT& origin
   }
 }
 
+template<class RDT, class RHT, class LBT, class RPT, class IDT>
+void
+TriggerDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::invoke_postprocess_schedule_timeout_policy() const
+{
+  return; // TODO
+}
+
 } // namespace dunedaq::trigger


### PR DESCRIPTION
Trigger has to define a policy on what to do in case of a timeout. For this, we introduced a new function in `DataHandlingModel` that will be overriden by `TriggerDataHandlingModel`. The function is called by postprocess scheduler.

https://github.com/DUNE-DAQ/datahandlinglibs/pull/104