### PR TITLE
Modified the integtest to support user-requested deletion of HDF5 files at the end of the integtest.

### DIFF
--- a/integtest/change_rate_test.py
+++ b/integtest/change_rate_test.py
@@ -4,8 +4,8 @@ import re
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.utility_functions as utility_functions
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 import functools
@@ -120,7 +120,7 @@ dunerc_command_list = (
 
 def test_dunerc_success(run_dunerc, caplog):
     # check for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=False)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=False)
 
 
 def test_log_files(run_dunerc):
@@ -155,3 +155,7 @@ def test_data_files(run_dunerc):
             assert data_file_checks.check_fragment_sizes(
                 data_file, fragment_check_list[jdx]
             )
+
+
+def test_cleanup(run_dunerc):
+    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)

--- a/integtest/change_rate_test.py
+++ b/integtest/change_rate_test.py
@@ -155,7 +155,3 @@ def test_data_files(run_dunerc):
             assert data_file_checks.check_fragment_sizes(
                 data_file, fragment_check_list[jdx]
             )
-
-
-def test_cleanup(run_dunerc):
-    utility_functions.remove_hdf5_files_if_requested(run_dunerc, this_test_requests_hdf5_file_removal=False)


### PR DESCRIPTION
# Description

The ability to remove HDF5 files at the end of each integtest (upon user request) was suggested some time ago in discussions about changes to the `integrationtest` infrastructure.  The `integrationtest` code has been modified to support this functionality (DUNE-DAQ/integrationtest#157), and the changes in this PR take advantage of those changes.

These changes should be tested and merged in conjunction with the changes in the `integrationtest` and other repos.  Please see DUNE-DAQ/integrationtest#157 for suggested testing steps.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
