### PR TITLE
Updated the change_rate_test.py to include the changes that are part …

### DIFF
--- a/integtest/README.md
+++ b/integtest/README.md
@@ -4,7 +4,7 @@
 Here is a sample command for invoking a test (feel free to keep or drop the options in brackets, as you prefer):
 
 ```
-pytest -s change_rate_test.py [--nanorc-option log-level debug]  # this nanorc option is still useful even when using drunc
+pytest -s change_rate_test.py [--dunerc-option log-level debug]
 ```
 
 For reference, here are the ideas behind the existing tests:

--- a/integtest/change_rate_test.py
+++ b/integtest/change_rate_test.py
@@ -4,7 +4,12 @@ import re
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
+import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
+
+import functools
+print = functools.partial(print, flush=True)  # always flush print() output
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -73,7 +78,7 @@ ignored_logfile_problems = {
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and drunc
 
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
@@ -115,8 +120,8 @@ conf_dict.config_substitutions.append(
 )
 
 confgen_arguments = {"MinimalSystem": conf_dict}
-# The commands to run in nanorc, as a list
-nanorc_command_list = (
+# The commands to run in dunerc, as a list
+dunerc_command_list = (
     "boot conf".split()
     + " start --run-number 101 wait 1 enable-triggers wait 2 disable-triggers wait 2 drain-dataflow stop-trigger-sources stop wait 2".split()
     + " start --run-number 102 wait 1 change-rate --trigger-rate 2.0 enable-triggers wait 1 disable-triggers wait 2 drain-dataflow stop-trigger-sources stop wait 2".split()
@@ -128,40 +133,31 @@ nanorc_command_list = (
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)
-
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+def test_dunerc_success(run_dunerc, caplog):
+    # check for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     # Run some tests on the output data file
-    assert len(run_nanorc.data_files) == expected_number_of_data_files
+    assert len(run_dunerc.data_files) == expected_number_of_data_files
 
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params]
     # fragment_check_list.append(wib1_frag_hsi_trig_params) # ProtoWIB
     # fragment_check_list.append(wib2_frag_params) # DuneWIB
     fragment_check_list.append(wibeth_frag_params)  # WIBEth
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         assert data_file_checks.sanity_check(data_file)
         assert data_file_checks.check_file_attributes(data_file)
         assert data_file_checks.check_event_count(


### PR DESCRIPTION
…of the --integtest-verbosity changes.

These changes are intended for the `fddaq-v5.7.0` software release.

# Description

In discussions of possible improvements to our regression/integration tests, it was suggested to provide several different levels of verbosity.  These changes are part of implementing those, and this PR is best tested and merged with DUNE-DAQ/integrationtest#152.  The `integrationtest` PR has some details about the changes.

There were a one change that was made in addition to the ones needed for verbosity levels.  That was the following:

- the `nanorc` name was replaced with the more generic `dunerc` name

Please see the suggested instructions for testing these changes in DUNE-DAQ/integrationtest#152.

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
