### PR TITLE
Modified the integtest to make use of new utility functions for setting trigger config params

### DIFF
--- a/integtest/change_rate_test.py
+++ b/integtest/change_rate_test.py
@@ -6,6 +6,7 @@ import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.utility_functions2 as utility_functions
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 import functools
@@ -82,26 +83,12 @@ conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "changerate"
 conf_dict.tpg_enabled = False
+utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=1.0,
+                                          readout_window_before_ticks=readout_window_time_before,
+                                          readout_window_after_ticks=readout_window_time_after)
 
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(obj_class="LatencyBuffer", updates={"size": 50000})
-)
-
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="RandomTCMakerConf",
-        updates={"trigger_rate_hz": 1.0},
-    )
-)
-
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_class="TCReadoutMap",
-        updates={
-            "time_before": readout_window_time_before,
-            "time_after": readout_window_time_after,
-        },
-    )
 )
 
 confgen_arguments = {"MinimalSystem": conf_dict}

--- a/integtest/change_rate_test.py
+++ b/integtest/change_rate_test.py
@@ -82,7 +82,7 @@ conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "changerate"
 conf_dict.tpg_enabled = False
-utility_functions.set_RTCM_trigger_params(conf_dict, trigger_rate=1.0,
+utility_functions.set_rtcm_trigger_params(conf_dict, trigger_rate=1.0,
                                           readout_window_before_ticks=readout_window_time_before,
                                           readout_window_after_ticks=readout_window_time_after)
 


### PR DESCRIPTION
# Description

These changes make use of the changes made in the `integrationtest` repo to provide utility functions that set various trigger parameters for integration tests (DUNE-DAQ/integrationtest#161).

There are instructions for testing these changes in DUNE-DAQ/integrationtest#161, and these changes need to be tested and merged together the with changes in the `integrationtest` repo.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
