### PR TITLE
New RTCM configuration

### DIFF
--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -101,9 +101,6 @@ RandomTCMakerModule::do_configure(const CommandData_t& /*obj*/)
   m_conf = m_mtrg->get_configuration();
 
   // Get the TC out configuration
-  // const appmodel::TCReadoutMap* tc_readout = m_conf->get_tc_readout();
-  // m_tcout_time_before = tc_readout->get_time_before();
-  // m_tcout_time_after_ts = tc_readout->get_time_after();
   m_tcout_time_offset_ts = m_conf->get_candidate_offset_ts();
   m_tcout_time_before_ts = m_conf->get_candidate_window_before_ts();
   m_tcout_time_after_ts = m_conf->get_candidate_window_after_ts();
@@ -119,6 +116,7 @@ RandomTCMakerModule::do_configure(const CommandData_t& /*obj*/)
   m_trigger_rate_hz.store(m_conf->get_trigger_rate_hz());
 
   TLOG() << "RandomTCMaker will output TC of type: " << m_conf->get_candidate_type_name();
+  TLOG() << "TC window center offset: " << m_tcout_time_offset_ts;
   TLOG() << "TC window time before: " << m_tcout_time_before_ts << " time after: " << m_tcout_time_after_ts;
   TLOG() << "Clock speed is: " << m_clock_speed_hz;
   TLOG() << "Output trigger rate is: " << m_trigger_rate_hz.load();

--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -101,11 +101,14 @@ RandomTCMakerModule::do_configure(const CommandData_t& /*obj*/)
   m_conf = m_mtrg->get_configuration();
 
   // Get the TC out configuration
-  const appmodel::TCReadoutMap* tc_readout = m_conf->get_tc_readout();
-  m_tcout_time_before = tc_readout->get_time_before();
-  m_tcout_time_after = tc_readout->get_time_after();
-  m_tcout_type =
-    static_cast<TCType>(dunedaq::trgdataformats::string_to_trigger_candidate_type(tc_readout->get_tc_type_name()));
+  // const appmodel::TCReadoutMap* tc_readout = m_conf->get_tc_readout();
+  // m_tcout_time_before = tc_readout->get_time_before();
+  // m_tcout_time_after_ts = tc_readout->get_time_after();
+  m_tcout_time_offset_ts = m_conf->get_candidate_offset_ts();
+  m_tcout_time_before_ts = m_conf->get_candidate_window_before_ts();
+  m_tcout_time_after_ts = m_conf->get_candidate_window_after_ts();
+
+  m_tcout_type = static_cast<TCType>(dunedaq::trgdataformats::string_to_trigger_candidate_type(m_conf->get_candidate_type_name()));
 
   // Throw error if unknown TC type
   if (m_tcout_type == TCType::kUnknown) {
@@ -115,8 +118,8 @@ RandomTCMakerModule::do_configure(const CommandData_t& /*obj*/)
   m_latency_monitoring.store(m_conf->get_latency_monitoring());
   m_trigger_rate_hz.store(m_conf->get_trigger_rate_hz());
 
-  TLOG() << "RandomTCMaker will output TC of type: " << tc_readout->get_tc_type_name();
-  TLOG() << "TC window time before: " << m_tcout_time_before << " time after: " << m_tcout_time_after;
+  TLOG() << "RandomTCMaker will output TC of type: " << m_conf->get_candidate_type_name();
+  TLOG() << "TC window time before: " << m_tcout_time_before_ts << " time after: " << m_tcout_time_after_ts;
   TLOG() << "Clock speed is: " << m_clock_speed_hz;
   TLOG() << "Output trigger rate is: " << m_trigger_rate_hz.load();
 
@@ -206,9 +209,9 @@ triggeralgs::TriggerCandidate
 RandomTCMakerModule::create_candidate(dfmessages::timestamp_t timestamp)
 {
   triggeralgs::TriggerCandidate candidate;
-  candidate.time_start = (timestamp - m_tcout_time_before);
-  candidate.time_end = (timestamp + m_tcout_time_after);
-  candidate.time_candidate = timestamp;
+  candidate.time_candidate = timestamp + m_tcout_time_offset_ts; //timestamp;
+  candidate.time_start = candidate.time_candidate-m_tcout_time_before_ts; //(timestamp - m_tcout_time_before_ts);
+  candidate.time_end = candidate.time_candidate+m_tcout_time_after_ts; //(timestamp + m_tcout_time_after_ts);
   candidate.detid = { 0 };
   candidate.type = m_tcout_type;
 

--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -101,9 +101,6 @@ RandomTCMakerModule::do_configure(const CommandData_t& /*obj*/)
   m_conf = m_mtrg->get_configuration();
 
   // Get the TC out configuration
-  // const appmodel::TCReadoutMap* tc_readout = m_conf->get_tc_readout();
-  // m_tcout_time_before = tc_readout->get_time_before();
-  // m_tcout_time_after_ts = tc_readout->get_time_after();
   m_tcout_time_backshift_ts = m_conf->get_candidate_backshift_ts();
   m_tcout_time_before_ts = m_conf->get_candidate_window_before_ts();
   m_tcout_time_after_ts = m_conf->get_candidate_window_after_ts();
@@ -210,9 +207,9 @@ triggeralgs::TriggerCandidate
 RandomTCMakerModule::create_candidate(dfmessages::timestamp_t timestamp)
 {
   triggeralgs::TriggerCandidate candidate;
-  candidate.time_candidate = timestamp - m_tcout_time_backshift_ts; //timestamp;
-  candidate.time_start = candidate.time_candidate-m_tcout_time_before_ts; //(timestamp - m_tcout_time_before_ts);
-  candidate.time_end = candidate.time_candidate+m_tcout_time_after_ts; //(timestamp + m_tcout_time_after_ts);
+  candidate.time_candidate = timestamp - m_tcout_time_backshift_ts;
+  candidate.time_start = candidate.time_candidate-m_tcout_time_before_ts;
+  candidate.time_end = candidate.time_candidate+m_tcout_time_after_ts;
   candidate.detid = { 0 };
   candidate.type = m_tcout_type;
 

--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -119,7 +119,7 @@ RandomTCMakerModule::do_configure(const CommandData_t& /*obj*/)
   m_trigger_rate_hz.store(m_conf->get_trigger_rate_hz());
 
   TLOG() << "RandomTCMaker will output TC of type: " << m_conf->get_candidate_type_name();
-  TLOG() << "TC window center offset: " << m_tcout_time_offset_ts;
+  TLOG() << "TC window center offset: " << m_tcout_time_backshift_ts;
   TLOG() << "TC window time before: " << m_tcout_time_before_ts << " time after: " << m_tcout_time_after_ts;
   TLOG() << "Clock speed is: " << m_clock_speed_hz;
   TLOG() << "Output trigger rate is: " << m_trigger_rate_hz.load();

--- a/plugins/RandomTCMakerModule.cpp
+++ b/plugins/RandomTCMakerModule.cpp
@@ -101,7 +101,10 @@ RandomTCMakerModule::do_configure(const CommandData_t& /*obj*/)
   m_conf = m_mtrg->get_configuration();
 
   // Get the TC out configuration
-  m_tcout_time_offset_ts = m_conf->get_candidate_offset_ts();
+  // const appmodel::TCReadoutMap* tc_readout = m_conf->get_tc_readout();
+  // m_tcout_time_before = tc_readout->get_time_before();
+  // m_tcout_time_after_ts = tc_readout->get_time_after();
+  m_tcout_time_backshift_ts = m_conf->get_candidate_backshift_ts();
   m_tcout_time_before_ts = m_conf->get_candidate_window_before_ts();
   m_tcout_time_after_ts = m_conf->get_candidate_window_after_ts();
 
@@ -207,7 +210,7 @@ triggeralgs::TriggerCandidate
 RandomTCMakerModule::create_candidate(dfmessages::timestamp_t timestamp)
 {
   triggeralgs::TriggerCandidate candidate;
-  candidate.time_candidate = timestamp + m_tcout_time_offset_ts; //timestamp;
+  candidate.time_candidate = timestamp - m_tcout_time_backshift_ts; //timestamp;
   candidate.time_start = candidate.time_candidate-m_tcout_time_before_ts; //(timestamp - m_tcout_time_before_ts);
   candidate.time_end = candidate.time_candidate+m_tcout_time_after_ts; //(timestamp + m_tcout_time_after_ts);
   candidate.detid = { 0 };

--- a/plugins/RandomTCMakerModule.hpp
+++ b/plugins/RandomTCMakerModule.hpp
@@ -100,10 +100,13 @@ private:
 
   /// @brief Output TC type
   TCType m_tcout_type;
-  /// @brief Output window start time, based off trigger timestamp
-  dfmessages::timestamp_t m_tcout_time_before;
-  /// @brief Output window end time, based off trigger timestamp
-  dfmessages::timestamp_t m_tcout_time_after;
+
+  /// @brief Output candidate central time, based off trigger timestamp
+  dfmessages::timestamp_t m_tcout_time_offset_ts;
+  /// @brief Output candidate start time, based off trigger timestamp
+  dfmessages::timestamp_t m_tcout_time_before_ts;
+  /// @brief Output candidate end time, based off trigger timestamp
+  dfmessages::timestamp_t m_tcout_time_after_ts;
 
   /// @brief Clock speed in hz, taken from detector configuration
   uint64_t m_clock_speed_hz;

--- a/plugins/RandomTCMakerModule.hpp
+++ b/plugins/RandomTCMakerModule.hpp
@@ -101,11 +101,11 @@ private:
   /// @brief Output TC type
   TCType m_tcout_type;
 
-  /// @brief Output candidate central time, based off trigger timestamp
+  /// @brief Offset applied to timestamp estimator time to generate random trigger candidates
   dfmessages::timestamp_t m_tcout_time_offset_ts;
-  /// @brief Output candidate start time, based off trigger timestamp
+  /// @brief Output candidate start time, relative to peak time
   dfmessages::timestamp_t m_tcout_time_before_ts;
-  /// @brief Output candidate end time, based off trigger timestamp
+  /// @brief Output candidate end time, relative to peak time
   dfmessages::timestamp_t m_tcout_time_after_ts;
 
   /// @brief Clock speed in hz, taken from detector configuration

--- a/plugins/RandomTCMakerModule.hpp
+++ b/plugins/RandomTCMakerModule.hpp
@@ -101,9 +101,9 @@ private:
   /// @brief Output TC type
   TCType m_tcout_type;
 
-  /// @brief Offset applied to timestamp estimator time to generate random trigger candidates
-  dfmessages::timestamp_t m_tcout_time_offset_ts;
-  /// @brief Output candidate start time, relative to peak time
+  /// @brief Output candidate central time, based off trigger timestamp
+  dfmessages::timestamp_t m_tcout_time_backshift_ts;
+  /// @brief Output candidate start time, based off trigger timestamp
   dfmessages::timestamp_t m_tcout_time_before_ts;
   /// @brief Output candidate end time, relative to peak time
   dfmessages::timestamp_t m_tcout_time_after_ts;


### PR DESCRIPTION
Address the RTCM limitations in #415.
The candidate time is shifted by `candidate_offset_ts` (signed integer, leaving the option to inject candidates into the future if needed), and the window is define by `candidate_window_before_ts`/`candidate_window_after_ts`

The use of `TCReadoutMap` for the window definition is discontinued (since it belongs to a different domain)

Requires associated changes in `appmodel`
https://github.com/DUNE-DAQ/appmodel/pull/259