### PR TITLE
JCF: supply reference rather than pointer to session in make_source_i…

### DIFF
--- a/plugins/MLTModule.cpp
+++ b/plugins/MLTModule.cpp
@@ -97,7 +97,7 @@ MLTModule::do_configure(const CommandData_t& /*obj*/)
   }
 
   hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t geoidmap =
-    hdf5libs::HDF5SourceIDHandler::make_source_id_geo_id_map(m_session);
+    hdf5libs::HDF5SourceIDHandler::make_source_id_geo_id_map(*m_session);
   // Fill the SourceID -- Subdetector map
   for (auto const& [sourceid, geoids] : geoidmap) {
     TLOG() << "SourceID: " << sourceid;


### PR DESCRIPTION
…d_geo_id_map so the code compiles with changes I've performed on a branch of the same name in hdf5libs

# Description


This draft PR is needed for the package to build against the primary draft PR, https://github.com/DUNE-DAQ/dfmodules/pull/497 and the other package with the same branch name available (`hdf5libs`). 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

