### PR TITLE
JCF: DUNE-DAQ/trgdataformats#59: use the function trgdataformats prov…

### DIFF
--- a/plugins/MLTModule.cpp
+++ b/plugins/MLTModule.cpp
@@ -188,7 +188,7 @@ MLTModule::generate_opmon_data()
   // per TC type
   std::lock_guard<std::mutex> guard(m_trigger_mutex);
   for (auto& [type, counts] : m_trigger_counters) {
-    auto name = dunedaq::trgdataformats::get_trigger_candidate_type_names()[type];
+    auto name = dunedaq::trgdataformats::trigger_candidate_type_to_string(type);
     opmon::TriggerDecisionInfo td_info;
     td_info.set_received(counts.received.exchange(0));
     td_info.set_sent(counts.sent.exchange(0));


### PR DESCRIPTION
…ides to convert the trigger candidate type enum into a string

# Description


This is a small change needed so this repo compiles against the updates to `trgdataformats` in https://github.com/DUNE-DAQ/trgdataformats/pull/61. It should not be merged before the `trgdataformats` PR is merged. 

A successful test build (`TDFRFD_DEV_260811_A9`, https://github.com/DUNE-DAQ/daq-release/actions/runs/31514886523) was performed using this branch.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [X ] Unit tests pass (e.g. `dbt-build --unittest`)
- [X ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [X ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

