### PR TITLE
Updated the WIBEth binary file used in the td_leakage_between_runs_test

### DIFF
--- a/integtest/td_leakage_between_runs_test.py
+++ b/integtest/td_leakage_between_runs_test.py
@@ -74,7 +74,7 @@ conf_dict["hsi"]["use_timing_hsi"] = False
 
 conf_dict["readout"]["data_files"] = []
 datafile_conf = {}
-datafile_conf["data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
+datafile_conf["data_file"] = "asset://?checksum=370df564205290d27cab47e44ae4ca47" # WIBEth
 datafile_conf["detector_id"] = 3
 conf_dict["readout"]["data_files"].append(datafile_conf)
 

--- a/integtest/td_leakage_between_runs_test.py
+++ b/integtest/td_leakage_between_runs_test.py
@@ -74,8 +74,9 @@ conf_dict["hsi"]["use_timing_hsi"] = False
 
 conf_dict["readout"]["data_files"] = []
 datafile_conf = {}
-datafile_conf["data_file"] = "asset://?checksum=370df564205290d27cab47e44ae4ca47" # WIBEth
 datafile_conf["detector_id"] = 3
+# We use default values for all other data-file-related parameters, including the
+# data file that is replayed to emulate the detector data.
 conf_dict["readout"]["data_files"].append(datafile_conf)
 
 confgen_arguments={"MinimalSystem": conf_dict}  # (required)


### PR DESCRIPTION
## Description

DUNE-DAQ/daqsystemtest#245 requests that we update our regression tests, etc. to use recent data-replay files from the _assets_ system.

In this repo, that translated to changing the checksum of the asset file that is used in the `td_leakage_between_runs_test`.  The new file is `wib_link_67.bin`, which was recently created by Eric.

*** Please Note that we modified the desired change in this repo.  Instead of changing the default value of the frames file, we simply removed the setting of the frames file value.

## Testing Suggestions

There are suggestions in DUNE-DAQ/daqsystemtest#245 for testing all of the asset-file-update changes together.  

However, the `td_leakage_between_runs_test` is currently broken, so the review of this PR should simply visually check that the new checksum is valid.  The test will be fixed soon, but not necessarily part of this PR.