### PR TITLE
Added a SIGHUP message to the list of ignored messages in the integtests

### DIFF
--- a/integtest/change_rate_test.py
+++ b/integtest/change_rate_test.py
@@ -60,18 +60,16 @@ hsi_frag_params = {
     "max_size_bytes": 100,
 }
 ignored_logfile_problems = {
-    "connectionservice": [
-        "Searching for connections matching uid_regex<errored_frames_q> and data_type Unknown"
-    ],
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 03-Nov, KAB/PMP/JCF
     ],
-    "local-connection-server": [
+    "connectivity-service": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal 1",
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 03-Nov, KAB/PMP/JCF
     ],
-    "log_.*_changerate_": ["connect: Connection refused"],
 }
 
 # The next three variable declarations *must* be present as globals in the test

--- a/integtest/tc_time_outside_window_test.py
+++ b/integtest/tc_time_outside_window_test.py
@@ -60,15 +60,14 @@ hsi_frag_params = {
     "max_size_bytes": 100,
 }
 ignored_logfile_problems = {
-    "connectionservice": [
-        "Searching for connections matching uid_regex<errored_frames_q> and data_type Unknown"
-    ],
     "-controller": [
         "Worker with pid \\d+ was terminated due to signal 1",
         "Connection '.*' not found on the application registry",
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 03-Nov, KAB/PMP/JCF
     ],
     "connectivity-service": [
         "errorlog: -",
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 03-Nov, KAB/PMP/JCF
     ],
 }
 

--- a/integtest/td_leakage_between_runs_test.py
+++ b/integtest/td_leakage_between_runs_test.py
@@ -27,7 +27,15 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "hdf5_source_subsystem": "Trigger",
                               "expected_fragment_count": 1,
                               "min_size_bytes": 72, "max_size_bytes": 216}
-ignored_logfile_problems={}
+ignored_logfile_problems = {
+    "-controller": [
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 03-Nov, KAB/PMP/JCF
+    ],
+    "connectivity-service": [
+        "errorlog: -",
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 03-Nov, KAB/PMP/JCF
+    ],
+}
 
 # The next several variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how


### PR DESCRIPTION
# Description

Recently, Pawel and John noticed that we occasionally see messages like the following in regression tests:

```
[ERROR] Worker (pid:3925714) was sent SIGHUP!
```

Some of the existing regression tests exclude messages like this when searching log files for errors and warnings, while others don't.

Pawel investigated the source of these messages and made some progress, but his preference is to defer a full investigation until after `fddaq-v5.5.0`.  Given that, we believe that it is prudent to add messages of this type to the ignored message lists in all regression tests.  This PR does that for the `trigger` repo.

These changes are independent of all other changes.

The testing of these changes is made a little complicated by the fact that only one of the three `trigger` integtests runs cleanly.  However, we can verify that the `change_rate_test` continues to run cleanly, and the `tc_time_outside_window_test` will not show any new problems.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

I have confirmed that existing tests run fine for me.

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
